### PR TITLE
chore: update go to 1.22.4 to unblock library upgrade

### DIFF
--- a/tools/.tool-versions
+++ b/tools/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.3
+golang 1.22.4

--- a/tools/cli/go.mod
+++ b/tools/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/openapi/tools/cli
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/getkin/kin-openapi v0.125.0


### PR DESCRIPTION
## Proposed changes
oasdf library upgrade is failing #48 because it requires go v1.22.4. This PR updates the go version to v1.22.4