### PR TITLE
CLOUDP-245766:  Define gitHub Action to release the CLI in mongodb/openapi 😸 

### DIFF
--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -7,6 +7,7 @@ on:
       - 'tools/**'
   pull_request: {}
   workflow_dispatch: {}
+  workflow_call: {}
 
 permissions:
   contents: read

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -95,7 +95,6 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Issue
         if: ${{ failure() }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -18,7 +18,6 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-latest
-    needs: [ release-config ]
     if: >-
       !cancelled()
       && inputs.use_existing_tag == 'false'

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -16,26 +16,12 @@ on:
         default: 'false'
 
 jobs:
-  release-config:
-    runs-on: ubuntu-latest
-    outputs:
-      creates_new_tag: ${{ steps.evaluate_inputs.outputs.creates_new_tag }}
-      runs_tests: ${{ steps.evaluate_inputs.outputs.runs_tests }}
-    steps:
-      - id: evaluate_inputs
-        run: |
-          {
-            echo "creates_new_tag=$(if [ '${{ inputs.use_existing_tag }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
-            echo "runs_tests=$(if [ '${{ inputs.skip_tests }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
-          } >> "$GITHUB_OUTPUT"
-
   create-tag:
     runs-on: ubuntu-latest
     needs: [ release-config ]
     if: >-
       !cancelled()
-      && !contains(needs.*.result, 'failure') 
-      && needs.release-config.outputs.creates_new_tag == 'true'
+      && inputs.use_existing_tag == 'false'
     steps:
       - name: Validation of version format
         run: |
@@ -63,11 +49,11 @@ jobs:
           body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   run-tests:
-    needs: [ release-config, create-tag ]
+    needs: [ create-tag ]
     if: >-
       !cancelled()
       && !contains(needs.*.result, 'failure')
-      && needs.release-config.outputs.runs_tests == 'true'
+      && inputs.skip_tests == 'false'
     secrets: inherit
     uses: ./.github/workflows/code-health-tools.yml
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,108 @@
+name: 'New Release'
+run-name: 'Release ${{ inputs.version_number }} (skip tests: ${{ inputs.skip_tests }}, use existing tag: ${{ inputs.use_existing_tag}})'
+
+# Used for creating a new release. This workflow will run qa acceptance tests, create a new tag, and generate the release with GoReleaser.
+on:
+  workflow_dispatch:
+    inputs:
+      version_number:
+        description: 'Version number (e.g., v1.0.0, v1.0.0-pre, v1.0.0-pre1)'
+        required: true
+      skip_tests:
+        description: 'Set value to `true` to skip tests, default is `false`'
+        default: 'false'
+      use_existing_tag:
+        description: 'Set value to `true` to use an existing tag for the release process, default is `false`'
+        default: 'false'
+
+jobs:
+  release-config:
+    runs-on: ubuntu-latest
+    outputs:
+      creates_new_tag: ${{ steps.evaluate_inputs.outputs.creates_new_tag }}
+      is_official_release: ${{ steps.evaluate_inputs.outputs.is_official_release }}
+      runs_tests: ${{ steps.evaluate_inputs.outputs.runs_tests }}
+    steps:
+      - id: evaluate_inputs
+        run: |
+          {
+            echo "creates_new_tag=$(if [ '${{ inputs.use_existing_tag }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
+            echo "is_official_release=$(if echo '${{ inputs.version_number }}' | grep -q 'pre'; then echo 'false'; else echo 'true'; fi)"
+            echo "runs_tests=$(if [ '${{ inputs.skip_tests }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
+          } >> "$GITHUB_OUTPUT"
+
+  create-tag:
+    runs-on: ubuntu-latest
+    needs: [ release-config ]
+    if: >-
+      !cancelled()
+      && !contains(needs.*.result, 'failure') 
+      && needs.release-config.outputs.creates_new_tag == 'true'
+    steps:
+      - name: Validation of version format
+        run: |
+          echo "${{ inputs.version_number }}" | grep -P '^v\d+\.\d+\.\d+(-pre[A-Za-z0-9-]*)?$'
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - name: Get the latest commit SHA
+        id: get-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Create release tag
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72
+        with:
+          tag: ${{ inputs.version_number }}
+          commit_sha: ${{ steps.get-sha.outputs.sha }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_passphrase: ${{ secrets.PASSPHRASE }}
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          labels: failed-release
+          title: Releasing openapicli v${{ inputs.version_number }} failed at the tag creation step
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  run-tests:
+    needs: [ release-config, create-tag ]
+    if: >-
+      !cancelled()
+      && !contains(needs.*.result, 'failure')
+      && needs.release-config.outputs.runs_tests == 'true'
+    secrets: inherit
+    uses: ./.github/workflows/code-health-tools.yml
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [ run-tests ]
+    # Release is skipped if there are failures in previous steps
+    if: >-
+      !cancelled()
+      && !contains(needs.*.result, 'failure')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          ref: ${{ inputs.version_number }}
+      - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+        with:
+          go-version-file: 'go.mod'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          labels: failed-release
+          title: Releasing openapicli v${{ inputs.version_number }} failed at the goreleaser step
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -20,14 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       creates_new_tag: ${{ steps.evaluate_inputs.outputs.creates_new_tag }}
-      is_official_release: ${{ steps.evaluate_inputs.outputs.is_official_release }}
       runs_tests: ${{ steps.evaluate_inputs.outputs.runs_tests }}
     steps:
       - id: evaluate_inputs
         run: |
           {
             echo "creates_new_tag=$(if [ '${{ inputs.use_existing_tag }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
-            echo "is_official_release=$(if echo '${{ inputs.version_number }}' | grep -q 'pre'; then echo 'false'; else echo 'true'; fi)"
             echo "runs_tests=$(if [ '${{ inputs.skip_tests }}' = 'true' ]; then echo 'false'; else echo 'true'; fi)"
           } >> "$GITHUB_OUTPUT"
 
@@ -61,7 +59,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           labels: failed-release
-          title: Releasing openapicli v${{ inputs.version_number }} failed at the tag creation step
+          title: "Releasing openapicli v${{ inputs.version_number }} failed at the tag creation step :scream_cat:"
           body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   run-tests:
@@ -88,11 +86,12 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'tools/cli/go.mod'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8
         with:
           version: latest
+          workdir: tools/cli
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -103,5 +102,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           labels: failed-release
-          title: Releasing openapicli v${{ inputs.version_number }} failed at the goreleaser step
+          title: "Releasing openapicli v${{ inputs.version_number }} failed at the goreleaser step :scream_cat:"
           body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-245766

This PR adds a github action to release the CLI.

I tested the action in my fork: https://github.com/andreaangiolillo/openapi-test/actions/runs/8836661589
![Screenshot 2024-04-25 at 18 17 13](https://github.com/mongodb/openapi/assets/5663078/b7717227-fdf1-4fa7-816d-a67735c31377)


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

# Next
- Open a PR with a `RELEASE.md`
