### PR TITLE
CLOUDP-259831: fix tag sorting

### DIFF
--- a/tools/cli/internal/openapi/oasdiff.go
+++ b/tools/cli/internal/openapi/oasdiff.go
@@ -16,7 +16,7 @@ package openapi
 
 import (
 	"log"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -234,7 +234,9 @@ func (o OasDiff) mergeTags() error {
 			}
 		}
 	}
-	sort.Sort(ByName(baseTags))
+	slices.SortFunc(ByName(baseTags), func(a, b *openapi3.Tag) int {
+		return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+	})
 	o.base.Spec.Tags = baseTags
 	return nil
 }

--- a/tools/cli/internal/openapi/oasdiff_test.go
+++ b/tools/cli/internal/openapi/oasdiff_test.go
@@ -174,13 +174,13 @@ func TestOasDiff_mergeTags(t *testing.T) {
 				Spec: &openapi3.T{
 					Tags: []*openapi3.Tag{
 						{
-							Name:        "Tag1",
-							Description: "Tag1",
+							Name:        "AWS Clusters DNS",
+							Description: "AWS Clusters DNS",
 						},
 
 						{
-							Name:        "Tag2",
-							Description: "Tag2",
+							Name:        "Access Tracking",
+							Description: "Access Tracking",
 						},
 					},
 				},
@@ -189,13 +189,13 @@ func TestOasDiff_mergeTags(t *testing.T) {
 			wantErr: require.NoError,
 			expectedTags: []*openapi3.Tag{
 				{
-					Name:        "Tag1",
-					Description: "Tag1",
+					Name:        "Access Tracking",
+					Description: "Access Tracking",
 				},
 
 				{
-					Name:        "Tag2",
-					Description: "Tag2",
+					Name:        "AWS Clusters DNS",
+					Description: "AWS Clusters DNS",
 				},
 				{
 					Name:        "TagBase1",


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-259831

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->
# Description:
Spectral is failing saying that the tags are not in alphabetical order. The issue is that the sort algorithm is case-sensitive so we need to lower case the strings before comparing
