### PR TITLE
CLOUDP-262517: Add check to only update the Postman Collection if OpenAPI spec has changed

### DIFF
--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      ## Will be removed after CLOUDP-263207
       - name: Fetch Collection
         working-directory: ./tools/postman
         run: |


### PR DESCRIPTION
## Proposed changes

- Use GitHub Actions cache to store the sha of the openapi file. 
- If the sha matches with the sha of the current openapi spec then do not upload collection.
- Only update cache if previous steps were successful 

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-262517

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->



## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
