### PR TITLE
CLOUDP-260965: Check that the extention x-xgen-hidden has the correct format

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -144,6 +144,18 @@ rules:
             - required: ["examples"]
             - required: ["schema"]
 
+  x-xgen-hidden-env-format:
+    description: "Ensure x-xgen-hidden-env extension has the correct format. https://go/openapi-hidden-extension"
+    severity: error
+    given: "$..x-xgen-hidden-env"                    # Match anywhere in the document
+    then:
+      - field: envs
+        function: truthy
+      - field: envs
+        function: pattern
+        functionOptions:
+          match: "^(dev|qa|stage|prod)(,(dev|qa|stage|prod))*$"
+
 overrides:
   - files: # load sample data has an issue with different path param names for different VERBS
       - "*.yaml#/paths/~1api~1atlas~1v1.0~1groups~1%7BgroupId%7D~1sampleDatasetLoad~1%7BsampleDatasetId%7D"


### PR DESCRIPTION
# Ticket
CLOUDP-260965

# Description
Add spectral rule to check for the correct format of `x-xgen-hidden-env`
<!-- Please include a summary of the changes and the related issue. Be sure to include relevant motivation and context. -->

# Testing
I tested locally by adding the `x-xgen-hidden-env` extension with the wrong format to multiple places (operation, response and response-body)
```bash
 spectral lint ./tools/cli/test/data/openapi-foas-dev.yaml --ruleset=.spectral.yaml --format stylish --display-only-failures

/Users/andrea.angiolillo/workspace/openapi/tools/cli/test/data/openapi-foas-dev.yaml
 33350:47  error  x-xgen-hidden-env-format  Ensure x-xgen-hidden-env extension has the correct format. https://go/openapi-hidden-extension  paths./api/atlas/v2/groups/{groupId}/clusters.get.responses[200].content.application/vnd.atlas.2025-01-01+json.x-xgen-hidden-env
 33514:43  error  x-xgen-hidden-env-format  Ensure x-xgen-hidden-env extension has the correct format. https://go/openapi-hidden-extension  paths./api/atlas/v2/groups/{groupId}/clusters.post.requestBody.content.application/vnd.atlas.2025-01-01+json.x-xgen-hidden-env
 33539:47  error  x-xgen-hidden-env-format  Ensure x-xgen-hidden-env extension has the correct format. https://go/openapi-hidden-extension  paths./api/atlas/v2/groups/{groupId}/clusters.post.responses[201].content.application/vnd.atlas.2025-01-01+json.x-xgen-hidden-env
 37609:31  error  x-xgen-hidden-env-format  Ensure x-xgen-hidden-env extension has the correct format. https://go/openapi-hidden-extension  paths./api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion.post.x-xgen-hidden-env
 37659:31  error  x-xgen-hidden-env-format  Ensure x-xgen-hidden-env extension has the correct format. https://go/openapi-hidden-extension  paths./api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion.post.x-xgen-hidden-env
 45864:23  error  x-xgen-hidden-env-format  Ensure x-xgen-hidden-env extension has the correct format. https://go/openapi-hidden-extension  paths./api/atlas/v2/groups/{groupId}/uss/{name}/backup/restoreJobs.post.x-xgen-hidden-env.envs

✖ 6 problems (6 errors, 0 warnings, 0 infos, 0 hints)
```