### PR TITLE
CLOUDP-262703: Add x-xgen-sha flag to GenerateAtlasOpenApiSpecTool

### DIFF
--- a/tools/cli/internal/cli/flag/flag.go
+++ b/tools/cli/internal/cli/flag/flag.go
@@ -26,4 +26,5 @@ const (
 	Spec          = "spec"
 	SpecShort     = "s"
 	Environment   = "env"
+	GitSha        = "sha"
 )

--- a/tools/cli/internal/cli/merge/merge.go
+++ b/tools/cli/internal/cli/merge/merge.go
@@ -32,6 +32,7 @@ type Opts struct {
 	basePath      string
 	outputPath    string
 	format        string
+	gitSha        string
 	externalPaths []string
 }
 
@@ -39,6 +40,12 @@ func (o *Opts) Run() error {
 	federated, err := o.Merger.MergeOpenAPISpecs(o.externalPaths)
 	if err != nil {
 		return err
+	}
+
+	if o.gitSha != "" {
+		federated.Info.Extensions = map[string]interface{}{
+			"x-xgen-sha": o.gitSha,
+		}
 	}
 
 	federatedBytes, err := json.MarshalIndent(*federated, "", "  ")
@@ -97,6 +104,7 @@ func Builder() *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.basePath, flag.Base, flag.BaseShort, "", usage.Base)
 	cmd.Flags().StringArrayVarP(&opts.externalPaths, flag.External, flag.ExternalShort, nil, usage.External)
+	cmd.Flags().StringVar(&opts.gitSha, flag.GitSha, "", usage.GitSha)
 	cmd.Flags().StringVarP(&opts.outputPath, flag.Output, flag.OutputShort, "", usage.Output)
 	cmd.Flags().StringVarP(&opts.format, flag.Format, flag.FormatShort, "json", usage.Format)
 

--- a/tools/cli/internal/cli/usage/usage.go
+++ b/tools/cli/internal/cli/usage/usage.go
@@ -22,4 +22,5 @@ const (
 	Versions    = "Boolean flag that defines wether to split the OAS into multiple versions."
 	Spec        = "Path to the OAS file."
 	Environment = "Environment to consider when generating the versioned OAS."
+	GitSha      = "GitSHA to use as identifier (x-xgen-sha) of the generated specification."
 )


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-262703:

Add support for `x-xgen-sha` to the `foascli merge` command
