### PR TITLE
CLOUDP-264634: Add links to the docs page for each endpoint in the Postman Collection

### DIFF
--- a/tools/postman/scripts/convert-to-collection.sh
+++ b/tools/postman/scripts/convert-to-collection.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
-set -o nounset
-set -o pipefail
+set -euo pipefail
 
 #########################################################
 # Convert from OpenAPI to PostmanV2 Collection

--- a/tools/postman/scripts/fetch-forks.sh
+++ b/tools/postman/scripts/fetch-forks.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
-set -o nounset
-set -o pipefail
+set -euo pipefail
 
 #########################################################
 # Fetch number of forks of each collection

--- a/tools/postman/scripts/fetch-openapi.sh
+++ b/tools/postman/scripts/fetch-openapi.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
-set -o nounset
+set -euo pipefail
 
 #########################################################
 # Fetch openapi from remote file

--- a/tools/postman/scripts/transform-for-api.sh
+++ b/tools/postman/scripts/transform-for-api.sh
@@ -70,7 +70,7 @@ for path in "${paths_array[@]}"; do
 
   # Search the collection for the request with the matching name. Add the link to its description 
   jq --arg title "$title" --arg url "$url" \
-    'first(.collection.item.[].item.[].request | objects |  select(.name == $title).description.content) += "\n\nFind out more at " + $url' \
+    'first(.collection.item.[].item.[].request |  select(.name == $title).description.content) += "\n\nFind out more at " + $url' \
     intermediateCollectionWithLinks.json > tmp.json && cp tmp.json intermediateCollectionWithLinks.json
 
 done

--- a/tools/postman/scripts/transform-for-api.sh
+++ b/tools/postman/scripts/transform-for-api.sh
@@ -51,14 +51,14 @@ jq --arg base_url "$BASE_URL" \
 echo "Adding links to docs"
 cp intermediateCollectionWithBaseURL.json intermediateCollectionWithLinks.json
 
-paths=$(jq 'path(.. | objects | select(has("summary"))) | @sh' ../"$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME") 
+paths=$(jq 'path(.. | objects | select(has("summary"))) | @sh' "$OLDPWD"/"$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME")
 declare -a paths_array="($paths)"
 
 for path in "${paths_array[@]}"; do
   declare -a single_path_array="($path)"
   path_json=$(jq -n '$ARGS.positional' --args "${single_path_array[@]}")
 
-  requestInfo=$(jq --argjson path "$path_json" 'getpath($path)' ../"$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME")
+  requestInfo=$(jq --argjson path "$path_json" 'getpath($path)' "$OLDPWD"/"$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME")
 
   title=$(echo "$requestInfo" | jq -r '.summary')
   operationId=$(echo "$requestInfo" | jq -r '.operationId')

--- a/tools/postman/scripts/transform-for-api.sh
+++ b/tools/postman/scripts/transform-for-api.sh
@@ -51,6 +51,7 @@ jq --arg base_url "$BASE_URL" \
 echo "Adding links to docs"
 cp intermediateCollectionWithBaseURL.json intermediateCollectionWithLinks.json
 
+# Store all paths to requests. The summary field is the same as the title in the collection
 paths=$(jq 'path(.. | objects | select(has("summary"))) | @sh' "$OLDPWD"/"$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME")
 declare -a paths_array="($paths)"
 
@@ -58,6 +59,7 @@ for path in "${paths_array[@]}"; do
   declare -a single_path_array="($path)"
   path_json=$(jq -n '$ARGS.positional' --args "${single_path_array[@]}")
 
+  # Use the path to get all the information about this request without searching
   requestInfo=$(jq --argjson path "$path_json" 'getpath($path)' "$OLDPWD"/"$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME")
 
   title=$(echo "$requestInfo" | jq -r '.summary')
@@ -66,6 +68,7 @@ for path in "${paths_array[@]}"; do
 
   url="https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/${tag}/operation/$operationId"
 
+  # Search the collection for the request with the matching name. Add the link to its description 
   jq --arg title "$title" --arg url "$url" \
     'first(.collection.item.[].item.[].request | objects |  select(.name == $title).description.content) += "\n\nFind out more at " + $url' \
     intermediateCollectionWithLinks.json > tmp.json && cp tmp.json intermediateCollectionWithLinks.json

--- a/tools/postman/scripts/transform-for-api.sh
+++ b/tools/postman/scripts/transform-for-api.sh
@@ -51,18 +51,18 @@ jq --arg base_url "$BASE_URL" \
 echo "Adding links to docs"
 cp intermediateCollectionWithBaseURL.json intermediateCollectionWithLinks.json
 
-paths=$(jq 'path(.. | objects | select(has("summary"))) | @sh' ../$OPENAPI_FOLDER/$OPENAPI_FILE_NAME) 
+paths=$(jq 'path(.. | objects | select(has("summary"))) | @sh' ../"$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME") 
 declare -a paths_array="($paths)"
 
 for path in "${paths_array[@]}"; do
   declare -a single_path_array="($path)"
   path_json=$(jq -n '$ARGS.positional' --args "${single_path_array[@]}")
 
-  requestInfo=$(jq --argjson path "$path_json" 'getpath($path)' ../$OPENAPI_FOLDER/$OPENAPI_FILE_NAME)
+  requestInfo=$(jq --argjson path "$path_json" 'getpath($path)' ../"$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME")
 
-  title=$(echo $requestInfo | jq -r '.summary')
-  operationId=$(echo $requestInfo | jq -r '.operationId')
-  tag=$(echo $requestInfo | jq -r '.tags.[0]' | tr " " "-")
+  title=$(echo "$requestInfo" | jq -r '.summary')
+  operationId=$(echo "$requestInfo" | jq -r '.operationId')
+  tag=$(echo "$requestInfo" | jq -r '.tags.[0]' | tr " " "-")
 
   url="https://mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/${tag}/operation/$operationId"
 

--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-set -o errexit
-set -o nounset
-set -o pipefail
+set -euo pipefail
 
 #########################################################
 # Upload collection to Postman


### PR DESCRIPTION
## Proposed changes

- Iterate through the OpenAPI Spec and save the json paths to each request
- Iterate through each path and get the name, operationId, and tag for each request
- Construct a URL to the docs page
- Search the collection for the matching request and add the link to the description

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-264634

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

Alternative approaches taken. Instead of saving the paths, perform a search in the OpenAPI Spec for a matching summary for each title in the collection. This approach uses an extra search when compared to the proposed solution
