### PR TITLE
CLOUDP-266130: Add changelog core logic

### DIFF
--- a/tools/cli/internal/cli/changelog/create.go
+++ b/tools/cli/internal/cli/changelog/create.go
@@ -44,6 +44,10 @@ func (o *Opts) Run() error {
 	}
 
 	checks, err := changelog.Check()
+	if err != nil {
+		return err
+	}
+
 	fmt.Print("Printing the checks\n")
 	base, err := json.MarshalIndent(*checks, "", "  ")
 	if err != nil {

--- a/tools/cli/internal/cli/changelog/create.go
+++ b/tools/cli/internal/cli/changelog/create.go
@@ -43,8 +43,9 @@ func (o *Opts) Run() error {
 		return err
 	}
 
-	fmt.Print("Printing the basr v2.json spec normalized...\n")
-	base, err := json.MarshalIndent(*changelog.Base, "", "  ")
+	checks, err := changelog.Check()
+	fmt.Print("Printing the checks\n")
+	base, err := json.MarshalIndent(*checks, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/tools/cli/internal/openapi/changelog.go
+++ b/tools/cli/internal/openapi/changelog.go
@@ -48,27 +48,12 @@ func (c *Changelog) Check() (*checker.Changes, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	changes := checker.CheckBackwardCompatibilityUntilLevel(
 		c.Config,
 		diffResult.Report,
 		diffResult.SourceMap,
 		checker.INFO)
 
-	return filterOutExceptions(&changes, c.ExceptionFilePath)
-}
-
-func filterOutExceptions(changes *checker.Changes, exceptionsPath string) (*checker.Changes, error) {
-	localizer := checker.NewLocalizer(lan)
-	changesWithoutExceptionsWarnings, err := checker.ProcessIgnoredBackwardCompatibilityErrors(checker.WARN, *changes, exceptionsPath, localizer)
-	if err != nil {
-		return nil, err
-	}
-
-	changesWithoutExceptions, err := checker.ProcessIgnoredBackwardCompatibilityErrors(checker.ERR, changesWithoutExceptionsWarnings, exceptionsPath, localizer)
-	if err != nil {
-		return nil, err
-	}
-
-	return &changesWithoutExceptions, nil
+	return &changes, nil
 }

--- a/tools/cli/internal/openapi/changelog.go
+++ b/tools/cli/internal/openapi/changelog.go
@@ -43,14 +43,14 @@ type Changelog struct {
 	ExceptionFilePath string
 }
 
-func (c *Changelog) Check() (*checker.Changes, error) {
-	diffResult, err := c.OasDiff.newDiffResult()
+func (s *Changelog) Check() (*checker.Changes, error) {
+	diffResult, err := s.OasDiff.newDiffResult()
 	if err != nil {
 		return nil, err
 	}
 
 	changes := checker.CheckBackwardCompatibilityUntilLevel(
-		c.Config,
+		s.Config,
 		diffResult.Report,
 		diffResult.SourceMap,
 		checker.INFO)

--- a/tools/cli/internal/openapi/oasdiff.go
+++ b/tools/cli/internal/openapi/oasdiff.go
@@ -33,6 +33,23 @@ type OasDiff struct {
 	parser   Parser
 }
 
+type OasDiffResult struct {
+	Report    *diff.Diff
+	SourceMap *diff.OperationsSourcesMap
+}
+
+func (o OasDiff) newDiffResult() (*OasDiffResult, error) {
+	diffReport, operationsSources, err := diff.GetWithOperationsSourcesMap(o.config, o.base, o.external)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OasDiffResult{
+		Report:    diffReport,
+		SourceMap: operationsSources,
+	}, nil
+}
+
 func (o OasDiff) mergeSpecIntoBase() (*load.SpecInfo, error) {
 	if o.external == nil || o.external.Spec == nil {
 		return o.base, nil

--- a/tools/cli/internal/openapi/openapi.go
+++ b/tools/cli/internal/openapi/openapi.go
@@ -97,14 +97,14 @@ func NewChangelog(base, revision, exceptionFilePath string) (*Changelog, error) 
 
 	changelogConfig := checker.NewConfig(
 		checker.GetAllChecks()).WithOptionalChecks(breakingChangesAdditionalCheckers).WithDeprecation(deprecationDaysBeta, deprecationDaysStable)
-	
-		return &Changelog{
+
+	return &Changelog{
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExceptionFilePath: exceptionFilePath,
 		Config:            changelogConfig,
 		OasDiff: &OasDiff{
-			base:   baseSpec,
+			base:     baseSpec,
 			external: revisionSpec,
 			config: &diff.Config{
 				IncludePathParams: true,

--- a/tools/cli/internal/openapi/openapi.go
+++ b/tools/cli/internal/openapi/openapi.go
@@ -97,11 +97,19 @@ func NewChangelog(base, revision, exceptionFilePath string) (*Changelog, error) 
 
 	changelogConfig := checker.NewConfig(
 		checker.GetAllChecks()).WithOptionalChecks(breakingChangesAdditionalCheckers).WithDeprecation(deprecationDaysBeta, deprecationDaysStable)
-	return &Changelog{
+	
+		return &Changelog{
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExceptionFilePath: exceptionFilePath,
 		Config:            changelogConfig,
+		OasDiff: &OasDiff{
+			base:   baseSpec,
+			external: revisionSpec,
+			config: &diff.Config{
+				IncludePathParams: true,
+			},
+		},
 	}, nil
 }
 

--- a/tools/cli/internal/openapi/openapi3.go
+++ b/tools/cli/internal/openapi/openapi3.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/tufin/oasdiff/flatten/allof"
 	"github.com/tufin/oasdiff/load"
 )
 
@@ -73,8 +74,14 @@ func CreateNormalizedOpenAPISpecFromPath(path string) (*load.SpecInfo, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	flattenAllOfSpec, err := allof.MergeSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+
 	return &load.SpecInfo{
-		Spec: spec,
+		Spec: flattenAllOfSpec,
 	}, nil
 }
 


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-266130

This PR adds changelog core logic to FOAS CLI

```bash
./bin/foascli changelog create -b ~/Downloads/test/base -r ~/Downloads/test/revision -e ~/Downloads/test/exceptions.yaml                         
Printing the checks
[
  {
    "Attributes": null,
    "Id": "api-schema-removed",
    "Args": [
      "AzureHardwareSpec20250101"
    ],
    "Comment": "",
    "Level": 3,
    "Component": "schemas",
    "SourceFile": "",
    "SourceLine": 0,
    "SourceLineEnd": 0,
    "SourceColumn": 0,
    "SourceColumnEnd": 0
  },
.....
]
```