### PR TITLE
CLOUDP-264585: Add toggle to remove generated request and response bodies

### DIFF
--- a/tools/postman/scripts/transform-for-api.sh
+++ b/tools/postman/scripts/transform-for-api.sh
@@ -23,7 +23,7 @@ TMP_FOLDER=${TMP_FOLDER:-"../tmp"}
 VERSIONS_FILE=${VERSIONS_FILE:-"versions.json"}
 
 TOGGLE_USE_ENVIRONMENT_AUTH=${TOGGLE_USE_ENVIRONMENT_AUTH:-true}
-TOGGLE_INCLUDE_BODY=${TOGGLE_INCLUDE_BODY:-false}
+TOGGLE_INCLUDE_BODY=${TOGGLE_INCLUDE_BODY:-true}
 
 current_api_revision=$(jq -r '.versions."2.0" | .[-1]' < "${OPENAPI_FOLDER}/${VERSIONS_FILE}")
 
@@ -58,9 +58,12 @@ if [ "$TOGGLE_INCLUDE_BODY" = "false" ]; then
     intermediateCollectionWithBaseURL.json > intermediateCollectionRemovedResponseBody.json
   
   jq '.collection.item.[].item.[].request.body |= {}' \
-    intermediateCollectionRemovedResponseBody.json > intermediateCollectionPostBody.json
+    intermediateCollectionRemovedResponseBody.json > intermediateCollectionRemovedRequestBody.json
+  
+  jq '.collection.item.[].item.[].response.[].originalRequest.body |= {}' \
+    intermediateCollectionRemovedRequestBody.json > intermediateCollectionPostBody.json
 
-  rm intermediateCollectionRemovedResponseBody.json
+  rm intermediateCollectionRemovedResponseBody.json intermediateCollectionRemovedRequestBody.json
 else
   cp intermediateCollectionWithBaseURL.json intermediateCollectionPostBody.json
 fi
@@ -75,6 +78,7 @@ else
 fi
 
 # Clean up temporary files
+echo "Removing temporary files"
 rm intermediateCollectionWrapped.json \
    intermediateCollectionDisableQueryParam.json \
    intermediateCollectionNoPostmanID.json \


### PR DESCRIPTION
## Proposed changes

- Add Environment variable to remove all generate request and response bodies
- Uses jq to set request bodies to an empty object
- Use jq to set response bodies to an empty string (due to constraints with empty body responses in Postman)
- This keeps the possible response codes but removes the possibly incorrect bodies

Tested on private postman upload
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-264585

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
