### PR TITLE
CLOUDP-245765: Add goreleaser to mongodb/openapi repo

### DIFF
--- a/tools/cli/.goreleaser.yml
+++ b/tools/cli/.goreleaser.yml
@@ -1,0 +1,64 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+project_name: openapicli
+before:
+  hooks:
+    # this is just an example and not a requirement for provider building/publishing
+    - go mod tidy
+builds:
+  - <<: &build_defaults
+      env:
+        - CGO_ENABLED=0
+      binary: bin/openapicli
+      main: ./cmd/openapicli
+      ldflags:
+         - -s -w -X github.com/mongodb/openapi/tools/cli/internal/version.Version={{.Version}} -X github.com/mongodb/openapi/tools/cli/internal/version.GitCommit={{.FullCommit}}
+    id: linux
+    goos: [linux]
+    goarch: [amd64,arm64]
+  - <<: *build_defaults
+    id: macos
+    goos: [darwin]
+    goarch: [amd64,arm64]
+
+gomod: # https://goreleaser.com/customization/verifiable_builds/
+  # Proxy a module from proxy.golang.org, making the builds verifiable.
+  # This will only be effective if running against a tag. Snapshots will ignore
+  # this setting.
+  # Notice: for this to work your `build.main` must be a package, not a `.go` file.
+  proxy: true
+  # Sets the `-mod` flag value.
+  #
+  # Since: v1.7
+  mod: mod
+
+archives:
+- id: linux_archives
+  name_template: mongodb-openapi-cli_{{ .Version }}_{{ .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end }}
+  builds: [linux]
+  wrap_in_directory: true
+  format: tar.gz
+  rlcp: false
+- id: macos
+  name_template: mongodb-atlas-cli_{{ .Version }}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}_{{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end }}
+  builds: [macos]
+  format: zip
+  wrap_in_directory: false
+  rlcp: false
+
+snapshot:
+  name_template: "{{ .Env.VERSION_GIT }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+    - '^chore:'
+    - '^build(deps):'
+
+release:
+  prerelease: auto
+  name_template: "OpenAPI CLI {{.Version}}"
+
+

--- a/tools/cli/.goreleaser.yml
+++ b/tools/cli/.goreleaser.yml
@@ -40,7 +40,7 @@ archives:
   format: tar.gz
   rlcp: false
 - id: macos
-  name_template: mongodb-atlas-cli_{{ .Version }}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}_{{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end }}
+  name_template: mongodb-openapi-cli_{{ .Version }}_{{- if eq .Os "darwin" }}macos{{- else }}{{ .Os }}{{ end }}_{{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end }}
   builds: [macos]
   format: zip
   wrap_in_directory: false

--- a/tools/cli/.goreleaser.yml
+++ b/tools/cli/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
       env:
         - CGO_ENABLED=0
       binary: bin/openapicli
-      main: ./cmd/openapicli
+      main: ./cmd/openapicli.go
       ldflags:
          - -s -w -X github.com/mongodb/openapi/tools/cli/internal/version.Version={{.Version}} -X github.com/mongodb/openapi/tools/cli/internal/version.GitCommit={{.FullCommit}}
     id: linux
@@ -26,7 +26,7 @@ gomod: # https://goreleaser.com/customization/verifiable_builds/
   # This will only be effective if running against a tag. Snapshots will ignore
   # this setting.
   # Notice: for this to work your `build.main` must be a package, not a `.go` file.
-  proxy: true
+  proxy: false
   # Sets the `-mod` flag value.
   #
   # Since: v1.7


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-245765

This PR adds goreleaser configuration to the openapi cli tool
I tested the goreleaser configuration in a fork and I was able to release the cli: https://github.com/andreaangiolillo/openapi-test/releases/tag/v0.0.1

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
