### PR TITLE
CLOUDP-225858: add changelog command skeleton

### DIFF
--- a/tools/cli/internal/cli/changelog/changelog.go
+++ b/tools/cli/internal/cli/changelog/changelog.go
@@ -1,0 +1,33 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Builder() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "changelog",
+		Short: "Manage the API Changelog for the OpenAPI spec.",
+		Annotations: map[string]string{
+			"toc": "true",
+		},
+	}
+
+	cmd.AddCommand(CreateBuilder())
+
+	return cmd
+}

--- a/tools/cli/internal/cli/changelog/changelog_test.go
+++ b/tools/cli/internal/cli/changelog/changelog_test.go
@@ -1,0 +1,30 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/mongodb/openapi/tools/cli/internal/test"
+)
+
+func TestBuilder(t *testing.T) {
+	test.CmdValidator(
+		t,
+		Builder(),
+		1,
+		[]string{},
+	)
+}

--- a/tools/cli/internal/cli/changelog/create.go
+++ b/tools/cli/internal/cli/changelog/create.go
@@ -1,0 +1,65 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
+	"github.com/mongodb/openapi/tools/cli/internal/cli/usage"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+type Opts struct {
+	fs           afero.Fs
+	basePath     string
+	revisionPath string
+}
+
+func (o *Opts) Run() error {
+	return nil
+}
+
+func (o *Opts) PreRunE(_ []string) error {
+	return nil
+}
+
+// Builder builds the merge command with the following signature:
+// changelog create -b path_folder -r path_folder --dry-run
+func CreateBuilder() *cobra.Command {
+	opts := &Opts{
+		fs: afero.NewOsFs(),
+	}
+
+	cmd := &cobra.Command{
+		Use:     "create -b path_folder -r path_folder --dry-run ...",
+		Aliases: []string{"generate"},
+		Short:   "Generate the changelog for the OpenAPI spec.",
+		Args:    cobra.NoArgs,
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			return opts.PreRunE(args)
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.basePath, flag.Base, flag.BaseShort, "", usage.BaseFolder)
+	cmd.Flags().StringVarP(&opts.revisionPath, flag.Revision, flag.RevisionShort, "", usage.RevisionFolder)
+
+	_ = cmd.MarkFlagRequired(flag.Base)
+	_ = cmd.MarkFlagRequired(flag.Revision)
+
+	return cmd
+}

--- a/tools/cli/internal/cli/changelog/create.go
+++ b/tools/cli/internal/cli/changelog/create.go
@@ -25,6 +25,7 @@ type Opts struct {
 	fs           afero.Fs
 	basePath     string
 	revisionPath string
+	dryRun       bool
 }
 
 func (o *Opts) Run() error {
@@ -57,6 +58,7 @@ func CreateBuilder() *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.basePath, flag.Base, flag.BaseShort, "", usage.BaseFolder)
 	cmd.Flags().StringVarP(&opts.revisionPath, flag.Revision, flag.RevisionShort, "", usage.RevisionFolder)
+	cmd.Flags().BoolVarP(&opts.dryRun, flag.DryRun, flag.DryRunShort, false, usage.DryRun)
 
 	_ = cmd.MarkFlagRequired(flag.Base)
 	_ = cmd.MarkFlagRequired(flag.Revision)

--- a/tools/cli/internal/cli/flag/flag.go
+++ b/tools/cli/internal/cli/flag/flag.go
@@ -31,4 +31,6 @@ const (
 	GitSha                   = "sha"
 	ExcludePrivatePaths      = "exclude-private-paths"
 	ExcludePrivatePathsShort = "x"
+	DryRun                   = "dry-run"
+	DryRunShort              = "d"
 )

--- a/tools/cli/internal/cli/flag/flag.go
+++ b/tools/cli/internal/cli/flag/flag.go
@@ -17,6 +17,8 @@ package flag
 const (
 	Base                     = "base"
 	BaseShort                = "b"
+	Revision                 = "revision"
+	RevisionShort            = "r"
 	External                 = "external"
 	ExternalShort            = "e"
 	Output                   = "output"

--- a/tools/cli/internal/cli/root/openapi/builder.go
+++ b/tools/cli/internal/cli/root/openapi/builder.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/mongodb/openapi/tools/cli/internal/cli/changelog"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/merge"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/split"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/versions"
@@ -55,6 +56,7 @@ func Builder() *cobra.Command {
 		merge.Builder(),
 		split.Builder(),
 		versions.Builder(),
+		changelog.Builder(),
 	)
 	return rootCmd
 }

--- a/tools/cli/internal/cli/usage/usage.go
+++ b/tools/cli/internal/cli/usage/usage.go
@@ -26,4 +26,5 @@ const (
 	ExcludePrivatePaths = "Exclude private paths from the generated specification."
 	BaseFolder          = "Base folder where the command will store the output."
 	RevisionFolder      = "Folder where the command will store the output."
+	DryRun              = "Dry run mode. The command will not write any files."
 )

--- a/tools/cli/internal/cli/usage/usage.go
+++ b/tools/cli/internal/cli/usage/usage.go
@@ -24,4 +24,6 @@ const (
 	Environment         = "Environment to consider when generating the versioned OAS."
 	GitSha              = "GitSHA to use as identifier (x-xgen-sha) of the generated specification."
 	ExcludePrivatePaths = "Exclude private paths from the generated specification."
+	BaseFolder          = "Base folder where the command will store the output."
+	RevisionFolder      = "Folder where the command will store the output."
 )

--- a/tools/cli/internal/test/test.go
+++ b/tools/cli/internal/test/test.go
@@ -1,0 +1,40 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+// CmdValidator helps validate a cobra.Command, verifying the number of sub commands
+// and the flags that are being defined for it.
+func CmdValidator(t *testing.T, subject *cobra.Command, nSubCommands int, flags []string) {
+	t.Helper()
+	a := assert.New(t)
+	if len(subject.Commands()) != nSubCommands {
+		t.Errorf("Sub command count mismatch. Expected %d, got %d. Check the CmdValidator for your command.\n", nSubCommands, len(subject.Commands()))
+	}
+	if len(flags) == 0 {
+		a.False(subject.HasAvailableFlags(), "expected command to not have flags but it does")
+		return
+	}
+	a.True(subject.HasAvailableFlags(), "expected command to have flag but has none")
+	for _, f := range flags {
+		a.NotNilf(subject.Flags().Lookup(f), "command has no flag: %s", f)
+	}
+}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-225858

This PR creates the skeleton of the changelog command

```bash
 ./bin/foascli changelog create --help                                     
Generate the changelog for the OpenAPI spec.

Usage:
  foascli changelog create -b path_folder -r path_folder --dry-run ... [flags]

Aliases:
  create, generate

Flags:
  -b, --base string       Base folder where the command will store the output.
  -d, --dry-run           Dry run mode. The command will not write any files.
  -h, --help              help for create
  -r, --revision string   Folder where the command will store the output.
```