### PR TITLE
fix: update the foas staging release to use `stage` instead of staging when using `foascli split`

### DIFF
--- a/.github/scripts/split_spec.sh
+++ b/.github/scripts/split_spec.sh
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
+echo "Running FOAS CLI split command with the following --env=${target_env} and -o=./openapi/v2/openapi.json"
 
-env_flag=${target_env:?}
-if [[ ${env_flag} == "staging" ]]; then
-    env_flag="stage"
-fi
-
-echo "Running FOAS CLI split command with the following --env=${env_flag} and -o=./openapi/v2/openapi.json"
-
-foascli split -s openapi-foas.json --env "${env_flag}" -o ./openapi/v2/openapi.json
+foascli split -s openapi-foas.json --env "${target_env}" -o ./openapi/v2/openapi.json
 cp -rf "openapi-foas.json" "./openapi/v2.json"
 
-foascli split -s openapi-foas.yaml --env "${env_flag}" -o ./openapi/v2/openapi.yaml
+foascli split -s openapi-foas.yaml --env "${target_env}" -o ./openapi/v2/openapi.yaml
 cp -rf "openapi-foas.yaml" "./openapi/v2.yaml"
 

--- a/.github/scripts/split_spec.sh
+++ b/.github/scripts/split_spec.sh
@@ -3,7 +3,7 @@ set -eou pipefail
 
 
 env_flag=${target_env}
-if [[ ${env_flag} == "staging"]]; do
+if [[ ${env_flag} == "staging"]]; then
     env_flag="stage"
 fi
 

--- a/.github/scripts/split_spec.sh
+++ b/.github/scripts/split_spec.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-echo "Running FOAS CLI split command with the following --env=${target_env} and -o=./openapi/v2/openapi.json"
+echo "Running FOAS CLI split command with the following --env=${target_env:?} and -o=./openapi/v2/openapi.json"
 
-foascli split -s openapi-foas.json --env "${target_env}" -o ./openapi/v2/openapi.json
+foascli split -s openapi-foas.json --env "${target_env:?}" -o ./openapi/v2/openapi.json
 cp -rf "openapi-foas.json" "./openapi/v2.json"
 
-foascli split -s openapi-foas.yaml --env "${target_env}" -o ./openapi/v2/openapi.yaml
+foascli split -s openapi-foas.yaml --env "${target_env:?}" -o ./openapi/v2/openapi.yaml
 cp -rf "openapi-foas.yaml" "./openapi/v2.yaml"
 

--- a/.github/scripts/split_spec.sh
+++ b/.github/scripts/split_spec.sh
@@ -3,7 +3,7 @@ set -eou pipefail
 
 
 env_flag=${target_env}
-if [[ env_flag == "staging"]]; do
+if [[ ${env_flag} == "staging"]]; do
     env_flag="stage"
 fi
 

--- a/.github/scripts/split_spec.sh
+++ b/.github/scripts/split_spec.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eou pipefail
+
+
+env_flag=${target_env}
+if [[ env_flag == "staging"]]; do
+    env_flag="stage"
+fi
+
+echo "Running FOAS CLI split command with the following --env=${env_flag} and -o=./openapi/v2/openapi.json"
+
+foascli split -s openapi-foas.json --env "${env_flag}" -o ./openapi/v2/openapi.json
+cp -rf "openapi-foas.json" "./openapi/v2.json"
+
+foascli split -s openapi-foas.yaml --env "${env_flag}" -o ./openapi/v2/openapi.yaml
+cp -rf "openapi-foas.yaml" "./openapi/v2.yaml"
+

--- a/.github/scripts/split_spec.sh
+++ b/.github/scripts/split_spec.sh
@@ -2,8 +2,8 @@
 set -eou pipefail
 
 
-env_flag=${target_env}
-if [[ ${env_flag} == "staging"]]; then
+env_flag=${target_env:?}
+if [[ ${env_flag} == "staging" ]]; then
     env_flag="stage"
 fi
 

--- a/.github/workflows/release-spec-prod.yml
+++ b/.github/workflows/release-spec-prod.yml
@@ -66,12 +66,9 @@ jobs:
           run: make build
         - name: Run foascli split command
           id: split
-          run: |
-            ./tools/cli/bin/foascli split -s openapi-foas.json --env prod -o ./openapi/v2/openapi.json
-            cp -rf "openapi-foas.json" "./openapi/v2.json"
-            
-            ./tools/cli/bin/foascli split -s openapi-foas.yaml --env prod -o ./openapi/v2/openapi.yaml
-            cp -rf "openapi-foas.yaml" "./openapi/v2.yaml"
+          env:
+            target_env: "prod"
+          run: .github/scripts/split_spec.sh
         - name: Create Issue
           if: ${{ failure() && steps.split.outcome == 'failure' }}
           uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd

--- a/.github/workflows/release-spec-runner.yml
+++ b/.github/workflows/release-spec-runner.yml
@@ -45,6 +45,6 @@ jobs:
     with:
         aws_default_region: ${{ vars.AWS_DEFAULT_REGION}}
         aws_s3_bucket: ${{ vars.S3_BUCKET_STAGING}}
-        env: staging
+        env: stage
         spectral_version: ${{ vars.SPECTRAL_VERSION }}
         foascli_version: ${{ vars.FOASCLI_VERSION }}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -97,12 +97,7 @@ jobs:
           id: split
           env:
             target_env: ${{ inputs.env }}
-          run: |
-            foascli split -s openapi-foas.json --env "${target_env}" -o ./openapi/v2/openapi.json
-            cp -rf "openapi-foas.json" "./openapi/v2.json"
-            
-            foascli split -s openapi-foas.yaml --env "${target_env}" -o ./openapi/v2/openapi.yaml
-            cp -rf "openapi-foas.yaml" "./openapi/v2.yaml"
+          run: .github/scripts/split_spec.sh
         - name: Create Issue
           if: ${{ failure() && steps.split.outcome == 'failure' }}
           uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue with the staging release process where we are using `staging` instead of `stage` when running `foascli split` command