### PR TITLE
CLOUDP-263186: Add Logic to retrieve the FOASMetadata from APIx s3 bucket

### DIFF
--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -1,6 +1,11 @@
 name: 'Optional Spec Validations'
 on:
   workflow_call:
+    inputs:
+      run-id:
+        description: 'Run ID of the workflow that triggered this workflow'
+        required: true
+        type: string
     secrets: # all secrets are passed explicitly in this workflow
       api_bot_pat:
         required: true
@@ -11,9 +16,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: openapi-foas
+          github-token: ${{ secrets.api_bot_pat }}
+          run-id: ${{ inputs.run-id }}
       - name: Validate the FOAS can be used to generate Postman collection
         run: |
-          cp -rf "./tools/cli/test/data/openapi-foas-dev.json" "./tools/postman/openapi/atlas-api.json"
+          cp -rf "openapi-foas.json" "./tools/postman/openapi/atlas-api.json"
           pushd tools/postman
           make convert_to_collection
           popd

--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - name: Download artifact
+      - name: Download openapi-foas
         uses: actions/download-artifact@v4
         with:
           name: openapi-foas

--- a/.github/workflows/release-spec-prod.yml
+++ b/.github/workflows/release-spec-prod.yml
@@ -7,20 +7,80 @@ permissions:
   contents: write
   pull-requests: write
 jobs:
+  generata-spec:
+    name: Generate the Federated OpenAPI Spec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          sparse-checkout: |
+            tools
+      - name: Install Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
+        with:
+          go-version-file: 'tools/cli/go.mod'
+          cache-dependency-path: "tools/cli/go.sum"
+      - name: Build CLI
+        working-directory: tools/cli
+        run: make build
+      - name: Retrieve Specs
+        working-directory: tools/cli/bin
+        env:
+          AWS_DEFAULT_REGION: ${{vars.AWS_DEFAULT_REGION}}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+          S3_BUCKET: ${{ vars.S3_BUCKET_PROD }}
+        run: |
+          aws s3 cp s3://"${S3_BUCKET}"/openapi/foas-metadata.json foas-metadata.json
+          < foas-metadata.json jq 
+          
+          jq -c '.services[]' foas-metadata.json | while read -r service; do
+            name=$(echo "${service}" | jq -c '.name' | tr -d '"')
+            sha=$(echo "${service}" | jq -c '.sha' | tr -d '"')
+
+            echo "Downloading the OpenAPI Spec for ${name} with sha ${sha}"
+            aws s3 cp "s3://${S3_BUCKET}/openapi/oas/${name}/${sha}.json" "openapi-${name}.json"
+          done
+      - name: Generate Federated Spec
+        working-directory: tools/cli/bin
+        run: |
+          # Loop through the filtered services and construct the flag
+          service_array=()
+          while IFS= read -r service; do
+            service_array+=("-e" "openapi-${service}.json")
+          done < <(jq -r '.services[] | select(.name != "mms") | .name' foas-metadata.json)
+          
+          echo "Running FOAS CLI merge command with the following services: " "${service_array[@]}"
+          ./foascli merge -b openapi-mms.json "${service_array[@]}" -o openapi-foas.json -f json
+          ./foascli merge -b openapi-mms.json "${service_array[@]}" -o openapi-foas.yaml -f yaml
+      - name: Upload artifact
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b
+        with:
+          name: openapi-foas
+          path: tools/cli/bin/openapi-foas.*
+
   # Required validations will stop the release if they fail
   run-required-validations:
+    name: Run Required Validations
+    needs: generata-spec
     uses: ./.github/workflows/required-spec-validations.yml
     secrets:
       api_bot_pat: ${{ secrets.API_BOT_PAT }}
     with:
       spectral_version: ${{ vars.SPECTRAL_VERSION }}
+      run-id: ${{ github.run_id }}
   # Optional validations won't stop the release but only open a GH issue if they fail
   run-optional-validations:
+    name: Run Optional Validations
+    needs: generata-spec
     uses: ./.github/workflows/optional-spec-validations.yml
     secrets:
       api_bot_pat: ${{ secrets.API_BOT_PAT }}
-
+    with:
+      run-id: ${{ github.run_id }}
   release:
+      name: Release OpenAPI Spec
       runs-on: ubuntu-latest
       needs: [run-required-validations]
       steps:
@@ -30,6 +90,7 @@ jobs:
           uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
           with:
             go-version-file: 'tools/cli/go.mod'
+            cache-dependency-path: "tools/cli/go.sum"
         - name: Run foascli split command
           run: |
             pushd tools/cli

--- a/.github/workflows/required-spec-validations.yml
+++ b/.github/workflows/required-spec-validations.yml
@@ -6,19 +6,30 @@ on:
         description: 'Version of Spectral to use'     
         type: string
         required: true
+      run-id:
+        description: 'Run ID of the workflow that triggered this workflow'
+        required: true
+        type: string
     secrets: # all secrets are passed explicitly in this workflow
       api_bot_pat:
         required: true
+
 jobs:  
   required-validations:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout repository
           uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        - name: Download artifact
+          uses: actions/download-artifact@v4
+          with:
+            name: openapi-foas
+            github-token: ${{ secrets.api_bot_pat }}
+            run-id: ${{ inputs.run-id }}
         - name: Run Spectral
           env:
             SPECTRAL_VERSION: ${{ inputs.spectral_version }}
-          run: npx -- @stoplight/spectral-cli@"${SPECTRAL_VERSION}" lint ./tools/cli/test/data/openapi-foas*.{yml,yaml} --ruleset=.spectral.yaml # we will update this to lint the FOAS in CLOUDP-263186
+          run: npx -- @stoplight/spectral-cli@"${SPECTRAL_VERSION}" lint openapi-foas.yaml --ruleset=.spectral.yaml # we will update this to lint the FOAS in CLOUDP-263186
         - name: Create Issue
           if: ${{ failure() }}
           uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
@@ -37,9 +48,15 @@ jobs:
             repository: 'mongodb/atlas-sdk-go'
             token: ${{ secrets.api_bot_pat }}
             path: 'atlas-sdk-go'
+        - name: Download artifact
+          uses: actions/download-artifact@v4
+          with:
+            name: openapi-foas
+            github-token: ${{ secrets.api_bot_pat }}
+            run-id: ${{ inputs.run-id }}
         - name: Validate the FOAS can be used with the Go SDK
           run: |
-            cp -rf "./tools/cli/test/data/openapi-foas-dev.yaml" "atlas-sdk-go/openapi/atlas-sdk.yaml"
+            cp -rf "openapi-foas.yaml" "atlas-sdk-go/openapi/atlas-sdk.yaml"
             pushd atlas-sdk-go
             make -e openapi-pipeline
             popd

--- a/.github/workflows/required-spec-validations.yml
+++ b/.github/workflows/required-spec-validations.yml
@@ -20,7 +20,7 @@ jobs:
       steps:
         - name: Checkout repository
           uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        - name: Download artifact
+        - name: Download openapi-foas
           uses: actions/download-artifact@v4
           with:
             name: openapi-foas
@@ -49,7 +49,7 @@ jobs:
             repository: 'mongodb/atlas-sdk-go'
             token: ${{ secrets.api_bot_pat }}
             path: 'atlas-sdk-go'
-        - name: Download artifact
+        - name: Download openapi-foas
           uses: actions/download-artifact@v4
           with:
             name: openapi-foas

--- a/.github/workflows/required-spec-validations.yml
+++ b/.github/workflows/required-spec-validations.yml
@@ -42,6 +42,7 @@ jobs:
           uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
           with:
             go-version-file: 'tools/cli/go.mod'
+            cache-dependency-path: "tools/cli/go.sum"
         - name: Checkout GO SDK repository
           uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
           with:


### PR DESCRIPTION
This PR adds the logic to retrieve the FOASMetadata from APIx s3 bucket.

I tested my changes in a fork: https://github.com/andreaangiolillo/openapi-test/actions/runs/10096226482

![Screenshot 2024-07-25 at 15 46 46](https://github.com/user-attachments/assets/10089714-10de-4150-a2cf-1bb971b63c7a)

# Next Steps
I plan to move the FOAS generation logic to another workflow that is called from the main one similar to the validations.