### PR TITLE
CLOUDP-266446: this PR adds the sunset and manual entry logic to foascli changelog

### DIFF
--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -48,6 +48,7 @@ type Metadata struct {
 	OasDiff           *openapi.OasDiff
 	BaseChangelog     []*Entry //  the base changelog entries
 	RunDate           string
+	PreviousRunDate   string
 	ExemptionFilePath string
 }
 
@@ -81,7 +82,8 @@ type Change struct {
 	HideFromChangelog  bool   `json:"hideFromChangelog,omitempty"`
 }
 
-func NewMetadata(base, revision, exemptionFilePath string, baseChangelog []*Entry) (*Metadata, error) {
+func NewMetadata(base, revision, exemptionFilePath, previourRunDate string, 
+	baseChangelog []*Entry) (*Metadata, error) {
 	loader := openapi.NewOpenAPI3().WithExcludedPrivatePaths()
 	baseSpec, err := loader.CreateOpenAPISpecFromPath(base)
 	if err != nil {
@@ -98,6 +100,7 @@ func NewMetadata(base, revision, exemptionFilePath string, baseChangelog []*Entr
 
 	return &Metadata{
 		RunDate:           time.Now().Format("2006-01-02"),
+		PreviousRunDate:  previourRunDate,
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExemptionFilePath: exemptionFilePath,
@@ -123,7 +126,8 @@ func NewChangelogEntries(path string) ([]*Entry, error) {
 	return entries, nil
 }
 
-func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath string, baseChangelog []*Entry) (*Metadata, error) {
+func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourRunDate string, 
+	baseChangelog []*Entry) (*Metadata, error) {
 	baseSpec, err := openapi.CreateNormalizedOpenAPISpecFromPath(base)
 	if err != nil {
 		return nil, err
@@ -139,6 +143,7 @@ func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath string, ba
 
 	return &Metadata{
 		RunDate:           time.Now().Format("2006-01-02"),
+		PreviousRunDate: previourRunDate,
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExemptionFilePath: exemptionFilePath,
@@ -148,4 +153,32 @@ func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath string, ba
 			IncludePathParams: true,
 		}),
 	}, nil
+}
+
+
+// findChangelogEntry finds the changelog entries for the given date and operationID, versions and changeCode.
+func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCode string) *Change {
+	for _, entry := range changelog {
+		if entry.Date == date {
+			for _, path := range entry.Paths {
+				if path.OperationID != operationID {
+					continue
+				}
+
+				for _, v := range path.Versions {
+					if v.Version != version {
+						continue
+					}
+
+					for _, change := range v.Changes {
+						if change.Code == changeCode {
+							return change
+						}
+					}	
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -82,7 +82,7 @@ type Change struct {
 	HideFromChangelog  bool   `json:"hideFromChangelog,omitempty"`
 }
 
-func NewMetadata(base, revision, exemptionFilePath, previourRunDate string, 
+func NewMetadata(base, revision, exemptionFilePath, previourRunDate string,
 	baseChangelog []*Entry) (*Metadata, error) {
 	loader := openapi.NewOpenAPI3().WithExcludedPrivatePaths()
 	baseSpec, err := loader.CreateOpenAPISpecFromPath(base)
@@ -100,7 +100,7 @@ func NewMetadata(base, revision, exemptionFilePath, previourRunDate string,
 
 	return &Metadata{
 		RunDate:           time.Now().Format("2006-01-02"),
-		PreviousRunDate:  previourRunDate,
+		PreviousRunDate:   previourRunDate,
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExemptionFilePath: exemptionFilePath,
@@ -126,7 +126,7 @@ func NewChangelogEntries(path string) ([]*Entry, error) {
 	return entries, nil
 }
 
-func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourRunDate string, 
+func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourRunDate string,
 	baseChangelog []*Entry) (*Metadata, error) {
 	baseSpec, err := openapi.CreateNormalizedOpenAPISpecFromPath(base)
 	if err != nil {
@@ -143,7 +143,7 @@ func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourR
 
 	return &Metadata{
 		RunDate:           time.Now().Format("2006-01-02"),
-		PreviousRunDate: previourRunDate,
+		PreviousRunDate:   previourRunDate,
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExemptionFilePath: exemptionFilePath,
@@ -154,7 +154,6 @@ func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourR
 		}),
 	}, nil
 }
-
 
 // findChangelogEntry finds the changelog entries for the given date and operationID, versions and changeCode.
 func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCode string) *Change {
@@ -174,7 +173,7 @@ func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCo
 						if change.Code == changeCode {
 							return change
 						}
-					}	
+					}
 				}
 			}
 		}

--- a/tools/cli/internal/changelog/changelog_test.go
+++ b/tools/cli/internal/changelog/changelog_test.go
@@ -1,0 +1,220 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindChangelogEntry(t *testing.T) {
+	tests := []struct {
+		name            string
+		entries         []*Entry
+		operationID     string
+		date            string
+		version         string
+		changeCode      string
+		expectedEntries *Change
+	}{
+
+		{
+			name: "find changelog entry",
+			entries: []*Entry{
+				{
+					Date: "2023-07-10",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Date: "2023-07-11",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+			},
+			operationID: "createCluster",
+			date:        "2023-07-10",
+			version:     "2023-02-01",
+			changeCode:  "endpoint-removed",
+			expectedEntries: &Change{
+				Description:        "endpoint removed",
+				Code:               "endpoint-removed",
+				BackwardCompatible: true,
+			},
+		},
+		{
+			name: "Not find changelog entry for different date",
+			entries: []*Entry{
+				{
+					Date: "2023-07-10",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Date: "2023-07-11",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+			},
+			operationID:     "createCluster",
+			date:            "2023-07-21",
+			version:         "2023-02-01",
+			changeCode:      "endpoint-removed",
+			expectedEntries: nil,
+		},
+		{
+			name: "Not find changelog entry for different version",
+			entries: []*Entry{
+				{
+					Date: "2023-07-10",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Date: "2023-07-11",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+			},
+			operationID:     "createCluster",
+			date:            "2023-07-11",
+			version:         "2023-02-02",
+			changeCode:      "endpoint-removed",
+			expectedEntries: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := findChangelogEntry(test.entries, test.date, test.operationID, test.version, test.changeCode)
+			assert.Equal(t, test.expectedEntries, result)
+		})
+	}
+}

--- a/tools/cli/internal/changelog/manual_entry.go
+++ b/tools/cli/internal/changelog/manual_entry.go
@@ -1,0 +1,108 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tufin/oasdiff/load"
+)
+
+func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
+	previousRunDate := "2023-07-10"
+	runDate := "2023-07-12"
+	version := "2023-02-01"
+	theDayAfterRunDate := "2023-07-13"
+
+	changelog := []*Entry{
+		{
+			Date: previousRunDate,
+			Paths: []*Path{
+				{
+					URI:         "/api/atlas/v2/groups/{groupId}/clusters",
+					HTTPMethod:  "POST",
+					OperationID: "createCluster",
+					Tag:         "Multi-Cloud Clusters",
+					Versions: []*Version{
+						{
+							Version:        version,
+							StabilityLevel: "stable",
+							ChangeType:     "update",
+							Changes: []*Change{
+								{
+									Description:        "change info 1",
+									Code:               "manual-changelog-entry",
+									BackwardCompatible: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	endpointsConfig := map[string]*outputfilter.OperationConfigs{
+		"createCluster": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:       "/api/atlas/v2/groups/{groupId}/clusters",
+				HTTPMethod: "POST",
+				Tag:        "Multi-Cloud Clusters",
+				Sunset:     "",
+				ManualChangelogEntries: map[string]interface{}{
+					previousRunDate: "change info 1",      // Already in the changelog
+					runDate:         "change info 2",      // Should be added to the changelog
+					theDayAfterRunDate: "change info 3",   // Should not be added to the changelog
+				},
+			},
+		},
+	}
+
+	expectedChanges := []*outputfilter.OasDiffEntry{
+		{
+			Date:        runDate,
+			ID:          "manual-changelog-entry",
+			Level:       1,
+			Operation:   "POST",
+			OperationID: "createCluster",
+			Path:        "/api/atlas/v2/groups/{groupId}/clusters",
+			Text:        "change info 2",
+		},
+	}
+
+	changelogMetadata := &Metadata{
+		Base: &load.SpecInfo{
+			Version: version,
+		},
+		Revision: &load.SpecInfo{
+			Version: version,
+		},
+		BaseChangelog:   changelog,
+		RunDate:         runDate,
+		PreviousRunDate: previousRunDate,
+	}
+
+	// Act
+	changes, err := changelogMetadata.detectManualEntriesAndMergeChangelog(endpointsConfig, version)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, changes)
+	assert.Equal(t, expectedChanges, changes)
+}

--- a/tools/cli/internal/changelog/manual_entry.go
+++ b/tools/cli/internal/changelog/manual_entry.go
@@ -52,7 +52,6 @@ func (m *Metadata) newOasDiffEntriesWithManualEntries(confs map[string]*outputfi
 				OperationID: operationID,
 				Path:        config.Revision.Path,
 			})
-
 		}
 	}
 

--- a/tools/cli/internal/changelog/manual_entry_test.go
+++ b/tools/cli/internal/changelog/manual_entry_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tufin/oasdiff/load"
+)
+
+func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
+	previousRunDate := "2023-07-10"
+	runDate := "2023-07-12"
+	version := "2023-02-01"
+	theDayAfterRunDate := "2023-07-13"
+
+	changelog := []*Entry{
+		{
+			Date: previousRunDate,
+			Paths: []*Path{
+				{
+					URI:         "/api/atlas/v2/groups/{groupId}/clusters",
+					HTTPMethod:  "POST",
+					OperationID: "createCluster",
+					Tag:         "Multi-Cloud Clusters",
+					Versions: []*Version{
+						{
+							Version:        version,
+							StabilityLevel: "stable",
+							ChangeType:     "update",
+							Changes: []*Change{
+								{
+									Description:        "change info 1",
+									Code:               "manual-changelog-entry",
+									BackwardCompatible: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	endpointsConfig := map[string]*outputfilter.OperationConfigs{
+		"createCluster": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:       "/api/atlas/v2/groups/{groupId}/clusters",
+				HTTPMethod: "POST",
+				Tag:        "Multi-Cloud Clusters",
+				Sunset:     "",
+				ManualChangelogEntries: map[string]interface{}{
+					previousRunDate: "change info 1",      // Already in the changelog
+					runDate:         "change info 2",      // Should be added to the changelog
+					theDayAfterRunDate: "change info 3",   // Should not be added to the changelog
+				},
+			},
+		},
+	}
+
+	expectedChanges := []*outputfilter.OasDiffEntry{
+		{
+			Date:        runDate,
+			ID:          "manual-changelog-entry",
+			Level:       1,
+			Operation:   "POST",
+			OperationID: "createCluster",
+			Path:        "/api/atlas/v2/groups/{groupId}/clusters",
+			Text:        "change info 2",
+		},
+	}
+
+	changelogMetadata := &Metadata{
+		Base: &load.SpecInfo{
+			Version: version,
+		},
+		Revision: &load.SpecInfo{
+			Version: version,
+		},
+		BaseChangelog:   changelog,
+		RunDate:         runDate,
+		PreviousRunDate: previousRunDate,
+	}
+
+	// Act
+	changes, err := changelogMetadata.detectManualEntriesAndMergeChangelog(endpointsConfig, version)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, changes)
+	assert.Equal(t, expectedChanges, changes)
+}

--- a/tools/cli/internal/changelog/manual_entry_test.go
+++ b/tools/cli/internal/changelog/manual_entry_test.go
@@ -66,9 +66,9 @@ func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
 				Tag:        "Multi-Cloud Clusters",
 				Sunset:     "",
 				ManualChangelogEntries: map[string]interface{}{
-					previousRunDate: "change info 1",      // Already in the changelog
-					runDate:         "change info 2",      // Should be added to the changelog
-					theDayAfterRunDate: "change info 3",   // Should not be added to the changelog
+					previousRunDate:    "change info 1", // Already in the changelog
+					runDate:            "change info 2", // Should be added to the changelog
+					theDayAfterRunDate: "change info 3", // Should not be added to the changelog
 				},
 			},
 		},
@@ -99,7 +99,7 @@ func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
 	}
 
 	// Act
-	changes, err := changelogMetadata.detectManualEntriesAndMergeChangelog(endpointsConfig, version)
+	changes, err := changelogMetadata.newOasDiffEntriesWithManualEntries(endpointsConfig, version)
 
 	// Assert
 	require.NoError(t, err)

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -55,7 +55,7 @@ func (m *Metadata) NewChangelogFromDataEntries() ([]*Entry, error) {
 	if err := m.newChangelogFromSunsetEndpoints(conf); err != nil {
 		return nil, err
 	}
-	
+
 	if err := m.newChangelogFromManualEntries(conf); err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (m *Metadata) NewChangelogFromDataEntries() ([]*Entry, error) {
 func (m *Metadata) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter.OperationConfigs) error {
 	sunsetChanges, err := m.newOasDiffEntriesFromSunsetEndpoints(conf, m.Revision.Version)
 	if err != nil {
-		return  err
+		return err
 	}
 
 	runDate := m.RunDate
@@ -80,7 +80,7 @@ func (m *Metadata) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter
 
 		changelog, err := m.mergeChangelog(changeTypeRemove, []*outputfilter.OasDiffEntry{change}, conf)
 		if err != nil {
-			return  err
+			return err
 		}
 
 		m.BaseChangelog = changelog
@@ -92,7 +92,7 @@ func (m *Metadata) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter
 func (m *Metadata) newChangelogFromManualEntries(conf map[string]*outputfilter.OperationConfigs) error {
 	manualChanges, err := m.newOasDiffEntriesWithManualEntries(conf, m.Revision.Version)
 	if err != nil {
-		return  err
+		return err
 	}
 
 	runDate := m.RunDate
@@ -112,9 +112,8 @@ func (m *Metadata) newChangelogFromManualEntries(conf map[string]*outputfilter.O
 		m.BaseChangelog = changelog
 	}
 
-	return  nil
+	return nil
 }
-
 
 // NewChangelogFromOasDiff merges the base changelog with the new changes from a Base and Revision OpenAPI specs
 func (m *Metadata) NewChangelogFromOasDiff() ([]*Entry, error) {

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -1,3 +1,17 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package changelog
 
 import (
@@ -35,8 +49,75 @@ func newChangeTypeOverrides() map[string]string {
 	}
 }
 
-// MergeChangelog merges the base changelog with the new changes from a Base and Revision OpenAPI specs
-func (m *Metadata) MergeChangelog() ([]*Entry, error) {
+// NewChangelogFromDataEntries merges the base changelog with the new changes from manual entries and sunset endpoints
+func (m *Metadata) NewChangelogFromDataEntries() ([]*Entry, error) {
+	conf := outputfilter.NewOperationConfigs(nil, m.Revision)
+	if err := m.newChangelogFromSunsetEndpoints(conf); err != nil {
+		return nil, err
+	}
+	
+	if err := m.newChangelogFromManualEntries(conf); err != nil {
+		return nil, err
+	}
+
+	return m.BaseChangelog, nil
+}
+
+func (m *Metadata) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter.OperationConfigs) error {
+	sunsetChanges, err := m.newOasDiffEntriesFromSunsetEndpoints(conf, m.Revision.Version)
+	if err != nil {
+		return  err
+	}
+
+	runDate := m.RunDate
+	for _, change := range sunsetChanges {
+		m.RunDate = func() string {
+			if change.Date == "" {
+				return runDate
+			}
+			return change.Date
+		}()
+
+		changelog, err := m.mergeChangelog(changeTypeRemove, []*outputfilter.OasDiffEntry{change}, conf)
+		if err != nil {
+			return  err
+		}
+
+		m.BaseChangelog = changelog
+	}
+
+	return nil
+}
+
+func (m *Metadata) newChangelogFromManualEntries(conf map[string]*outputfilter.OperationConfigs) error {
+	manualChanges, err := m.newOasDiffEntriesWithManualEntries(conf, m.Revision.Version)
+	if err != nil {
+		return  err
+	}
+
+	runDate := m.RunDate
+	for _, change := range manualChanges {
+		m.RunDate = func() string {
+			if change.Date == "" {
+				return runDate
+			}
+			return change.Date
+		}()
+
+		changelog, err := m.mergeChangelog(changeTypeUpdate, []*outputfilter.OasDiffEntry{change}, conf)
+		if err != nil {
+			return err
+		}
+
+		m.BaseChangelog = changelog
+	}
+
+	return  nil
+}
+
+
+// NewChangelogFromOasDiff merges the base changelog with the new changes from a Base and Revision OpenAPI specs
+func (m *Metadata) NewChangelogFromOasDiff() ([]*Entry, error) {
 	changes, err := m.newOasDiffEntries()
 	if err != nil {
 		return nil, err

--- a/tools/cli/internal/changelog/merge_test.go
+++ b/tools/cli/internal/changelog/merge_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package changelog
 
 import (

--- a/tools/cli/internal/changelog/outputfilter/outputfilter.go
+++ b/tools/cli/internal/changelog/outputfilter/outputfilter.go
@@ -26,6 +26,7 @@ const lan = "en" // language for localized output
 
 type OasDiffEntry struct {
 	ID                string `json:"id"`
+	Date              string `json:"date"`
 	Text              string `json:"text"`
 	Level             int    `json:"level"`
 	Operation         string `json:"operation,omitempty"`

--- a/tools/cli/internal/changelog/sunset.go
+++ b/tools/cli/internal/changelog/sunset.go
@@ -1,0 +1,118 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
+	"github.com/tufin/oasdiff/checker"
+)
+
+const endpointRemovedCode = "endpoint-removed"
+
+// newOasDiffEntriesFromSunsetEndpoints searches for resource versions marked for removal between
+// previous changelog run date and current date (inclusive), and that not already included in the changelog.
+// Returns a list of sunset endpoints with the same format as oasdiff results.
+func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
+	confs map[string]*outputfilter.OperationConfigs, 
+	version string) ([]*outputfilter.OasDiffEntry, error) {
+	changes := make([]*outputfilter.OasDiffEntry, 0)
+	for operationID, config := range confs {
+		markedForRemoval, err := isResourceVersionMarkedForRemoval(config, m.PreviousRunDate, m.RunDate)
+		if err != nil {
+			return nil, err
+		}
+
+		if  ! markedForRemoval{
+			continue
+		}
+
+		// Avoid adding duplicates in the changelog
+		if findChangelogEntry(m.BaseChangelog, config.Revision.Sunset, operationID, version, endpointRemovedCode) == nil {
+			changes = append(changes, &outputfilter.OasDiffEntry{
+				Date:        config.Revision.Sunset,
+				ID:          endpointRemovedCode,
+				Text:        "endpoint removed",
+				Level:       int(checker.ERR),
+				Operation:   config.Revision.HTTPMethod,
+				OperationID: operationID,
+				Path:        config.Revision.Path,
+			})
+		}
+	}
+
+	printSunsetLogChanges(changes, version, m.PreviousRunDate, m.RunDate)
+	return changes, nil
+}
+
+
+
+// isResourceVersionMarkedForRemoval checks if a resource sunset is marked for removal between previousRunDate and runDate.
+func isResourceVersionMarkedForRemoval(config *outputfilter.OperationConfigs, previousRunDate, runDate string) (bool, error) {
+	if config == nil || config.Revision == nil {
+		return false, nil
+	}
+
+	if config.Revision == nil || config.Revision.Sunset == "" {
+		return false, nil
+	}
+
+	return isEntryDateBetween(config.Revision.Sunset, previousRunDate, runDate)
+}
+
+func isEntryDateBetween(entryDateString, startDateString, endDateString string) (bool, error) {
+	startDate, err := newDateFromString(startDateString)
+    if err != nil {
+        return false, err
+    }
+	endDate, err := newDateFromString(endDateString)
+	if err != nil {
+		return false, err
+	}
+
+	entryDate, err := newDateFromString(entryDateString)
+	if err != nil {
+		return false, err
+	}
+
+	return  (entryDate.After(startDate) || entryDate.Equal(startDate)) && 
+	(entryDate.Before(endDate)|| entryDate.Equal(endDate)), nil
+}
+
+
+func newDateFromString(dateString string) (time.Time, error) {
+	return time.Parse("2006-01-02", dateString)
+}
+
+func printSunsetLogChanges(changes []*outputfilter.OasDiffEntry, version, previousRunDate, runDate string) {
+	if len(changes) == 0 {
+		log.Printf("No endpoints marked for removal between [%s, %s]\n", previousRunDate, runDate)
+		return
+	}
+
+	log.Printf("Detected %d v%s endpoints marked for removal between [%s, %s]\n  - %s",
+		len(changes), version, previousRunDate, runDate,
+		strings.Join(func() []string {
+			var result []string
+			for _, c := range changes {
+				result = append(result, fmt.Sprintf("%s %s %s", c.OperationID, c.Operation, c.Path))
+			}
+			return result
+		}(), "\n  - "))
+}

--- a/tools/cli/internal/changelog/sunset.go
+++ b/tools/cli/internal/changelog/sunset.go
@@ -30,7 +30,7 @@ const endpointRemovedCode = "endpoint-removed"
 // previous changelog run date and current date (inclusive), and that not already included in the changelog.
 // Returns a list of sunset endpoints with the same format as oasdiff results.
 func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
-	confs map[string]*outputfilter.OperationConfigs, 
+	confs map[string]*outputfilter.OperationConfigs,
 	version string) ([]*outputfilter.OasDiffEntry, error) {
 	changes := make([]*outputfilter.OasDiffEntry, 0)
 	for operationID, config := range confs {
@@ -39,7 +39,7 @@ func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
 			return nil, err
 		}
 
-		if  ! markedForRemoval{
+		if !markedForRemoval {
 			continue
 		}
 
@@ -61,8 +61,6 @@ func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
 	return changes, nil
 }
 
-
-
 // isResourceVersionMarkedForRemoval checks if a resource sunset is marked for removal between previousRunDate and runDate.
 func isResourceVersionMarkedForRemoval(config *outputfilter.OperationConfigs, previousRunDate, runDate string) (bool, error) {
 	if config == nil || config.Revision == nil {
@@ -78,9 +76,9 @@ func isResourceVersionMarkedForRemoval(config *outputfilter.OperationConfigs, pr
 
 func isEntryDateBetween(entryDateString, startDateString, endDateString string) (bool, error) {
 	startDate, err := newDateFromString(startDateString)
-    if err != nil {
-        return false, err
-    }
+	if err != nil {
+		return false, err
+	}
 	endDate, err := newDateFromString(endDateString)
 	if err != nil {
 		return false, err
@@ -91,10 +89,9 @@ func isEntryDateBetween(entryDateString, startDateString, endDateString string) 
 		return false, err
 	}
 
-	return  (entryDate.After(startDate) || entryDate.Equal(startDate)) && 
-	(entryDate.Before(endDate)|| entryDate.Equal(endDate)), nil
+	return (entryDate.After(startDate) || entryDate.Equal(startDate)) &&
+		(entryDate.Before(endDate) || entryDate.Equal(endDate)), nil
 }
-
 
 func newDateFromString(dateString string) (time.Time, error) {
 	return time.Parse("2006-01-02", dateString)

--- a/tools/cli/internal/changelog/sunset_test.go
+++ b/tools/cli/internal/changelog/sunset_test.go
@@ -121,13 +121,13 @@ func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
 
 	expectedChanges := []*outputfilter.OasDiffEntry{
 		{
-			Date: 	  runDate,
-			ID: 		"endpoint-removed",
-			Level: 		3,
-			Operation:  "GET",
+			Date:        runDate,
+			ID:          "endpoint-removed",
+			Level:       3,
+			Operation:   "GET",
 			OperationID: "listStreamInstances",
-			Path: 	  "/api/atlas/v2/groups/{id}/streams",
-			Text: 	  "endpoint removed",
+			Path:        "/api/atlas/v2/groups/{id}/streams",
+			Text:        "endpoint removed",
 		},
 	}
 

--- a/tools/cli/internal/changelog/sunset_test.go
+++ b/tools/cli/internal/changelog/sunset_test.go
@@ -1,0 +1,151 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tufin/oasdiff/load"
+)
+
+func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
+	previousRunDate := "2023-07-10"
+	runDate := "2023-07-12"
+	previousVersion := "2023-01-01"
+	version := "2023-02-01"
+	changelog := []*Entry{
+		{
+			Date: previousRunDate,
+			Paths: []*Path{
+				{
+					URI:         "/api/atlas/v2/groups/{id}/clusters",
+					HTTPMethod:  "POST",
+					OperationID: "createCluster",
+					Tag:         "Multi-Cloud Clusters",
+					Versions: []*Version{
+						{
+							Version:        version,
+							StabilityLevel: "stable",
+							ChangeType:     "remove",
+							Changes: []*Change{
+								{
+									Description:        "endpoint removed",
+									Code:               "endpoint-removed",
+									BackwardCompatible: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					URI:         "/api/atlas/v2/groups/{id}/streams",
+					HTTPMethod:  "GET",
+					OperationID: "listStreamInstances",
+					Tag:         "Streams",
+					Versions: []*Version{
+						{
+							Version:        previousVersion,
+							StabilityLevel: "stable",
+							ChangeType:     "remove",
+							Changes: []*Change{
+								{
+									Description:        "endpoint removed",
+									Code:               "endpoint-removed",
+									BackwardCompatible: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	endpointsConfig := map[string]*outputfilter.OperationConfigs{
+		"createCluster": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:                   "/api/atlas/v2/groups/{id}/clusters",
+				HTTPMethod:             "POST",
+				Tag:                    "Multi-Cloud Clusters",
+				Sunset:                 previousRunDate,
+				ManualChangelogEntries: map[string]interface{}{},
+			},
+		},
+		"getCluster": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:                   "/api/atlas/v2/groups/{id}/clusters",
+				HTTPMethod:             "GET",
+				Tag:                    "Multi-Cloud Clusters",
+				Sunset:                 "",
+				ManualChangelogEntries: map[string]interface{}{},
+			},
+		},
+		"listStreamInstances": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:                   "/api/atlas/v2/groups/{id}/streams",
+				HTTPMethod:             "GET",
+				Tag:                    "Streams",
+				Sunset:                 runDate,
+				ManualChangelogEntries: map[string]interface{}{},
+			},
+		},
+		"getStreamInstance": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:                   "/api/atlas/v2/groups/{id}/streams/{tenantName}",
+				HTTPMethod:             "GET",
+				Tag:                    "Streams",
+				Sunset:                 "2023-07-13",
+				ManualChangelogEntries: map[string]interface{}{},
+			},
+		},
+	}
+
+	expectedChanges := []*outputfilter.OasDiffEntry{
+		{
+			Date: 	  runDate,
+			ID: 		"endpoint-removed",
+			Level: 		3,
+			Operation:  "GET",
+			OperationID: "listStreamInstances",
+			Path: 	  "/api/atlas/v2/groups/{id}/streams",
+			Text: 	  "endpoint removed",
+		},
+	}
+
+	changelogMetadata := &Metadata{
+		Base: &load.SpecInfo{
+			Version: version,
+		},
+		Revision: &load.SpecInfo{
+			Version: version,
+		},
+		BaseChangelog:   changelog,
+		RunDate:         runDate,
+		PreviousRunDate: previousRunDate,
+	}
+
+	changes, err := changelogMetadata.newOasDiffEntriesFromSunsetEndpoints(endpointsConfig, version)
+
+	require.NoError(t, err)
+	require.NotNil(t, changes)
+	assert.Equal(t, expectedChanges, changes)
+}

--- a/tools/cli/internal/cli/changelog/create.go
+++ b/tools/cli/internal/cli/changelog/create.go
@@ -17,6 +17,7 @@ package changelog
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/mongodb/openapi/tools/cli/internal/changelog"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
@@ -49,16 +50,18 @@ func (o *Opts) Run() error {
 		fmt.Println(string(base))
 	}
 
+	previousRunDate := time.Now().AddDate(0, -1, -1).Format("2006-01-02")
 	metadata, err := changelog.NewMetadata(
 		fmt.Sprintf("%s/%s", o.basePath, "v2.json"),
 		fmt.Sprintf("%s/%s", o.revisionPath, "v2.json"),
+		previousRunDate,
 		o.exceptionsPaths, baseChangelog)
 
 	if err != nil {
 		return err
 	}
 
-	checks, err := metadata.MergeChangelog()
+	checks, err := metadata.NewChangelogFromOasDiff()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-266446

This PR migrates the code in `sunset_endpoints.py` and `changelog_manual_entries.py`