### PR TITLE
CLOUDP-263265: Add step to split the FOAS to versions

### DIFF
--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -1,0 +1,27 @@
+name: 'Optional Spec Validations'
+on:
+  workflow_call:
+    secrets: # all secrets are passed explicitly in this workflow
+      api_bot_pat:
+        required: true
+
+jobs:  
+  optional-validations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Validate the FOAS can be used to generate Postman collection
+        run: |
+          cp -rf "./tools/cli/test/data/openapi-foas-dev.json" "./tools/postman/openapi/atlas-api.json"
+          pushd tools/postman
+          make convert_to_collection
+          popd
+      - name: Create Issue
+        if: ${{ failure() }}
+        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
+        with:
+          labels: failed-release
+          title: "(PROD) Optional Postman validation failed :scream_cat:"
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.api_bot_pat }}

--- a/.github/workflows/release-spec-prod.yml
+++ b/.github/workflows/release-spec-prod.yml
@@ -8,64 +8,30 @@ permissions:
 jobs:
   # Required validations will stop the release if they fail
   run-required-validations:
+    uses: ./.github/workflows/required-spec-validations.yml
+    secrets:
+      api_bot_pat: ${{ secrets.API_BOT_PAT }}
+    with:
+      spectral_version: ${{ vars.SPECTRAL_VERSION }}
+  # Optional validations won't stop the release but only open a GH issue if they fail
+  run-optional-validations:
+    uses: ./.github/workflows/optional-spec-validations.yml
+    secrets:
+      api_bot_pat: ${{ secrets.API_BOT_PAT }}
+
+  split-spec-to-versions:
     runs-on: ubuntu-latest
+    needs: [run-required-validations]
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - name: Run Spectral
-        env:
-          SPECTRAL_VERSION: ${{ vars.SPECTRAL_VERSION }}
-        run: npx -- @stoplight/spectral-cli@"${SPECTRAL_VERSION}" lint ./tools/cli/test/data/openapi-foas*.{yml,yaml} --ruleset=.spectral.yaml # we will update this to lint the FOAS in CLOUDP-263186
-      - name: Create Issue
-        if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
-        with:
-          labels: failed-release
-          title: "(PROD) Required Spectral validation failed :scream_cat:"
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          token: ${{ secrets.API_BOT_PAT }}
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
           go-version-file: 'tools/cli/go.mod'
-      - name: Checkout GO SDK repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-         repository: 'mongodb/atlas-sdk-go'
-         token: ${{ secrets.API_BOT_PAT }}
-         path: 'atlas-sdk-go'
-      - name: Validate the FOAS can be used with the Go SDK
+      - name: Run foascli split command
         run: |
-          cp -rf "./tools/cli/test/data/openapi-foas-dev.yaml" "atlas-sdk-go/openapi/atlas-sdk.yaml"
-          pushd atlas-sdk-go
-          make -e openapi-pipeline
+          pushd tools/cli
+          make build
           popd
-      - name: Create Issue
-        if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
-        with:
-          labels: failed-release
-          title: "(PROD) Required GO SDK validation failed :scream_cat:"
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          token: ${{ secrets.API_BOT_PAT }}
-  
-  # Optional validations won't stop the release but only open a GH issue if they fail
-  run-optional-validations:
-      runs-on: ubuntu-latest
-      steps:
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - name: Validate the FOAS can be used to generate Postman collection
-        run: |
-          cp -rf "./tools/cli/test/data/openapi-foas-dev.json" "./tools/postman/openapi/atlas-api.json"
-          pushd tools/postman
-          make convert_to_collection
-          popd
-      - name: Create Issue
-        if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
-        with:
-          labels: failed-release
-          title: "(PROD) Optional Postman validation failed :scream_cat:"
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          token: ${{ secrets.API_BOT_PAT }}
+          ./tools/cli/bin/foascli split -s ./tools/cli/test/data/openapi-foas-dev.yaml --env prod

--- a/.github/workflows/release-spec-prod.yml
+++ b/.github/workflows/release-spec-prod.yml
@@ -19,7 +19,7 @@ jobs:
     secrets:
       api_bot_pat: ${{ secrets.API_BOT_PAT }}
 
-  split-spec-to-versions:
+  generate-versioned-specs
     runs-on: ubuntu-latest
     needs: [run-required-validations]
     steps:

--- a/.github/workflows/release-spec-prod.yml
+++ b/.github/workflows/release-spec-prod.yml
@@ -19,7 +19,7 @@ jobs:
     secrets:
       api_bot_pat: ${{ secrets.API_BOT_PAT }}
 
-  generate-versioned-specs
+  generate-versioned-specs:
     runs-on: ubuntu-latest
     needs: [run-required-validations]
     steps:

--- a/.github/workflows/required-spec-validations.yml
+++ b/.github/workflows/required-spec-validations.yml
@@ -51,4 +51,3 @@ jobs:
             title: "(PROD) Required GO SDK validation failed :scream_cat:"
             body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
             token: ${{ secrets.api_bot_pat }}
-    

--- a/.github/workflows/required-spec-validations.yml
+++ b/.github/workflows/required-spec-validations.yml
@@ -1,0 +1,54 @@
+name: 'Required Spec Validations'
+on:
+  workflow_call:
+    inputs:
+      spectral_version:
+        description: 'Version of Spectral to use'     
+        type: string
+        required: true
+    secrets: # all secrets are passed explicitly in this workflow
+      api_bot_pat:
+        required: true
+jobs:  
+  required-validations:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        - name: Run Spectral
+          env:
+            SPECTRAL_VERSION: ${{ inputs.spectral_version }}
+          run: npx -- @stoplight/spectral-cli@"${SPECTRAL_VERSION}" lint ./tools/cli/test/data/openapi-foas*.{yml,yaml} --ruleset=.spectral.yaml # we will update this to lint the FOAS in CLOUDP-263186
+        - name: Create Issue
+          if: ${{ failure() }}
+          uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
+          with:
+            labels: failed-release
+            title: "(PROD) Required Spectal validation failed :scream_cat:"
+            body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            token: ${{ secrets.api_bot_pat }}
+        - name: Install Go
+          uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
+          with:
+            go-version-file: 'tools/cli/go.mod'
+        - name: Checkout GO SDK repository
+          uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+          with:
+            repository: 'mongodb/atlas-sdk-go'
+            token: ${{ secrets.api_bot_pat }}
+            path: 'atlas-sdk-go'
+        - name: Validate the FOAS can be used with the Go SDK
+          run: |
+            cp -rf "./tools/cli/test/data/openapi-foas-dev.yaml" "atlas-sdk-go/openapi/atlas-sdk.yaml"
+            pushd atlas-sdk-go
+            make -e openapi-pipeline
+            popd
+        - name: Create Issue
+          if: ${{ failure() }}
+          uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
+          with:
+            labels: failed-release
+            title: "(PROD) Required GO SDK validation failed :scream_cat:"
+            body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            token: ${{ secrets.api_bot_pat }}
+    


### PR DESCRIPTION
## Description
This PR proposes the following changes:
1) splits the validations to different workflows to allow us to reuse them when running in other environments
2) adds the split step to the release workflow


I tested the changes in a fork: https://github.com/andreaangiolillo/openapi-test/actions/runs/10061894444
![Screenshot 2024-07-23 at 16 37 35](https://github.com/user-attachments/assets/69d5d278-0aa9-47b0-b079-c30e9470c4bb)
