### PR TITLE
feat: update the merge logic to generate an OAS where the fields are in the same order as the Atlas OAS

### DIFF
--- a/tools/cli/internal/cli/merge/merge.go
+++ b/tools/cli/internal/cli/merge/merge.go
@@ -40,7 +40,7 @@ func (o *Opts) Run() error {
 		return err
 	}
 
-	federatedBytes, err := json.MarshalIndent(*federated, "", "    ")
+	federatedBytes, err := json.MarshalIndent(*federated, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/tools/cli/internal/cli/merge/merge_test.go
+++ b/tools/cli/internal/cli/merge/merge_test.go
@@ -16,9 +16,9 @@ package merge
 
 import (
 	"fmt"
-	"github.com/getkin/kin-openapi/openapi3"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
 	"github.com/mongodb/openapi/tools/cli/internal/openapi"
 	"github.com/spf13/afero"

--- a/tools/cli/internal/cli/merge/merge_test.go
+++ b/tools/cli/internal/cli/merge/merge_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/mongodb/openapi/tools/cli/internal/openapi"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
-	"github.com/tufin/oasdiff/load"
 	"go.uber.org/mock/gomock"
 )
 
@@ -40,10 +39,11 @@ func TestSuccessfulMerge_Run(t *testing.T) {
 		fs:            fs,
 	}
 
-	response := &load.SpecInfo{
-		Spec:    &openapi3.T{},
-		Url:     "test",
-		Version: "3.0.1",
+	response := &openapi.Spec{
+		OpenAPI: "v3.0.1",
+		Info:    &openapi3.Info{},
+		Servers: nil,
+		Tags:    openapi3.Tags{},
 	}
 
 	mockMergerStore.

--- a/tools/cli/internal/openapi/mock_openapi.go
+++ b/tools/cli/internal/openapi/mock_openapi.go
@@ -78,10 +78,10 @@ func (m *MockMerger) EXPECT() *MockMergerMockRecorder {
 }
 
 // MergeOpenAPISpecs mocks base method.
-func (m *MockMerger) MergeOpenAPISpecs(arg0 []string) (*load.SpecInfo, error) {
+func (m *MockMerger) MergeOpenAPISpecs(arg0 []string) (*Spec, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MergeOpenAPISpecs", arg0)
-	ret0, _ := ret[0].(*load.SpecInfo)
+	ret0, _ := ret[0].(*Spec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/tools/cli/internal/openapi/openapi.go
+++ b/tools/cli/internal/openapi/openapi.go
@@ -16,9 +16,9 @@ package openapi
 
 //go:generate mockgen -destination=../openapi/mock_openapi.go -package=openapi github.com/mongodb/openapi/tools/cli/internal/openapi Parser,Merger
 import (
-	"github.com/getkin/kin-openapi/openapi3"
 	"log"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/tufin/oasdiff/diff"
 	"github.com/tufin/oasdiff/load"
 )
@@ -33,12 +33,12 @@ type Merger interface {
 
 type Spec struct {
 	OpenAPI      string                        `json:"openapi" yaml:"openapi"`
-	Info         *openapi3.Info                `json:"info" yaml:"info"`
+	Security     openapi3.SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
 	Servers      openapi3.Servers              `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Tags         openapi3.Tags                 `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Info         *openapi3.Info                `json:"info" yaml:"info"`
 	Paths        *openapi3.Paths               `json:"paths" yaml:"paths"`
 	Components   *openapi3.Components          `json:"components,omitempty" yaml:"components,omitempty"`
-	Security     openapi3.SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
 	ExternalDocs *openapi3.ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
 

--- a/tools/cli/internal/openapi/openapi.go
+++ b/tools/cli/internal/openapi/openapi.go
@@ -16,7 +16,6 @@ package openapi
 
 //go:generate mockgen -destination=../openapi/mock_openapi.go -package=openapi github.com/mongodb/openapi/tools/cli/internal/openapi Parser,Merger
 import (
-	"github.com/getkin/kin-openapi/openapi3"
 	"log"
 
 	"github.com/getkin/kin-openapi/openapi3"


### PR DESCRIPTION
## Context
The `merge` command prints the fields of the generated FOAS in the following order
Example:
```json
{
  "components": {},
  "info": {},
  "openapi": {},
  "paths": {},
  "servers": {},
  "tags": {}
}
```

The Atlas OAS has the following order instead
```json
{
  "openapi": {},
  "info": {},
  "servers": {},
  "tags": {},
  "paths": {},
  "components": {}
}
```


## Proposed changes
Update the `merge` command logic to generate a FOAS spec where the root elements have the same order as the Atlas OAS
