### PR TITLE
CLOUDP-253686: Update mongodb/openapi to use goreleaser v2

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -73,11 +73,11 @@ jobs:
         with:
           go-version-file: 'tools/cli/go.mod'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200
         with:
-          version: latest
+          version: '~> v2'
           workdir: tools/cli
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Issue


### PR DESCRIPTION
## Proposed changes
This PR updates the Release action to use goreleaser v2. I checked the release log and the [only warning](https://github.com/mongodb/openapi/actions/runs/9356736227/job/25755006235#step:4:21) was about using the `--clean` flag
