### PR TITLE
CLOUDP-260462: Add support for detecting latest matched version in an operation

### DIFF
--- a/tools/cli/internal/openapi/filter/filter.go
+++ b/tools/cli/internal/openapi/filter/filter.go
@@ -15,19 +15,32 @@ package filter
 
 import (
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/mongodb/openapi/tools/cli/internal/apiversion"
 )
 
 type Filter interface {
-	Apply(doc *openapi3.T) error
+	Apply(doc *openapi3.T, metadata *FilterMetadata) error
+}
+
+type FilterMetadata struct {
+	targetVersion *apiversion.APIVersion
+	targetEnv     string
 }
 
 var filters = map[string]Filter{
 	"path": &PathFilter{},
 }
 
-func ApplyFilters(doc *openapi3.T) error {
+func NewMetadata(targetVersion *apiversion.APIVersion, targetEnv string) *FilterMetadata {
+	return &FilterMetadata{
+		targetVersion: targetVersion,
+		targetEnv:     targetEnv,
+	}
+}
+
+func ApplyFilters(doc *openapi3.T, metadata *FilterMetadata) error {
 	for _, filter := range filters {
-		if err := filter.Apply(doc); err != nil {
+		if err := filter.Apply(doc, metadata); err != nil {
 			return err
 		}
 	}

--- a/tools/cli/internal/openapi/filter/filter.go
+++ b/tools/cli/internal/openapi/filter/filter.go
@@ -19,10 +19,10 @@ import (
 )
 
 type Filter interface {
-	Apply(doc *openapi3.T, metadata *FilterMetadata) error
+	Apply(doc *openapi3.T, metadata *Metadata) error
 }
 
-type FilterMetadata struct {
+type Metadata struct {
 	targetVersion *apiversion.APIVersion
 	targetEnv     string
 }
@@ -31,14 +31,14 @@ var filters = map[string]Filter{
 	"path": &PathFilter{},
 }
 
-func NewMetadata(targetVersion *apiversion.APIVersion, targetEnv string) *FilterMetadata {
-	return &FilterMetadata{
+func NewMetadata(targetVersion *apiversion.APIVersion, targetEnv string) *Metadata {
+	return &Metadata{
 		targetVersion: targetVersion,
 		targetEnv:     targetEnv,
 	}
 }
 
-func ApplyFilters(doc *openapi3.T, metadata *FilterMetadata) error {
+func ApplyFilters(doc *openapi3.T, metadata *Metadata) error {
 	for _, filter := range filters {
 		if err := filter.Apply(doc, metadata); err != nil {
 			return err

--- a/tools/cli/internal/openapi/filter/path.go
+++ b/tools/cli/internal/openapi/filter/path.go
@@ -34,9 +34,6 @@ func (f *PathFilter) Apply(doc *openapi3.T, metadata *FilterMetadata) error {
 }
 
 func filterPathItem(pPath *openapi3.PathItem, m *FilterMetadata) {
-	// versionFoundForOperation := false
-	// operationsToBeRemoved := make(map[string]*openapi3.Operation)
-
 	version := m.targetVersion
 	for _, op := range pPath.Operations() {
 		latestMatchedVersion, err := getLatestVersionMatch(op, version)
@@ -45,48 +42,8 @@ func filterPathItem(pPath *openapi3.PathItem, m *FilterMetadata) {
 			return
 		}
 
-		log.Printf("targetVersion: %s", version)
-		log.Printf("latestMatchedVersion: %s", latestMatchedVersion)
-
-		versionFoundForOperation := false
-		deprecatedVersions := make([]*apiversion.APIVersion, 0)
-		removeResponseCodes := make([]string, 0)
-
-		for _, response := range op.Responses.Map() {
-			filteredContent, _ := filterVersionedContent(response.Value.Content, latestMatchedVersion, true)
-			if len(filteredContent) > 0 {
-				versionFoundForOperation = true
-				deprecatedVersionsPerContent := getDeprecatedVersionsPerContent(response.Value.Content, latestMatchedVersion)
-				deprecatedVersions = append(deprecatedVersions, deprecatedVersionsPerContent...)
-			}
-
-			log.Printf("versionFoundForOperation: %t", versionFoundForOperation)
-			log.Printf("deprecatedVersions: %v", deprecatedVersions)
-
-			// remove entirely the response code (e.g. "200") if the filtered content is empty
-			if filteredContent == nil && isVersionedContent(response.Value.Content) {
-				removeResponseCodes = append(removeResponseCodes, response.Ref)
-			}
-			response.Value.Content = filteredContent
-		}
-		for _, c := range removeResponseCodes {
-			log.Printf("Removing response code: %s", c)
-			delete(op.Responses.Map(), c)
-		}
-
-		// if requestBody := op.RequestBody; requestBody != nil && len(requestBody.Content) > 0 {
-		// 	filteredRequestBody := filterVersionedContent(requestBody.Content, pVersion, false).Content
-		// 	if filteredRequestBody != nil && len(filteredRequestBody) > 0 {
-		// 		requestBody.Content = filteredRequestBody
-		// 	} else {
-		// 		// We do not want empty request. Remove request body object
-		// 		op.RequestBody = nil
-		// 	}
-		// }
-
-		// if len(deprecatedVersions) > 0 {
-		// 	op.Description += ". Deprecated versions: " + strings.Join(deprecatedVersions, ", ")
-		// }
+		log.Printf("Parsing OperationId: %s for targetVersion %s and got the latest matched version: %s", op.OperationID, version, latestMatchedVersion)
+		// TODO: Continue parsing...
 	}
 }
 

--- a/tools/cli/internal/openapi/filter/path.go
+++ b/tools/cli/internal/openapi/filter/path.go
@@ -24,7 +24,7 @@ import (
 type PathFilter struct {
 }
 
-func (f *PathFilter) Apply(doc *openapi3.T, metadata *FilterMetadata) error {
+func (f *PathFilter) Apply(doc *openapi3.T, metadata *Metadata) error {
 	log.Printf("Applying path for OAS with Title %s", doc.Info.Title)
 	for path, pathItem := range doc.Paths.Map() {
 		log.Printf("Path: %s", path)
@@ -33,7 +33,7 @@ func (f *PathFilter) Apply(doc *openapi3.T, metadata *FilterMetadata) error {
 	return nil
 }
 
-func filterPathItem(pPath *openapi3.PathItem, m *FilterMetadata) {
+func filterPathItem(pPath *openapi3.PathItem, m *Metadata) {
 	version := m.targetVersion
 	for _, op := range pPath.Operations() {
 		latestMatchedVersion, err := getLatestVersionMatch(op, version)
@@ -42,12 +42,14 @@ func filterPathItem(pPath *openapi3.PathItem, m *FilterMetadata) {
 			return
 		}
 
-		log.Printf("Parsing OperationId: %s for targetVersion %s and got the latest matched version: %s", op.OperationID, version, latestMatchedVersion)
+		log.Printf("Parsing OperationId: %s for targetVersion %s and got the latest matched version: %s",
+			op.OperationID, version, latestMatchedVersion)
 		// TODO: Continue parsing...
 	}
 }
 
-func getLatestVersionMatch(op *openapi3.Operation, requestedVersion *apiversion.APIVersion) (*apiversion.APIVersion, error) {
+func getLatestVersionMatch(
+	op *openapi3.Operation, requestedVersion *apiversion.APIVersion) (*apiversion.APIVersion, error) {
 	/*
 		  given:
 			 version: 2024-01-01
@@ -59,7 +61,7 @@ func getLatestVersionMatch(op *openapi3.Operation, requestedVersion *apiversion.
 				  content: application/vnd.atlas.2025-01-01+json
 		  should return latestVersionMatch=2023-12-01
 	*/
-	var latestVersionMatch *apiversion.APIVersion = nil
+	var latestVersionMatch *apiversion.APIVersion
 	for _, response := range op.Responses.Map() {
 		if response.Value.Content == nil {
 			continue

--- a/tools/cli/internal/openapi/filter/path.go
+++ b/tools/cli/internal/openapi/filter/path.go
@@ -16,13 +16,121 @@ package filter
 import (
 	"log"
 
+	"github.com/mongodb/openapi/tools/cli/internal/apiversion"
+
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
 type PathFilter struct {
 }
 
-func (f *PathFilter) Apply(doc *openapi3.T) error {
+func (f *PathFilter) Apply(doc *openapi3.T, metadata *FilterMetadata) error {
 	log.Printf("Applying path for OAS with Title %s", doc.Info.Title)
+	for path, pathItem := range doc.Paths.Map() {
+		log.Printf("Path: %s", path)
+		filterPathItem(pathItem, metadata)
+	}
 	return nil
+}
+
+func filterPathItem(pPath *openapi3.PathItem, m *FilterMetadata) {
+	// versionFoundForOperation := false
+	// operationsToBeRemoved := make(map[string]*openapi3.Operation)
+
+	version := m.targetVersion
+	for _, op := range pPath.Operations() {
+		latestMatchedVersion, err := getLatestVersionMatch(op, version)
+		if err != nil {
+			log.Fatalf("Error getting latest version match: %s", err)
+			return
+		}
+
+		log.Printf("targetVersion: %s", version)
+		log.Printf("latestMatchedVersion: %s", latestMatchedVersion)
+
+		versionFoundForOperation := false
+		deprecatedVersions := make([]*apiversion.APIVersion, 0)
+		removeResponseCodes := make([]string, 0)
+
+		for _, response := range op.Responses.Map() {
+			filteredContent, _ := filterVersionedContent(response.Value.Content, latestMatchedVersion, true)
+			if len(filteredContent) > 0 {
+				versionFoundForOperation = true
+				deprecatedVersionsPerContent := getDeprecatedVersionsPerContent(response.Value.Content, latestMatchedVersion)
+				deprecatedVersions = append(deprecatedVersions, deprecatedVersionsPerContent...)
+			}
+
+			log.Printf("versionFoundForOperation: %t", versionFoundForOperation)
+			log.Printf("deprecatedVersions: %v", deprecatedVersions)
+
+			// remove entirely the response code (e.g. "200") if the filtered content is empty
+			if filteredContent == nil && isVersionedContent(response.Value.Content) {
+				removeResponseCodes = append(removeResponseCodes, response.Ref)
+			}
+			response.Value.Content = filteredContent
+		}
+		for _, c := range removeResponseCodes {
+			log.Printf("Removing response code: %s", c)
+			delete(op.Responses.Map(), c)
+		}
+
+		// if requestBody := op.RequestBody; requestBody != nil && len(requestBody.Content) > 0 {
+		// 	filteredRequestBody := filterVersionedContent(requestBody.Content, pVersion, false).Content
+		// 	if filteredRequestBody != nil && len(filteredRequestBody) > 0 {
+		// 		requestBody.Content = filteredRequestBody
+		// 	} else {
+		// 		// We do not want empty request. Remove request body object
+		// 		op.RequestBody = nil
+		// 	}
+		// }
+
+		// if len(deprecatedVersions) > 0 {
+		// 	op.Description += ". Deprecated versions: " + strings.Join(deprecatedVersions, ", ")
+		// }
+	}
+}
+
+func getLatestVersionMatch(op *openapi3.Operation, requestedVersion *apiversion.APIVersion) (*apiversion.APIVersion, error) {
+	/*
+		  given:
+			 version: 2024-01-01
+			 op response:
+			   "200":
+				  content: application/vnd.atlas.2023-01-01+json
+			   "201":
+				  content: application/vnd.atlas.2023-12-01+json
+				  content: application/vnd.atlas.2025-01-01+json
+		  should return latestVersionMatch=2023-12-01
+	*/
+	var latestVersionMatch *apiversion.APIVersion = nil
+	for _, response := range op.Responses.Map() {
+		if response.Value.Content == nil {
+			continue
+		}
+
+		for contentType := range response.Value.Content {
+			contentVersion, err := apiversion.New(apiversion.WithContent(contentType))
+			if err != nil {
+				log.Printf("Ignoring invalid content type: %s", contentType)
+				continue
+			}
+			if contentVersion.GreaterThan(requestedVersion) {
+				continue
+			}
+
+			if contentVersion.Equal(requestedVersion) {
+				return contentVersion, nil
+			}
+
+			if latestVersionMatch == nil || contentVersion.GreaterThan(latestVersionMatch) {
+				latestVersionMatch = contentVersion
+			}
+		}
+	}
+
+	if latestVersionMatch == nil {
+		return requestedVersion, nil
+	}
+
+	return latestVersionMatch, nil
 }

--- a/tools/cli/internal/openapi/filter/path_test.go
+++ b/tools/cli/internal/openapi/filter/path_test.go
@@ -1,0 +1,104 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/mongodb/openapi/tools/cli/internal/apiversion"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathFilter_getLatestVersionMatch(t *testing.T) {
+	testCases := []struct {
+		name          string
+		targetVersion string
+		expectedMatch string
+	}{
+		{
+			name:          "exact match 2023-01-01",
+			targetVersion: "2023-01-01",
+			expectedMatch: "2023-01-01",
+		},
+		{
+			name:          "exact match 2023-11-15",
+			targetVersion: "2023-11-15",
+			expectedMatch: "2023-11-15",
+		},
+		{
+			name:          "exact match 2024-05-30",
+			targetVersion: "2024-05-30",
+			expectedMatch: "2024-05-30",
+		},
+		{
+			name:          "approx match 2023-01-01",
+			targetVersion: "2023-01-02",
+			expectedMatch: "2023-01-01",
+		},
+		{
+			name:          "approx match 2023-01-01",
+			targetVersion: "2023-01-31",
+			expectedMatch: "2023-01-01",
+		},
+		{
+			name:          "approx match 2023-02-01",
+			targetVersion: "2023-02-20",
+			expectedMatch: "2023-02-01",
+		},
+		{
+			name:          "future date",
+			targetVersion: "2030-02-20",
+			expectedMatch: "2024-05-30",
+		},
+		{
+			name:          "past date",
+			targetVersion: "1999-02-20",
+			expectedMatch: "1999-02-20",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			targetVersion, err := apiversion.New(apiversion.WithVersion(tt.targetVersion))
+			assert.NoError(t, err)
+			r, err := getLatestVersionMatch(oasOperationAllVersions(), targetVersion)
+			assert.NoError(t, err)
+			// transform time to str with format "2006-01-02"
+			assert.Equal(t, tt.expectedMatch, r.String())
+		})
+	}
+
+}
+
+func oasOperationAllVersions() *openapi3.Operation {
+	responses := &openapi3.Responses{}
+	responses.Set("200", &openapi3.ResponseRef{
+		Value: &openapi3.Response{
+			Content: map[string]*openapi3.MediaType{
+				"application/vnd.atlas.2023-01-01+json": {},
+				"application/vnd.atlas.2023-02-01+json": {},
+				"application/vnd.atlas.2023-10-01+json": {},
+				"application/vnd.atlas.2023-11-15+json": {},
+				"application/vnd.atlas.2024-05-30+json": {},
+			},
+		},
+	})
+
+	return &openapi3.Operation{
+		OperationID: "operationId",
+		Responses:   responses,
+	}
+}

--- a/tools/cli/internal/openapi/filter/path_test.go
+++ b/tools/cli/internal/openapi/filter/path_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/mongodb/openapi/tools/cli/internal/apiversion"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPathFilter_getLatestVersionMatch(t *testing.T) {
@@ -73,14 +74,13 @@ func TestPathFilter_getLatestVersionMatch(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			targetVersion, err := apiversion.New(apiversion.WithVersion(tt.targetVersion))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			r, err := getLatestVersionMatch(oasOperationAllVersions(), targetVersion)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			// transform time to str with format "2006-01-02"
 			assert.Equal(t, tt.expectedMatch, r.String())
 		})
 	}
-
 }
 
 func oasOperationAllVersions() *openapi3.Operation {


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-260462


```shell

❯ make build && ./bin/foascli split -s test2.yaml --versions
==> Building foascli binary
go build -ldflags "-s -w -X github.com/mongodb/openapi/tools/cli/internal/version.GitCommit=d4fc46664ef3d32ade5e45f3d06ed2cbbad370a4 -X github.com/mongodb/openapi/tools/cli/internal/version.Version=v0.0.1" -o ./bin/foascli ./cmd
2024/07/08 14:34:40 Filtering OpenAPI document by version 2023-01-01
2024/07/08 14:34:40 Applying path for OAS with Title MongoDB Atlas Administration API
2024/07/08 14:34:40 Path: /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/jwks
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Parsing OperationId: revokeJwksFromIdentityProvider for targetVersion 2023-01-01 and got the latest matched version: 2023-01-01
2024/07/08 14:34:40 Path: /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders
2024/07/08 14:34:40 Parsing OperationId: listIdentityProviders for targetVersion 2023-01-01 and got the latest matched version: 2023-01-01
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Parsing OperationId: createIdentityProvider for targetVersion 2023-01-01 and got the latest matched version: 2023-01-01
2024/07/08 14:34:40 Path: /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Parsing OperationId: deleteIdentityProvider for targetVersion 2023-01-01 and got the latest matched version: 2023-01-01
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Parsing OperationId: getIdentityProvider for targetVersion 2023-01-01 and got the latest matched version: 2023-01-01
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Parsing OperationId: updateIdentityProvider for targetVersion 2023-01-01 and got the latest matched version: 2023-01-01
2024/07/08 14:34:40 
Versioned spec was saved in 'test2-2023-01-01.yaml'.

2024/07/08 14:34:40 [WARN] OpenAPI document is invalid: invalid components: schema "AccessListItemView": error parsing regexp: invalid or unsupported Perl syntax: `(?!`
2024/07/08 14:34:40 Filtering OpenAPI document by version 2023-11-15
2024/07/08 14:34:40 Applying path for OAS with Title MongoDB Atlas Administration API
2024/07/08 14:34:40 Path: /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}
2024/07/08 14:34:40 Parsing OperationId: deleteIdentityProvider for targetVersion 2023-11-15 and got the latest matched version: 2023-11-15
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Parsing OperationId: getIdentityProvider for targetVersion 2023-11-15 and got the latest matched version: 2023-11-15
2024/07/08 14:34:40 Parsing OperationId: updateIdentityProvider for targetVersion 2023-11-15 and got the latest matched version: 2023-11-15
2024/07/08 14:34:40 Path: /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/jwks
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Parsing OperationId: revokeJwksFromIdentityProvider for targetVersion 2023-11-15 and got the latest matched version: 2023-11-15
2024/07/08 14:34:40 Path: /api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders
2024/07/08 14:34:40 Parsing OperationId: createIdentityProvider for targetVersion 2023-11-15 and got the latest matched version: 2023-11-15
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Ignoring invalid content type: application/json
2024/07/08 14:34:40 Parsing OperationId: listIdentityProviders for targetVersion 2023-11-15 and got the latest matched version: 2023-01-01
2024/07/08 14:34:40 
Versioned spec was saved in 'test2-2023-11-15.yaml'.

2024/07/08 14:34:40 [WARN] OpenAPI document is invalid: invalid components: schema "AccessListItemView": error parsing regexp: invalid or unsupported Perl syntax: `(?!`
```

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
