### PR TITLE
CLOUDP-251170: The foas.json contains external references to the openapi-mms.json spec

### DIFF
--- a/tools/cli/internal/openapi/oasdiff.go
+++ b/tools/cli/internal/openapi/oasdiff.go
@@ -127,8 +127,7 @@ func updateExternalRefResponses(responses *openapi3.Responses) {
 
 	for _, v := range responses.Map() {
 		if strings.Contains(v.Ref, ".json#") {
-			pos := strings.Index(v.Ref, "#")
-			v.Ref = v.Ref[pos:]
+			v.Ref = removeExternalRef(v.Ref)
 			continue
 		}
 
@@ -140,6 +139,15 @@ func updateExternalRefResponses(responses *openapi3.Responses) {
 	}
 }
 
+func removeExternalRef(ref string) string {
+	pos := strings.Index(ref, "#")
+	if pos == -1 {
+		return ref
+	}
+
+	return ref[:pos]
+}
+
 // updateExternalRefContent updates the external references of OASes to remove the reference to openapi-mms.json
 // in the Schema.Content.
 func updateExternalRefContent(content *openapi3.Content) {
@@ -149,8 +157,7 @@ func updateExternalRefContent(content *openapi3.Content) {
 		}
 
 		if strings.Contains(value.Schema.Ref, ".json#") {
-			pos := strings.Index(value.Schema.Ref, "#")
-			value.Schema.Ref = value.Schema.Ref[pos:]
+			value.Schema.Ref = removeExternalRef(value.Schema.Ref)
 		}
 	}
 }
@@ -165,8 +172,7 @@ func updateExternalRefParams(params *openapi3.Parameters) {
 
 	for _, v := range *params {
 		if strings.Contains(v.Ref, ".json#") {
-			pos := strings.Index(v.Ref, "#")
-			v.Ref = v.Ref[pos:]
+			v.Ref = removeExternalRef(v.Ref)
 			continue
 		}
 
@@ -188,8 +194,7 @@ func updateExternalRefReqBody(reqBody *openapi3.RequestBodyRef) {
 
 	if reqBody.Ref != "" {
 		if strings.Contains(reqBody.Ref, ".json#") {
-			pos := strings.Index(reqBody.Ref, "#")
-			reqBody.Ref = reqBody.Ref[pos:]
+			reqBody.Ref = removeExternalRef(reqBody.Ref)
 		}
 		return
 	}

--- a/tools/cli/internal/openapi/oasdiff.go
+++ b/tools/cli/internal/openapi/oasdiff.go
@@ -16,7 +16,9 @@ package openapi
 
 import (
 	"log"
+	"strings"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/mongodb/openapi/tools/cli/internal/openapi/errors"
 	"github.com/tufin/oasdiff/diff"
 	"github.com/tufin/oasdiff/load"
@@ -68,7 +70,7 @@ func (o OasDiff) mergePaths() error {
 
 	for k, v := range pathsToMerge.Map() {
 		if ok := basePaths.Value(k); ok == nil {
-			basePaths.Set(k, v)
+			basePaths.Set(k, removeExternalRefs(v))
 		} else {
 			return errors.PathConflictError{
 				Entry: k,
@@ -78,6 +80,125 @@ func (o OasDiff) mergePaths() error {
 
 	o.base.Spec.Paths = basePaths
 	return nil
+}
+
+// removeExternalRefs updates the external references of OASes to remove the reference to openapi-mms.json.
+// Example of an external ref is "$ref": "openapi-mms.json#/components/responses/internalServerError"
+// Example of an external ref after removeExternalRefs: "$ref": "#/components/responses/internalServerError"
+func removeExternalRefs(path *openapi3.PathItem) *openapi3.PathItem {
+	if path.Get != nil {
+		updateExternalRefResponses(path.Get.Responses)
+		updateExternalRefParams(&path.Get.Parameters)
+	}
+
+	if path.Put != nil {
+		updateExternalRefResponses(path.Put.Responses)
+		updateExternalRefParams(&path.Put.Parameters)
+		updateExternalRefReqBody(path.Put.RequestBody)
+	}
+
+	if path.Post != nil {
+		updateExternalRefResponses(path.Post.Responses)
+		updateExternalRefParams(&path.Post.Parameters)
+		updateExternalRefReqBody(path.Post.RequestBody)
+	}
+
+	if path.Patch != nil {
+		updateExternalRefResponses(path.Patch.Responses)
+		updateExternalRefParams(&path.Patch.Parameters)
+		updateExternalRefReqBody(path.Patch.RequestBody)
+	}
+
+	if path.Delete != nil {
+		updateExternalRefResponses(path.Delete.Responses)
+		updateExternalRefParams(&path.Delete.Parameters)
+	}
+
+	return path
+}
+
+// updateExternalRefResponses updates the external references of OASes to remove the reference to openapi-mms.json
+// in the Responses.
+// A Response can have an external ref in Response.Ref or in its content (Response.Content.Schema.Ref)
+func updateExternalRefResponses(responses *openapi3.Responses) {
+	if responses == nil {
+		return
+	}
+
+	for _, v := range responses.Map() {
+		if strings.Contains(v.Ref, ".json#") {
+			pos := strings.Index(v.Ref, "#")
+			v.Ref = v.Ref[pos:]
+			continue
+		}
+
+		if v.Value == nil || v.Value.Content == nil {
+			continue
+		}
+
+		updateExternalRefContent(&v.Value.Content)
+	}
+}
+
+// updateExternalRefContent updates the external references of OASes to remove the reference to openapi-mms.json
+// in the Schema.Content.
+func updateExternalRefContent(content *openapi3.Content) {
+	for _, value := range *content {
+		if value.Schema == nil {
+			continue
+		}
+
+		if strings.Contains(value.Schema.Ref, ".json#") {
+			pos := strings.Index(value.Schema.Ref, "#")
+			value.Schema.Ref = value.Schema.Ref[pos:]
+		}
+	}
+}
+
+// updateExternalRefParams updates the external references of OASes to remove the reference to openapi-mms.json
+// in the Parameters.
+// A Parameter can have an external ref in Parameter.Ref or in its content (Parameter.Content.Schema.Ref)
+func updateExternalRefParams(params *openapi3.Parameters) {
+	if params == nil {
+		return
+	}
+
+	for _, v := range *params {
+		if strings.Contains(v.Ref, ".json#") {
+			pos := strings.Index(v.Ref, "#")
+			v.Ref = v.Ref[pos:]
+			continue
+		}
+
+		if v.Value == nil || v.Value.Content == nil {
+			continue
+		}
+
+		updateExternalRefContent(&v.Value.Content)
+	}
+}
+
+// updateExternalRefReqBody updates the external references of OASes to remove the reference to openapi-mms.json
+// in the RequestBody.
+// A RequestBody can have an external ref in RequestBody.Ref or in its content (RequestBody.Content.Schema.Ref)
+func updateExternalRefReqBody(reqBody *openapi3.RequestBodyRef) {
+	if reqBody == nil {
+		return
+	}
+
+	if reqBody.Ref != "" {
+		if strings.Contains(reqBody.Ref, ".json#") {
+			pos := strings.Index(reqBody.Ref, "#")
+			reqBody.Ref = reqBody.Ref[pos:]
+		}
+		return
+	}
+
+	if reqBody.Value == nil || reqBody.Value.Content == nil {
+		return
+	}
+
+	updateExternalRefContent(&reqBody.Value.Content)
 }
 
 func (o OasDiff) mergeTags() error {

--- a/tools/cli/internal/openapi/oasdiff.go
+++ b/tools/cli/internal/openapi/oasdiff.go
@@ -145,7 +145,7 @@ func removeExternalRef(ref string) string {
 		return ref
 	}
 
-	return ref[:pos]
+	return ref[pos:]
 }
 
 // updateExternalRefContent updates the external references of OASes to remove the reference to openapi-mms.json

--- a/tools/cli/internal/openapi/oasdiff_test.go
+++ b/tools/cli/internal/openapi/oasdiff_test.go
@@ -844,7 +844,7 @@ func TestUpdateExternalRefResponses(t *testing.T) {
 			expected: map[string]*openapi3.ResponseRef{},
 		},
 		{
-			name: "Responses with Ref to .json#",
+			name: "Responses with external ref",
 			input: map[string]*openapi3.ResponseRef{
 				"200": {
 					Ref: "openapi-mms.json#someRef",
@@ -870,7 +870,7 @@ func TestUpdateExternalRefResponses(t *testing.T) {
 			},
 		},
 		{
-			name: "Responses with nested Content Ref to .json#",
+			name: "Responses with nested Content with external ref",
 			input: map[string]*openapi3.ResponseRef{
 				"200": {
 					Value: &openapi3.Response{
@@ -899,7 +899,7 @@ func TestUpdateExternalRefResponses(t *testing.T) {
 			},
 		},
 		{
-			name: "Responses with no matching Ref",
+			name: "Responses with no external ref to another OAS than openapi-mms.json",
 			input: map[string]*openapi3.ResponseRef{
 				"200": {
 					Ref: "other.json#someRef",
@@ -933,4 +933,98 @@ func newResponseFromMap(t *testing.T, input map[string]*openapi3.ResponseRef) *o
 	}
 
 	return output
+}
+
+func TestUpdateExternalRefParams(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *openapi3.Parameters
+		expected *openapi3.Parameters
+	}{
+		{
+			name:     "Nil Param",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "Empty Param",
+			input:    &openapi3.Parameters{},
+			expected: &openapi3.Parameters{},
+		},
+		{
+			name: "Param with external ref#",
+			input: &openapi3.Parameters{
+				{
+					Ref: "openapi-mms.json#someRef",
+				},
+			},
+			expected: &openapi3.Parameters{
+				{
+					Ref: "#someRef",
+				},
+			},
+		},
+		{
+			name: "Param with internal Ref",
+			input: &openapi3.Parameters{
+				{
+					Ref: "#someRef",
+				},
+			},
+			expected: &openapi3.Parameters{
+				{
+					Ref: "#someRef",
+				},
+			},
+		},
+		{
+			name: "Param with nested Content with external Ref",
+			input: &openapi3.Parameters{
+				{
+					Value: &openapi3.Parameter{
+						Content: openapi3.Content{
+							"application/json": &openapi3.MediaType{
+								Schema: &openapi3.SchemaRef{
+									Ref: "openapi-mms.json#nestedRef",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &openapi3.Parameters{
+				{
+					Value: &openapi3.Parameter{
+						Content: openapi3.Content{
+							"application/json": &openapi3.MediaType{
+								Schema: &openapi3.SchemaRef{
+									Ref: "#nestedRef",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Responses with no external ref to another OAS than openapi-mms.json",
+			input: &openapi3.Parameters{
+				{
+					Ref: "other.json#someRef",
+				},
+			},
+			expected: &openapi3.Parameters{
+				{
+					Ref: "#someRef",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updateExternalRefParams(tt.input)
+			assert.True(t, reflect.DeepEqual(tt.expected, tt.input))
+		})
+	}
 }

--- a/tools/cli/internal/openapi/oasdiff_test.go
+++ b/tools/cli/internal/openapi/oasdiff_test.go
@@ -15,14 +15,13 @@
 package openapi
 
 import (
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/mongodb/openapi/tools/cli/internal/pointer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tufin/oasdiff/diff"
 	"github.com/tufin/oasdiff/load"
 )


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ [CLOUDP-251170](https://jira.mongodb.org/browse/CLOUDP-251170)

The generate `foas.json` contains external references to `openapi-mms.json` components.
This PR updates the merging logic to remove `openapi-mms.json` from the path references.

Example of external reference:
`$ref": "openapi-mms.json#/components/responses/internalServerError"`

what we want in the foas.json is
`$ref": "#/components/responses/internalServerError"`