### PR TITLE
CLOUDP-267021: Add changelog-all logic to the foascli

### DIFF
--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -48,6 +48,7 @@ type Metadata struct {
 	OasDiff           *openapi.OasDiff
 	BaseChangelog     []*Entry //  the base changelog entries
 	RunDate           string
+	PreviousRunDate   string
 	ExemptionFilePath string
 }
 
@@ -81,7 +82,8 @@ type Change struct {
 	HideFromChangelog  bool   `json:"hideFromChangelog,omitempty"`
 }
 
-func NewMetadata(base, revision, exemptionFilePath string, baseChangelog []*Entry) (*Metadata, error) {
+func NewMetadata(base, revision, exemptionFilePath, previourRunDate string, 
+	baseChangelog []*Entry) (*Metadata, error) {
 	loader := openapi.NewOpenAPI3().WithExcludedPrivatePaths()
 	baseSpec, err := loader.CreateOpenAPISpecFromPath(base)
 	if err != nil {
@@ -98,6 +100,7 @@ func NewMetadata(base, revision, exemptionFilePath string, baseChangelog []*Entr
 
 	return &Metadata{
 		RunDate:           time.Now().Format("2006-01-02"),
+		PreviousRunDate:  previourRunDate,
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExemptionFilePath: exemptionFilePath,
@@ -123,7 +126,8 @@ func NewChangelogEntries(path string) ([]*Entry, error) {
 	return entries, nil
 }
 
-func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath string, baseChangelog []*Entry) (*Metadata, error) {
+func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourRunDate string, 
+	baseChangelog []*Entry) (*Metadata, error) {
 	baseSpec, err := openapi.CreateNormalizedOpenAPISpecFromPath(base)
 	if err != nil {
 		return nil, err
@@ -139,6 +143,7 @@ func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath string, ba
 
 	return &Metadata{
 		RunDate:           time.Now().Format("2006-01-02"),
+		PreviousRunDate: previourRunDate,
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExemptionFilePath: exemptionFilePath,
@@ -148,4 +153,32 @@ func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath string, ba
 			IncludePathParams: true,
 		}),
 	}, nil
+}
+
+
+// findChangelogEntry finds the changelog entries for the given date and operationID, versions and changeCode.
+func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCode string) *Change {
+	for _, entry := range changelog {
+		if entry.Date == date {
+			for _, path := range entry.Paths {
+				if path.OperationID != operationID {
+					continue
+				}
+
+				for _, v := range path.Versions {
+					if v.Version != version {
+						continue
+					}
+
+					for _, change := range v.Changes {
+						if change.Code == changeCode {
+							return change
+						}
+					}	
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -82,7 +82,7 @@ type Change struct {
 	HideFromChangelog  bool   `json:"hideFromChangelog,omitempty"`
 }
 
-func NewMetadata(base, revision, exemptionFilePath, previourRunDate string, 
+func NewMetadata(base, revision, exemptionFilePath, previourRunDate string,
 	baseChangelog []*Entry) (*Metadata, error) {
 	loader := openapi.NewOpenAPI3().WithExcludedPrivatePaths()
 	baseSpec, err := loader.CreateOpenAPISpecFromPath(base)
@@ -100,7 +100,7 @@ func NewMetadata(base, revision, exemptionFilePath, previourRunDate string,
 
 	return &Metadata{
 		RunDate:           time.Now().Format("2006-01-02"),
-		PreviousRunDate:  previourRunDate,
+		PreviousRunDate:   previourRunDate,
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExemptionFilePath: exemptionFilePath,
@@ -126,7 +126,7 @@ func NewChangelogEntries(path string) ([]*Entry, error) {
 	return entries, nil
 }
 
-func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourRunDate string, 
+func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourRunDate string,
 	baseChangelog []*Entry) (*Metadata, error) {
 	baseSpec, err := openapi.CreateNormalizedOpenAPISpecFromPath(base)
 	if err != nil {
@@ -143,7 +143,7 @@ func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourR
 
 	return &Metadata{
 		RunDate:           time.Now().Format("2006-01-02"),
-		PreviousRunDate: previourRunDate,
+		PreviousRunDate:   previourRunDate,
 		Base:              baseSpec,
 		Revision:          revisionSpec,
 		ExemptionFilePath: exemptionFilePath,
@@ -154,7 +154,6 @@ func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourR
 		}),
 	}, nil
 }
-
 
 // findChangelogEntry finds the changelog entries for the given date and operationID, versions and changeCode.
 func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCode string) *Change {
@@ -174,7 +173,7 @@ func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCo
 						if change.Code == changeCode {
 							return change
 						}
-					}	
+					}
 				}
 			}
 		}

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -16,6 +16,8 @@ package changelog
 
 import (
 	"encoding/json"
+	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -41,15 +43,39 @@ var breakingChangesAdditionalCheckers = []string{
 	"api-schema-removed",
 }
 
-type Metadata struct {
+type Changelog struct {
+	BaseMetadata      *Metadata
+	RevisionMetadata  *Metadata
 	Base              *load.SpecInfo //  the base spec to compare against the revision
 	Revision          *load.SpecInfo //  the new spec to compare against the base
+	BaseChangelog     []*Entry
 	Config            *checker.Config
 	OasDiff           *openapi.OasDiff
-	BaseChangelog     []*Entry //  the base changelog entries
-	RunDate           string
-	PreviousRunDate   string
 	ExemptionFilePath string
+	RunDate           string
+}
+
+// type Metadata struct {
+// 	Base              *load.SpecInfo //  the base spec to compare against the revision
+// 	Revision          *load.SpecInfo //  the new spec to compare against the base
+// 	Config            *checker.Config
+// 	OasDiff           *openapi.OasDiff
+// 	BaseChangelog     []*Entry //  the base changelog entries
+// 	RunDate           string
+// 	PreviousRunDate   string
+// 	ExemptionFilePath string
+// 	BaseVersions      []string //  list of api versions supported when generating the base changelog
+// 	RevisionVersions  []string // list of api versions supported at runDate
+// 	BasePath 		string
+// 	RevisionPath string
+// }
+
+type Metadata struct {
+	Path          string
+	ActiveVersion string
+	RunDate       string   `json:"runDate"`
+	SpecRevision  string   `json:"specRevision"`
+	Versions      []string `json:"versions"`
 }
 
 type Entry struct {
@@ -82,15 +108,114 @@ type Change struct {
 	HideFromChangelog  bool   `json:"hideFromChangelog,omitempty"`
 }
 
-func NewMetadata(base, revision, exemptionFilePath, previourRunDate string,
-	baseChangelog []*Entry) (*Metadata, error) {
-	loader := openapi.NewOpenAPI3().WithExcludedPrivatePaths()
-	baseSpec, err := loader.CreateOpenAPISpecFromPath(base)
+func NewEntries(basePath, revisionPath string) ([]*Entry, error) {
+	baseMetadata, err := newMetadataFromFile(fmt.Sprintf("%s/%s", basePath, "metadata.json"))
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Base Metadata: %s", string(newBytesFromStruct(baseMetadata)))
+
+	revisionMetadata, err := newMetadataFromFile(fmt.Sprintf("%s/%s", revisionPath, "metadata.json"))
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("Revision Metadata: %s", string(newBytesFromStruct(revisionMetadata)))
+
+	revisionMetadata.RunDate = time.Now().Format("2006-01-02")
+
+	baseActiveVersionOnPreviousRunDate, err := latestVersionActiveOnDate(baseMetadata.RunDate, baseMetadata.Versions)
 	if err != nil {
 		return nil, err
 	}
 
-	revisionSpec, err := loader.CreateOpenAPISpecFromPath(revision)
+	revisionActiveVersionOnPreviousRunDate, err := latestVersionActiveOnDate(baseMetadata.RunDate, revisionMetadata.Versions)
+	if err != nil {
+		return nil, err
+	}
+
+	baseActiveVersionOnRunDate, err := latestVersionActiveOnDate(revisionMetadata.RunDate, baseMetadata.Versions)
+	if err != nil {
+		return nil, err
+	}
+
+	revisionActiveVersionOnRunDate, err := latestVersionActiveOnDate(revisionMetadata.RunDate, revisionMetadata.Versions)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf(`Base specs (from when last changelog was generated): current active version as of today %s, 
+	active version when last changelog was generated %s`, baseActiveVersionOnRunDate, baseActiveVersionOnPreviousRunDate)
+
+	log.Printf(`Revision specs (new specs): current active version as of today %s, 
+	active version when last changelog was generated %s`, revisionActiveVersionOnRunDate, revisionActiveVersionOnPreviousRunDate)
+
+	baseMetadata.ActiveVersion = baseActiveVersionOnPreviousRunDate
+	revisionMetadata.ActiveVersion = revisionActiveVersionOnPreviousRunDate
+
+	changelog, err := newChangelog(baseMetadata, revisionMetadata, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	changelogEntries, err := changelog.NewChangelogFromOasDiff()
+	if err != nil {
+		return nil, err
+	}
+
+	changelog.BaseChangelog = changelogEntries
+	if revisionActiveVersionOnRunDate != baseActiveVersionOnPreviousRunDate {
+		// new version was released or become active since last changelog run
+		// compare "baseActiveVersionOnPreviousRunDate" with "revisionActiveVersionOnRunDate"
+		// (using latest specs, since above, we're comparing
+		// baseActiveVersionOnPreviousRunDate with revisionActiveVersionOnPreviousRunDate)
+		baseMetadata.ActiveVersion = baseActiveVersionOnRunDate
+		revisionMetadata.ActiveVersion = revisionActiveVersionOnRunDate
+		changelog, err = newChangelog(baseMetadata, revisionMetadata, changelogEntries)
+		if err != nil {
+			return nil, err
+		}
+
+		changelogEntries, err = changelog.NewChangelogFromOasDiff()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, version := range changelog.RevisionMetadata.Versions {
+		changelog.RevisionMetadata.ActiveVersion = version
+		changelog, err = newChangelog(baseMetadata, revisionMetadata, changelogEntries)
+		if err != nil {
+			return nil, err
+		}
+
+		changelogEntries, err = changelog.NewChangelogFromDataEntries()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return changelogEntries, nil
+}
+
+func NewEntriesWithoutHidden(basePath, revisionPath string) ([]*Entry, error) {
+	entries, err := NewEntries(basePath, revisionPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return newNotHiddenEntries(entries), nil
+}
+
+func newChangelog(baseMetadata, revisionMetadata *Metadata, baseChangelog []*Entry) (*Changelog, error) {
+	var err error
+	if baseChangelog == nil {
+		baseChangelog, err = newEntriesFromPath(fmt.Sprintf("%s/%s", baseMetadata.Path, "changelog.json"))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	baseSpec, revisionSpec, err := newBaseAndRevisionSpecs(baseMetadata, revisionMetadata)
 	if err != nil {
 		return nil, err
 	}
@@ -98,21 +223,21 @@ func NewMetadata(base, revision, exemptionFilePath, previourRunDate string,
 	changelogConfig := checker.NewConfig(
 		checker.GetAllChecks()).WithOptionalChecks(breakingChangesAdditionalCheckers).WithDeprecation(deprecationDaysBeta, deprecationDaysStable)
 
-	return &Metadata{
-		RunDate:           time.Now().Format("2006-01-02"),
-		PreviousRunDate:   previourRunDate,
-		Base:              baseSpec,
-		Revision:          revisionSpec,
-		ExemptionFilePath: exemptionFilePath,
-		Config:            changelogConfig,
-		BaseChangelog:     baseChangelog,
+	return &Changelog{
+		BaseChangelog:    baseChangelog,
+		RunDate:          revisionMetadata.RunDate,
+		Base:             baseSpec,
+		Revision:         revisionSpec,
+		BaseMetadata:     baseMetadata,
+		RevisionMetadata: revisionMetadata,
+		Config:           changelogConfig,
 		OasDiff: openapi.NewOasDiffWithSpecInfo(baseSpec, revisionSpec, &diff.Config{
 			IncludePathParams: true,
 		}),
 	}, nil
 }
 
-func NewChangelogEntries(path string) ([]*Entry, error) {
+func newEntriesFromPath(path string) ([]*Entry, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -126,33 +251,90 @@ func NewChangelogEntries(path string) ([]*Entry, error) {
 	return entries, nil
 }
 
-func NewMetadataWithNormalizedSpecs(base, revision, exemptionFilePath, previourRunDate string,
-	baseChangelog []*Entry) (*Metadata, error) {
-	baseSpec, err := openapi.CreateNormalizedOpenAPISpecFromPath(base)
+func newBaseAndRevisionSpecs(baseMetadata, revisionMetadata *Metadata) (baseSpec, revisionSpec *load.SpecInfo, err error) {
+	if baseMetadata.ActiveVersion != baseMetadata.SpecRevision {
+		log.Printf("Base spec revision %s is different from the active version %s", baseMetadata.SpecRevision, baseMetadata.ActiveVersion)
+		log.Println("Normalizing the specs: replace versioned media-types with corresponding standard media-types")
+		baseSpec, err = openapi.CreateNormalizedOpenAPISpecFromPath(fmt.Sprintf("%s/%s", baseMetadata.Path, baseMetadata.ActiveVersion))
+		if err != nil {
+			return nil, nil, err
+		}
+		revisionSpec, err = openapi.CreateNormalizedOpenAPISpecFromPath(fmt.Sprintf("%s/%s", revisionMetadata.Path, revisionMetadata.ActiveVersion))
+		if err != nil {
+			return nil, nil, err
+		}
+		baseSpec.Version = baseMetadata.ActiveVersion
+		revisionSpec.Version = revisionMetadata.ActiveVersion
+
+		return baseSpec, revisionSpec, nil
+	}
+
+	loader := openapi.NewOpenAPI3().WithExcludedPrivatePaths()
+	baseSpec, err = loader.CreateOpenAPISpecFromPath(fmt.Sprintf("%s/%s", baseMetadata.Path, baseMetadata.ActiveVersion))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	revisionSpec, err = loader.CreateOpenAPISpecFromPath(fmt.Sprintf("%s/%s", revisionMetadata.Path, revisionMetadata.ActiveVersion))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	baseSpec.Version = baseMetadata.ActiveVersion
+	revisionSpec.Version = revisionMetadata.ActiveVersion
+
+	return baseSpec, revisionSpec, nil
+}
+
+// newMetadataFromFile
+func newMetadataFromFile(path string) (*Metadata, error) {
+	metadataContent, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	revisionSpec, err := openapi.CreateNormalizedOpenAPISpecFromPath(revision)
-	if err != nil {
+	var metadata *Metadata
+	if err := json.Unmarshal(metadataContent, &metadata); err != nil {
 		return nil, err
 	}
 
-	changelogConfig := checker.NewConfig(
-		checker.GetAllChecks()).WithOptionalChecks(breakingChangesAdditionalCheckers).WithDeprecation(deprecationDaysBeta, deprecationDaysStable)
+	return metadata, nil
+}
 
-	return &Metadata{
-		RunDate:           time.Now().Format("2006-01-02"),
-		PreviousRunDate:   previourRunDate,
-		Base:              baseSpec,
-		Revision:          revisionSpec,
-		ExemptionFilePath: exemptionFilePath,
-		Config:            changelogConfig,
-		BaseChangelog:     baseChangelog,
-		OasDiff: openapi.NewOasDiffWithSpecInfo(baseSpec, revisionSpec, &diff.Config{
-			IncludePathParams: true,
-		}),
-	}, nil
+// latestVersionActiveOnDate returns before current UTC date.
+func latestVersionActiveOnDate(date string, versions []string) (string, error) {
+	dateTime, err := newDateFromString(date)
+	if err != nil {
+		return "", err
+	}
+
+	activeVersions := []time.Time{}
+	for _, version := range versions {
+		versionTime, err := newDateFromString(version)
+		if err != nil {
+			return "", err
+		}
+
+		if versionTime.Before(dateTime) || versionTime.Equal(dateTime) {
+			activeVersions = append(activeVersions, versionTime)
+		}
+	}
+
+	return latestVersion(activeVersions), nil
+}
+
+func latestVersion(dates []time.Time) string {
+	if len(dates) == 0 {
+		return ""
+	}
+
+	latest := dates[0]
+	for _, date := range dates {
+		if d := date.After(latest); d {
+			latest = date
+		}
+	}
+	return latest.Format("2006-01-02")
 }
 
 // findChangelogEntry finds the changelog entries for the given date and operationID, versions and changeCode.
@@ -180,4 +362,73 @@ func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCo
 	}
 
 	return nil
+}
+
+func newBytesFromStruct(data interface{}) []byte {
+	bytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return nil
+	}
+
+	return bytes
+}
+
+// newNotHiddenEntries returns the entries that are not hidden from the changelog.
+// Logic:
+// Gets the last changelog date entry at index 0 and:
+// 1. Remove all entries with hideFromChangelog
+// 2. Remove all empty versions
+// 3. Remove all empty paths
+// 4. Shift changelog entry if it turns out empty
+func newNotHiddenEntries(changelog []*Entry) []*Entry {
+	if len(changelog) == 0 {
+		return changelog
+	}
+
+	// Get changes only for the last date, which is what was recently merged
+	changes := changelog[0]
+
+	// Remove hidden changes
+	for _, path := range changes.Paths {
+		for _, version := range path.Versions {
+			version.Changes = newNotHiddenChanges(version.Changes)
+		}
+	}
+
+	// Remove empty versions
+	for _, path := range changes.Paths {
+		versions := []*Version{}
+		for _, version := range path.Versions {
+			if len(version.Changes) > 0 {
+				versions = append(versions, version)
+			}
+		}
+		path.Versions = versions
+	}
+
+	// Remove empty paths
+	paths := []*Path{}
+	for _, path := range changes.Paths {
+		if len(path.Versions) > 0 {
+			paths = append(paths, path)
+		}
+	}
+
+	if len(paths) == 0 {
+		return changelog[1:]
+	}
+
+	changelog[0].Paths = paths
+	return changelog
+}
+
+func newNotHiddenChanges(changes []*Change) []*Change {
+	var notHiddenChanges []*Change
+	for _, change := range changes {
+		if !change.HideFromChangelog {
+			notHiddenChanges = append(notHiddenChanges, change)
+		}
+	}
+
+	return notHiddenChanges
 }

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -101,13 +101,13 @@ func NewEntries(basePath, revisionPath string) ([]*Entry, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Base Metadata: %s", string(newBytesFromStruct(baseMetadata)))
+	log.Printf("Base Metadata: %s", newStringFromStruct(baseMetadata))
 
 	revisionMetadata, err := newMetadataFromFile(fmt.Sprintf("%s/%s", revisionPath, "metadata.json"))
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("Revision Metadata: %s", string(newBytesFromStruct(revisionMetadata)))
+	log.Printf("Revision Metadata: %s", newStringFromStruct(revisionMetadata))
 
 	revisionMetadata.RunDate = time.Now().Format("2006-01-02")
 
@@ -355,13 +355,13 @@ func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCo
 	return nil
 }
 
-func newBytesFromStruct(data interface{}) []byte {
+func newStringFromStruct(data interface{}) string {
 	bytes, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		return nil
+		return ""
 	}
 
-	return bytes
+	return string(bytes)
 }
 
 // newNotHiddenEntries returns the entries that are not hidden from the changelog.

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -55,21 +55,6 @@ type Changelog struct {
 	RunDate           string
 }
 
-// type Metadata struct {
-// 	Base              *load.SpecInfo //  the base spec to compare against the revision
-// 	Revision          *load.SpecInfo //  the new spec to compare against the base
-// 	Config            *checker.Config
-// 	OasDiff           *openapi.OasDiff
-// 	BaseChangelog     []*Entry //  the base changelog entries
-// 	RunDate           string
-// 	PreviousRunDate   string
-// 	ExemptionFilePath string
-// 	BaseVersions      []string //  list of api versions supported when generating the base changelog
-// 	RevisionVersions  []string // list of api versions supported at runDate
-// 	BasePath 		string
-// 	RevisionPath string
-// }
-
 type Metadata struct {
 	Path          string
 	ActiveVersion string

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -215,13 +215,13 @@ func newChangelog(baseMetadata, revisionMetadata *Metadata, baseChangelog []*Ent
 		checker.GetAllChecks()).WithOptionalChecks(breakingChangesAdditionalCheckers).WithDeprecation(deprecationDaysBeta, deprecationDaysStable)
 
 	return &Changelog{
-		BaseChangelog:    baseChangelog,
-		RunDate:          revisionMetadata.RunDate,
-		Base:             baseSpec,
-		Revision:         revisionSpec,
-		BaseMetadata:     baseMetadata,
-		RevisionMetadata: revisionMetadata,
-		Config:           changelogConfig,
+		BaseChangelog:     baseChangelog,
+		RunDate:           revisionMetadata.RunDate,
+		Base:              baseSpec,
+		Revision:          revisionSpec,
+		BaseMetadata:      baseMetadata,
+		RevisionMetadata:  revisionMetadata,
+		Config:            changelogConfig,
 		ExemptionFilePath: fmt.Sprintf("%s/%s", revisionMetadata.Path, "exemptions.yaml"),
 		OasDiff: openapi.NewOasDiffWithSpecInfo(baseSpec, revisionSpec, &diff.Config{
 			IncludePathParams: true,
@@ -251,7 +251,8 @@ func newBaseAndRevisionSpecs(baseMetadata, revisionMetadata *Metadata) (baseSpec
 		if err != nil {
 			return nil, nil, err
 		}
-		revisionSpec, err = openapi.CreateNormalizedOpenAPISpecFromPath(fmt.Sprintf("%s/openapi-%s.json", revisionMetadata.Path, revisionMetadata.ActiveVersion))
+		revisionSpec, err = openapi.CreateNormalizedOpenAPISpecFromPath(fmt.Sprintf("%s/openapi-%s.json",
+			revisionMetadata.Path, revisionMetadata.ActiveVersion))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -108,6 +108,9 @@ type Change struct {
 	HideFromChangelog  bool   `json:"hideFromChangelog,omitempty"`
 }
 
+// NewEntries generates the changelog entries between the base and revision specs.
+// The returned entries includes all the changes between the base and revision specs included the one
+// marked as hidden.
 func NewEntries(basePath, revisionPath string) ([]*Entry, error) {
 	baseMetadata, err := newMetadataFromFile(fmt.Sprintf("%s/%s", basePath, "metadata.json"))
 	if err != nil {
@@ -157,7 +160,7 @@ func NewEntries(basePath, revisionPath string) ([]*Entry, error) {
 		return nil, err
 	}
 
-	changelogEntries, err := changelog.NewChangelogFromOasDiff()
+	changelogEntries, err := changelog.newEntryFromOasDiff()
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +178,7 @@ func NewEntries(basePath, revisionPath string) ([]*Entry, error) {
 			return nil, err
 		}
 
-		changelogEntries, err = changelog.NewChangelogFromOasDiff()
+		changelogEntries, err = changelog.newEntryFromOasDiff()
 		if err != nil {
 			return nil, err
 		}
@@ -188,7 +191,7 @@ func NewEntries(basePath, revisionPath string) ([]*Entry, error) {
 			return nil, err
 		}
 
-		changelogEntries, err = changelog.NewChangelogFromDataEntries()
+		changelogEntries, err = changelog.NewEntriesFromSunsetAndManualEntry()
 		if err != nil {
 			return nil, err
 		}
@@ -197,6 +200,9 @@ func NewEntries(basePath, revisionPath string) ([]*Entry, error) {
 	return changelogEntries, nil
 }
 
+// NewEntriesWithoutHidden generates the changelog entries between the base and revision specs.
+// The returned entries includes the changes between the base and revision specs that are not
+// marked as hidden.
 func NewEntriesWithoutHidden(basePath, revisionPath string) ([]*Entry, error) {
 	entries, err := NewEntries(basePath, revisionPath)
 	if err != nil {

--- a/tools/cli/internal/changelog/changelog_test.go
+++ b/tools/cli/internal/changelog/changelog_test.go
@@ -1,0 +1,220 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindChangelogEntry(t *testing.T) {
+	tests := []struct {
+		name            string
+		entries         []*Entry
+		operationID     string
+		date            string
+		version         string
+		changeCode      string
+		expectedEntries *Change
+	}{
+
+		{
+			name: "find changelog entry",
+			entries: []*Entry{
+				{
+					Date: "2023-07-10",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Date: "2023-07-11",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+			},
+			operationID: "createCluster",
+			date:        "2023-07-10",
+			version:     "2023-02-01",
+			changeCode:  "endpoint-removed",
+			expectedEntries: &Change{
+				Description:        "endpoint removed",
+				Code:               "endpoint-removed",
+				BackwardCompatible: true,
+			},
+		},
+		{
+			name: "Not find changelog entry for different date",
+			entries: []*Entry{
+				{
+					Date: "2023-07-10",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Date: "2023-07-11",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+			},
+			operationID:     "createCluster",
+			date:            "2023-07-21",
+			version:         "2023-02-01",
+			changeCode:      "endpoint-removed",
+			expectedEntries: nil,
+		},
+		{
+			name: "Not find changelog entry for different version",
+			entries: []*Entry{
+				{
+					Date: "2023-07-10",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+				{
+					Date: "2023-07-11",
+					Paths: []*Path{
+						{
+							URI:         "/api/atlas/v2/groups/{id}/clusters",
+							HTTPMethod:  "POST",
+							OperationID: "createCluster",
+							Tag:         "Multi-Cloud Clusters",
+							Versions: []*Version{
+								{
+									Version:        "2023-02-01",
+									StabilityLevel: "stable",
+									ChangeType:     "remove",
+									Changes: []*Change{
+										{
+											Description:        "endpoint removed",
+											Code:               "endpoint-removed",
+											BackwardCompatible: true,
+										}},
+								},
+							},
+						},
+					},
+				},
+			},
+			operationID:     "createCluster",
+			date:            "2023-07-11",
+			version:         "2023-02-02",
+			changeCode:      "endpoint-removed",
+			expectedEntries: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := findChangelogEntry(test.entries, test.date, test.operationID, test.version, test.changeCode)
+			assert.Equal(t, test.expectedEntries, result)
+		})
+	}
+}

--- a/tools/cli/internal/changelog/changelog_test.go
+++ b/tools/cli/internal/changelog/changelog_test.go
@@ -20,6 +20,224 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewNotHiddenEntries(t *testing.T) {
+	tests := []struct {
+		name      string
+		changelog []*Entry
+		expected  []*Entry
+	}{
+		{
+			name:      "EmptyChangelog",
+			changelog: []*Entry{},
+			expected:  []*Entry{},
+		},
+		{
+			name: "NoHiddenChanges",
+			changelog: []*Entry{
+				{
+					Date: "2024-08-01",
+					Paths: []*Path{
+						{
+							URI:         "/api/v1/test",
+							HTTPMethod:  "GET",
+							OperationID: "getTest",
+							Versions: []*Version{
+								{
+									Version:        "v1",
+									StabilityLevel: "stable",
+									ChangeType:     "add",
+									Changes: []*Change{
+										{
+											Description:        "added endpoint",
+											Code:               "endpoint-added",
+											BackwardCompatible: true,
+											HideFromChangelog:  false,
+										},
+									},
+								},
+							},
+						},
+						{
+							URI:         "/api/v1/test2",
+							HTTPMethod:  "GET",
+							OperationID: "getTest2",
+							Versions: []*Version{
+								{
+									Version:        "v1",
+									StabilityLevel: "stable",
+									ChangeType:     "add",
+									Changes: []*Change{
+										{
+											Description:        "added endpoint",
+											Code:               "endpoint-added",
+											BackwardCompatible: true,
+											HideFromChangelog:  false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*Entry{
+				{
+					Date: "2024-08-01",
+					Paths: []*Path{
+						{
+							URI:         "/api/v1/test",
+							HTTPMethod:  "GET",
+							OperationID: "getTest",
+							Versions: []*Version{
+								{
+									Version:        "v1",
+									StabilityLevel: "stable",
+									ChangeType:     "add",
+									Changes: []*Change{
+										{
+											Description:        "added endpoint",
+											Code:               "endpoint-added",
+											BackwardCompatible: true,
+											HideFromChangelog:  false,
+										},
+									},
+								},
+							},
+						},
+						{
+							URI:         "/api/v1/test2",
+							HTTPMethod:  "GET",
+							OperationID: "getTest2",
+							Versions: []*Version{
+								{
+									Version:        "v1",
+									StabilityLevel: "stable",
+									ChangeType:     "add",
+									Changes: []*Change{
+										{
+											Description:        "added endpoint",
+											Code:               "endpoint-added",
+											BackwardCompatible: true,
+											HideFromChangelog:  false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SomeHiddenChanges",
+			changelog: []*Entry{
+				{
+					Date: "2024-08-01",
+					Paths: []*Path{
+						{
+							URI:         "/api/v1/test",
+							HTTPMethod:  "GET",
+							OperationID: "getTest",
+							Versions: []*Version{
+								{
+									Version:        "v1",
+									StabilityLevel: "stable",
+									ChangeType:     "add",
+									Changes: []*Change{
+										{
+											Description:        "added endpoint",
+											Code:               "endpoint-added",
+											BackwardCompatible: true,
+											HideFromChangelog:  false,
+										},
+										{
+											Description:        "hidden change",
+											Code:               "hidden-change",
+											BackwardCompatible: true,
+											HideFromChangelog:  true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*Entry{
+				{
+					Date: "2024-08-01",
+					Paths: []*Path{
+						{
+							URI:         "/api/v1/test",
+							HTTPMethod:  "GET",
+							OperationID: "getTest",
+							Versions: []*Version{
+								{
+									Version:        "v1",
+									StabilityLevel: "stable",
+									ChangeType:     "add",
+									Changes: []*Change{
+										{
+											Description:        "added endpoint",
+											Code:               "endpoint-added",
+											BackwardCompatible: true,
+											HideFromChangelog:  false,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "AllChangesHidden",
+			changelog: []*Entry{
+				{
+					Date: "2024-08-01",
+					Paths: []*Path{
+						{
+							URI:         "/api/v1/test",
+							HTTPMethod:  "GET",
+							OperationID: "getTest",
+							Versions: []*Version{
+								{
+									Version:        "v1",
+									StabilityLevel: "stable",
+									ChangeType:     "add",
+									Changes: []*Change{
+										{
+											Description:        "hidden change 1",
+											Code:               "hidden-change-1",
+											BackwardCompatible: true,
+											HideFromChangelog:  true,
+										},
+										{
+											Description:        "hidden change 2",
+											Code:               "hidden-change-2",
+											BackwardCompatible: true,
+											HideFromChangelog:  true,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []*Entry{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := newNotHiddenEntries(tt.changelog)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestFindChangelogEntry(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/tools/cli/internal/changelog/manual_entry.go
+++ b/tools/cli/internal/changelog/manual_entry.go
@@ -1,0 +1,108 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tufin/oasdiff/load"
+)
+
+func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
+	previousRunDate := "2023-07-10"
+	runDate := "2023-07-12"
+	version := "2023-02-01"
+	theDayAfterRunDate := "2023-07-13"
+
+	changelog := []*Entry{
+		{
+			Date: previousRunDate,
+			Paths: []*Path{
+				{
+					URI:         "/api/atlas/v2/groups/{groupId}/clusters",
+					HTTPMethod:  "POST",
+					OperationID: "createCluster",
+					Tag:         "Multi-Cloud Clusters",
+					Versions: []*Version{
+						{
+							Version:        version,
+							StabilityLevel: "stable",
+							ChangeType:     "update",
+							Changes: []*Change{
+								{
+									Description:        "change info 1",
+									Code:               "manual-changelog-entry",
+									BackwardCompatible: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	endpointsConfig := map[string]*outputfilter.OperationConfigs{
+		"createCluster": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:       "/api/atlas/v2/groups/{groupId}/clusters",
+				HTTPMethod: "POST",
+				Tag:        "Multi-Cloud Clusters",
+				Sunset:     "",
+				ManualChangelogEntries: map[string]interface{}{
+					previousRunDate: "change info 1",      // Already in the changelog
+					runDate:         "change info 2",      // Should be added to the changelog
+					theDayAfterRunDate: "change info 3",   // Should not be added to the changelog
+				},
+			},
+		},
+	}
+
+	expectedChanges := []*outputfilter.OasDiffEntry{
+		{
+			Date:        runDate,
+			ID:          "manual-changelog-entry",
+			Level:       1,
+			Operation:   "POST",
+			OperationID: "createCluster",
+			Path:        "/api/atlas/v2/groups/{groupId}/clusters",
+			Text:        "change info 2",
+		},
+	}
+
+	changelogMetadata := &Metadata{
+		Base: &load.SpecInfo{
+			Version: version,
+		},
+		Revision: &load.SpecInfo{
+			Version: version,
+		},
+		BaseChangelog:   changelog,
+		RunDate:         runDate,
+		PreviousRunDate: previousRunDate,
+	}
+
+	// Act
+	changes, err := changelogMetadata.detectManualEntriesAndMergeChangelog(endpointsConfig, version)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, changes)
+	assert.Equal(t, expectedChanges, changes)
+}

--- a/tools/cli/internal/changelog/manual_entry.go
+++ b/tools/cli/internal/changelog/manual_entry.go
@@ -25,7 +25,7 @@ import (
 
 const manualChangelogEntry = "manual-changelog-entry"
 
-func (m *Metadata) newOasDiffEntriesWithManualEntries(confs map[string]*outputfilter.OperationConfigs,
+func (m *Changelog) newOasDiffEntriesWithManualEntries(confs map[string]*outputfilter.OperationConfigs,
 	version string) ([]*outputfilter.OasDiffEntry, error) {
 	changes := make([]*outputfilter.OasDiffEntry, 0)
 
@@ -35,7 +35,7 @@ func (m *Metadata) newOasDiffEntriesWithManualEntries(confs map[string]*outputfi
 		}
 
 		for entryDate, entryText := range config.Revision.ManualChangelogEntries {
-			if value, err := isEntryDateBetween(entryDate, m.PreviousRunDate, m.RunDate); err != nil || !value {
+			if value, err := isEntryDateBetween(entryDate, m.BaseMetadata.RunDate, m.RevisionMetadata.RunDate); err != nil || !value {
 				continue
 			}
 
@@ -55,7 +55,7 @@ func (m *Metadata) newOasDiffEntriesWithManualEntries(confs map[string]*outputfi
 		}
 	}
 
-	printManualChangesLogs(changes, version, m.PreviousRunDate, m.RunDate)
+	printManualChangesLogs(changes, version, m.BaseMetadata.RunDate, m.RevisionMetadata.RunDate)
 	return changes, nil
 }
 

--- a/tools/cli/internal/changelog/manual_entry.go
+++ b/tools/cli/internal/changelog/manual_entry.go
@@ -52,7 +52,6 @@ func (m *Metadata) newOasDiffEntriesWithManualEntries(confs map[string]*outputfi
 				OperationID: operationID,
 				Path:        config.Revision.Path,
 			})
-
 		}
 	}
 

--- a/tools/cli/internal/changelog/manual_entry_test.go
+++ b/tools/cli/internal/changelog/manual_entry_test.go
@@ -1,0 +1,108 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tufin/oasdiff/load"
+)
+
+func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
+	previousRunDate := "2023-07-10"
+	runDate := "2023-07-12"
+	version := "2023-02-01"
+	theDayAfterRunDate := "2023-07-13"
+
+	changelog := []*Entry{
+		{
+			Date: previousRunDate,
+			Paths: []*Path{
+				{
+					URI:         "/api/atlas/v2/groups/{groupId}/clusters",
+					HTTPMethod:  "POST",
+					OperationID: "createCluster",
+					Tag:         "Multi-Cloud Clusters",
+					Versions: []*Version{
+						{
+							Version:        version,
+							StabilityLevel: "stable",
+							ChangeType:     "update",
+							Changes: []*Change{
+								{
+									Description:        "change info 1",
+									Code:               "manual-changelog-entry",
+									BackwardCompatible: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	endpointsConfig := map[string]*outputfilter.OperationConfigs{
+		"createCluster": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:       "/api/atlas/v2/groups/{groupId}/clusters",
+				HTTPMethod: "POST",
+				Tag:        "Multi-Cloud Clusters",
+				Sunset:     "",
+				ManualChangelogEntries: map[string]interface{}{
+					previousRunDate: "change info 1",      // Already in the changelog
+					runDate:         "change info 2",      // Should be added to the changelog
+					theDayAfterRunDate: "change info 3",   // Should not be added to the changelog
+				},
+			},
+		},
+	}
+
+	expectedChanges := []*outputfilter.OasDiffEntry{
+		{
+			Date:        runDate,
+			ID:          "manual-changelog-entry",
+			Level:       1,
+			Operation:   "POST",
+			OperationID: "createCluster",
+			Path:        "/api/atlas/v2/groups/{groupId}/clusters",
+			Text:        "change info 2",
+		},
+	}
+
+	changelogMetadata := &Metadata{
+		Base: &load.SpecInfo{
+			Version: version,
+		},
+		Revision: &load.SpecInfo{
+			Version: version,
+		},
+		BaseChangelog:   changelog,
+		RunDate:         runDate,
+		PreviousRunDate: previousRunDate,
+	}
+
+	// Act
+	changes, err := changelogMetadata.detectManualEntriesAndMergeChangelog(endpointsConfig, version)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, changes)
+	assert.Equal(t, expectedChanges, changes)
+}

--- a/tools/cli/internal/changelog/manual_entry_test.go
+++ b/tools/cli/internal/changelog/manual_entry_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tufin/oasdiff/load"
 )
 
 func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
@@ -29,7 +28,7 @@ func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
 	version := "2023-02-01"
 	theDayAfterRunDate := "2023-07-13"
 
-	changelog := []*Entry{
+	baseChangelog := []*Entry{
 		{
 			Date: previousRunDate,
 			Paths: []*Path{
@@ -86,20 +85,21 @@ func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
 		},
 	}
 
-	changelogMetadata := &Metadata{
-		Base: &load.SpecInfo{
-			Version: version,
+	changelog := &Changelog{
+		BaseMetadata: &Metadata{
+			RunDate:       previousRunDate,
+			ActiveVersion: version,
 		},
-		Revision: &load.SpecInfo{
-			Version: version,
+		RevisionMetadata: &Metadata{
+			RunDate:       runDate,
+			ActiveVersion: version,
 		},
-		BaseChangelog:   changelog,
-		RunDate:         runDate,
-		PreviousRunDate: previousRunDate,
+		RunDate:       runDate,
+		BaseChangelog: baseChangelog,
 	}
 
 	// Act
-	changes, err := changelogMetadata.newOasDiffEntriesWithManualEntries(endpointsConfig, version)
+	changes, err := changelog.newOasDiffEntriesWithManualEntries(endpointsConfig, version)
 
 	// Assert
 	require.NoError(t, err)

--- a/tools/cli/internal/changelog/manual_entry_test.go
+++ b/tools/cli/internal/changelog/manual_entry_test.go
@@ -66,9 +66,9 @@ func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
 				Tag:        "Multi-Cloud Clusters",
 				Sunset:     "",
 				ManualChangelogEntries: map[string]interface{}{
-					previousRunDate: "change info 1",      // Already in the changelog
-					runDate:         "change info 2",      // Should be added to the changelog
-					theDayAfterRunDate: "change info 3",   // Should not be added to the changelog
+					previousRunDate:    "change info 1", // Already in the changelog
+					runDate:            "change info 2", // Should be added to the changelog
+					theDayAfterRunDate: "change info 3", // Should not be added to the changelog
 				},
 			},
 		},
@@ -99,7 +99,7 @@ func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
 	}
 
 	// Act
-	changes, err := changelogMetadata.detectManualEntriesAndMergeChangelog(endpointsConfig, version)
+	changes, err := changelogMetadata.newOasDiffEntriesWithManualEntries(endpointsConfig, version)
 
 	// Assert
 	require.NoError(t, err)

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -50,24 +50,24 @@ func newChangeTypeOverrides() map[string]string {
 	}
 }
 
-// NewChangelogFromDataEntries merges the base changelog with the new changes from manual entries and sunset endpoints
-func (m *Changelog) NewChangelogFromDataEntries() ([]*Entry, error) {
+// NewEntriesFromSunsetAndManualEntry merges the base changelog with the new changes from manual entries and sunset endpoints
+func (m *Changelog) NewEntriesFromSunsetAndManualEntry() ([]*Entry, error) {
 	conf := outputfilter.NewOperationConfigs(nil, m.Revision)
-	if err := m.newChangelogFromSunsetEndpoints(conf); err != nil {
+	if _, err := m.newEntriesFromSunsetEndpoints(conf); err != nil {
 		return nil, err
 	}
 
-	if err := m.newChangelogFromManualEntries(conf); err != nil {
+	if _, err := m.newManualEntries(conf); err != nil {
 		return nil, err
 	}
 
 	return m.BaseChangelog, nil
 }
 
-func (m *Changelog) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter.OperationConfigs) error {
-	sunsetChanges, err := m.newOasDiffEntriesFromSunsetEndpoints(conf, m.Revision.Version)
+func (m *Changelog) newEntriesFromSunsetEndpoints(conf map[string]*outputfilter.OperationConfigs) ([]*Entry, error) {
+	sunsetChanges, err := m.newOasDiffEntriesFromSunsetEndpoints(conf, m.RevisionMetadata.ActiveVersion)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	runDate := m.RunDate
@@ -81,19 +81,19 @@ func (m *Changelog) newChangelogFromSunsetEndpoints(conf map[string]*outputfilte
 
 		changelog, err := m.mergeChangelog(changeTypeRemove, []*outputfilter.OasDiffEntry{change}, conf)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		m.BaseChangelog = changelog
 	}
 
-	return nil
+	return m.BaseChangelog, nil
 }
 
-func (m *Changelog) newChangelogFromManualEntries(conf map[string]*outputfilter.OperationConfigs) error {
-	manualChanges, err := m.newOasDiffEntriesWithManualEntries(conf, m.Revision.Version)
+func (m *Changelog) newManualEntries(conf map[string]*outputfilter.OperationConfigs) ([]*Entry, error) {
+	manualChanges, err := m.newOasDiffEntriesWithManualEntries(conf, m.RevisionMetadata.ActiveVersion)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	runDate := m.RunDate
@@ -107,17 +107,17 @@ func (m *Changelog) newChangelogFromManualEntries(conf map[string]*outputfilter.
 
 		changelog, err := m.mergeChangelog(changeTypeUpdate, []*outputfilter.OasDiffEntry{change}, conf)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		m.BaseChangelog = changelog
 	}
 
-	return nil
+	return m.BaseChangelog, nil
 }
 
-// NewChangelogFromOasDiff merges the base changelog with the new changes from a Base and Revision OpenAPI specs
-func (m *Changelog) NewChangelogFromOasDiff() ([]*Entry, error) {
+// newEntryFromOasDiff merges the base changelog with the new changes from a Base and Revision OpenAPI specs
+func (m *Changelog) newEntryFromOasDiff() ([]*Entry, error) {
 	changes, err := m.newOasDiffEntries()
 	if err != nil {
 		return nil, err

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -128,7 +128,7 @@ func (m *Changelog) newEntryFromOasDiff() ([]*Entry, error) {
 	}
 
 	log.Printf("Found %d changes between %s and %s", len(changes), m.Base.Url, m.Revision.Url)
-	log.Printf("Changes: %s", newBytesFromStruct(changes))
+	log.Printf("Changes: %s", newStringFromStruct(changes))
 
 	conf := outputfilter.NewOperationConfigs(m.Base, m.Revision)
 

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -55,7 +55,7 @@ func (m *Metadata) NewChangelogFromDataEntries() ([]*Entry, error) {
 	if err := m.newChangelogFromSunsetEndpoints(conf); err != nil {
 		return nil, err
 	}
-	
+
 	if err := m.newChangelogFromManualEntries(conf); err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func (m *Metadata) NewChangelogFromDataEntries() ([]*Entry, error) {
 func (m *Metadata) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter.OperationConfigs) error {
 	sunsetChanges, err := m.newOasDiffEntriesFromSunsetEndpoints(conf, m.Revision.Version)
 	if err != nil {
-		return  err
+		return err
 	}
 
 	runDate := m.RunDate
@@ -80,7 +80,7 @@ func (m *Metadata) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter
 
 		changelog, err := m.mergeChangelog(changeTypeRemove, []*outputfilter.OasDiffEntry{change}, conf)
 		if err != nil {
-			return  err
+			return err
 		}
 
 		m.BaseChangelog = changelog
@@ -92,7 +92,7 @@ func (m *Metadata) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter
 func (m *Metadata) newChangelogFromManualEntries(conf map[string]*outputfilter.OperationConfigs) error {
 	manualChanges, err := m.newOasDiffEntriesWithManualEntries(conf, m.Revision.Version)
 	if err != nil {
-		return  err
+		return err
 	}
 
 	runDate := m.RunDate
@@ -112,9 +112,8 @@ func (m *Metadata) newChangelogFromManualEntries(conf map[string]*outputfilter.O
 		m.BaseChangelog = changelog
 	}
 
-	return  nil
+	return nil
 }
-
 
 // NewChangelogFromOasDiff merges the base changelog with the new changes from a Base and Revision OpenAPI specs
 func (m *Metadata) NewChangelogFromOasDiff() ([]*Entry, error) {

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -149,7 +149,7 @@ func (m *Changelog) mergeChangelog(
 	changeType string,
 	changes []*outputfilter.OasDiffEntry,
 	conf map[string]*outputfilter.OperationConfigs) ([]*Entry, error) {
-	changelog, err := duplicateChangelog(m.BaseChangelog)
+	changelog, err := duplicateEntries(m.BaseChangelog)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (m *Changelog) newPathsFromDeprecatedChanges(
 	changes []*outputfilter.OasDiffEntry,
 	changelogPath *[]*Path,
 	conf map[string]*outputfilter.OperationConfigs) ([]*Path, error) {
-	depreactedChanges := m.newDeprecatedByNewerVersionChanges(changes, conf)
+	depreactedChanges := m.newDeprecatedByNewerVersionOasDiffEntries(changes, conf)
 	return newMergedChanges(depreactedChanges, changeTypeDeprecated, m.BaseMetadata.ActiveVersion, changelogPath, conf)
 }
 
@@ -243,6 +243,7 @@ func sortChangelog(changelog []*Entry) []*Entry {
 	return changelog
 }
 
+// newMergedChanges merges the OasDiff changes into the changelog []paths
 func newMergedChanges(changes []*outputfilter.OasDiffEntry,
 	changeType, version string, changelogPath *[]*Path,
 	operationConfig map[string]*outputfilter.OperationConfigs) ([]*Path, error) {
@@ -286,7 +287,7 @@ var priorityGivenChangeType = func(changeType string) int {
 	return notSetPriority
 }
 
-func (m *Changelog) newDeprecatedByNewerVersionChanges(
+func (m *Changelog) newDeprecatedByNewerVersionOasDiffEntries(
 	changes []*outputfilter.OasDiffEntry,
 	operationConfig map[string]*outputfilter.OperationConfigs) []*outputfilter.OasDiffEntry {
 	// deprecation by newer version occurs only when
@@ -424,7 +425,7 @@ func retrieveEntryAtDate(changelog *[]*Entry, date string) *Entry {
 	return nil
 }
 
-func duplicateChangelog(changelog []*Entry) ([]*Entry, error) {
+func duplicateEntries(changelog []*Entry) ([]*Entry, error) {
 	// Marshal the original document to JSON
 	contents, err := json.Marshal(changelog)
 	if err != nil {

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -1,3 +1,17 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package changelog
 
 import (
@@ -35,8 +49,75 @@ func newChangeTypeOverrides() map[string]string {
 	}
 }
 
-// MergeChangelog merges the base changelog with the new changes from a Base and Revision OpenAPI specs
-func (m *Metadata) MergeChangelog() ([]*Entry, error) {
+// NewChangelogFromDataEntries merges the base changelog with the new changes from manual entries and sunset endpoints
+func (m *Metadata) NewChangelogFromDataEntries() ([]*Entry, error) {
+	conf := outputfilter.NewOperationConfigs(nil, m.Revision)
+	if err := m.newChangelogFromSunsetEndpoints(conf); err != nil {
+		return nil, err
+	}
+	
+	if err := m.newChangelogFromManualEntries(conf); err != nil {
+		return nil, err
+	}
+
+	return m.BaseChangelog, nil
+}
+
+func (m *Metadata) newChangelogFromSunsetEndpoints(conf map[string]*outputfilter.OperationConfigs) error {
+	sunsetChanges, err := m.newOasDiffEntriesFromSunsetEndpoints(conf, m.Revision.Version)
+	if err != nil {
+		return  err
+	}
+
+	runDate := m.RunDate
+	for _, change := range sunsetChanges {
+		m.RunDate = func() string {
+			if change.Date == "" {
+				return runDate
+			}
+			return change.Date
+		}()
+
+		changelog, err := m.mergeChangelog(changeTypeRemove, []*outputfilter.OasDiffEntry{change}, conf)
+		if err != nil {
+			return  err
+		}
+
+		m.BaseChangelog = changelog
+	}
+
+	return nil
+}
+
+func (m *Metadata) newChangelogFromManualEntries(conf map[string]*outputfilter.OperationConfigs) error {
+	manualChanges, err := m.newOasDiffEntriesWithManualEntries(conf, m.Revision.Version)
+	if err != nil {
+		return  err
+	}
+
+	runDate := m.RunDate
+	for _, change := range manualChanges {
+		m.RunDate = func() string {
+			if change.Date == "" {
+				return runDate
+			}
+			return change.Date
+		}()
+
+		changelog, err := m.mergeChangelog(changeTypeUpdate, []*outputfilter.OasDiffEntry{change}, conf)
+		if err != nil {
+			return err
+		}
+
+		m.BaseChangelog = changelog
+	}
+
+	return  nil
+}
+
+
+// NewChangelogFromOasDiff merges the base changelog with the new changes from a Base and Revision OpenAPI specs
+func (m *Metadata) NewChangelogFromOasDiff() ([]*Entry, error) {
 	changes, err := m.newOasDiffEntries()
 	if err != nil {
 		return nil, err

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -192,7 +192,7 @@ func (m *Changelog) newPathsFromRevisionChanges(
 	changeType string, changelogPath *[]*Path,
 	conf map[string]*outputfilter.OperationConfigs) ([]*Path, error) {
 	revisionChanges := m.newRevisionChanges(changes)
-	return newMergedChanges(revisionChanges, changeType, m.Revision.Version, changelogPath, conf)
+	return newMergedChanges(revisionChanges, changeType, m.RevisionMetadata.ActiveVersion, changelogPath, conf)
 }
 
 // newPathsFromDeprecatedChanges creates new paths from deprecated changes
@@ -201,7 +201,7 @@ func (m *Changelog) newPathsFromDeprecatedChanges(
 	changelogPath *[]*Path,
 	conf map[string]*outputfilter.OperationConfigs) ([]*Path, error) {
 	depreactedChanges := m.newDeprecatedByNewerVersionChanges(changes, conf)
-	return newMergedChanges(depreactedChanges, changeTypeDeprecated, m.Base.Version, changelogPath, conf)
+	return newMergedChanges(depreactedChanges, changeTypeDeprecated, m.BaseMetadata.ActiveVersion, changelogPath, conf)
 }
 
 func (m *Changelog) newOasDiffEntries() ([]*outputfilter.OasDiffEntry, error) {

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -217,6 +217,7 @@ func (m *Changelog) newOasDiffEntries() ([]*outputfilter.OasDiffEntry, error) {
 		diffResult.SourceMap,
 		checker.INFO)
 
+	log.Printf("Found '%d' oasdiff changes between %s and %s", len(changes), m.Base.Url, m.Revision.Url)
 	return outputfilter.NewChangelogEntries(changes, diffResult.SpecInfoPair, m.ExemptionFilePath)
 }
 

--- a/tools/cli/internal/changelog/merge_test.go
+++ b/tools/cli/internal/changelog/merge_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package changelog
 
 import (

--- a/tools/cli/internal/changelog/merge_test.go
+++ b/tools/cli/internal/changelog/merge_test.go
@@ -474,7 +474,7 @@ func TestSortChangelog(t *testing.T) {
 
 func TestMergeChangelogTwoVersionsWithDeprecations(t *testing.T) {
 	// arrange
-	baseChangelog, err := NewChangelogEntries("../../test/data/changelog/changelog.json")
+	baseChangelog, err := newEntriesFromPath("../../test/data/changelog/changelog.json")
 	require.NoError(t, err)
 
 	lastChangelogRunDate := baseChangelog[0].Date
@@ -535,32 +535,36 @@ func TestMergeChangelogTwoVersionsWithDeprecations(t *testing.T) {
 		},
 	}
 
-	changelogMetadataFirstVersion := &Metadata{
-		Base: &load.SpecInfo{
-			Version: firstVersion,
+	changelogStruct := &Changelog{
+		BaseMetadata: &Metadata{
+			RunDate:       runDate,
+			ActiveVersion: firstVersion,
 		},
-		Revision: &load.SpecInfo{
-			Version: firstVersion,
+		RevisionMetadata: &Metadata{
+			RunDate:       runDate,
+			ActiveVersion: firstVersion,
 		},
-		BaseChangelog: baseChangelog,
 		RunDate:       runDate,
+		BaseChangelog: baseChangelog,
 	}
 
-	changelog, err := changelogMetadataFirstVersion.mergeChangelog(changeTypeFirstVersion, changesFirstVersion, endpointsConfig)
+	changelog, err := changelogStruct.mergeChangelog(changeTypeFirstVersion, changesFirstVersion, endpointsConfig)
 	require.NoError(t, err)
 
-	changelogMetadataSecondVersion := &Metadata{
-		Base: &load.SpecInfo{
-			Version: firstVersion,
+	changelogStruct = &Changelog{
+		BaseMetadata: &Metadata{
+			RunDate:       runDate,
+			ActiveVersion: firstVersion,
 		},
-		Revision: &load.SpecInfo{
-			Version: secondVersion,
+		RevisionMetadata: &Metadata{
+			RunDate:       runDate,
+			ActiveVersion: secondVersion,
 		},
-		BaseChangelog: changelog,
 		RunDate:       runDate,
+		BaseChangelog: changelog,
 	}
 
-	changelog, err = changelogMetadataSecondVersion.mergeChangelog(changeTypeSecondVersion, changesSecondVersion, endpointsConfig)
+	changelog, err = changelogStruct.mergeChangelog(changeTypeSecondVersion, changesSecondVersion, endpointsConfig)
 	require.NoError(t, err)
 
 	require.Len(t, changelog, 2, fmt.Sprintf("merged changelog should have 2 entries, got %d", len(changelog)))

--- a/tools/cli/internal/changelog/outputfilter/operationconfig.go
+++ b/tools/cli/internal/changelog/outputfilter/operationconfig.go
@@ -72,6 +72,10 @@ func NewOperationConfigs(base, revision *load.SpecInfo) map[string]*OperationCon
 
 func newOperationConfigFromSpec(spec *load.SpecInfo) map[string]*OperationConfig {
 	endpointsConfigMap := make(map[string]*OperationConfig)
+	if spec == nil || spec.Spec == nil {
+		return nil
+	}
+
 	paths := spec.Spec.Paths
 	if paths == nil || paths.Len() == 0 {
 		return nil

--- a/tools/cli/internal/changelog/outputfilter/outputfilter.go
+++ b/tools/cli/internal/changelog/outputfilter/outputfilter.go
@@ -26,6 +26,7 @@ const lan = "en" // language for localized output
 
 type OasDiffEntry struct {
 	ID                string `json:"id"`
+	Date              string `json:"date"`
 	Text              string `json:"text"`
 	Level             int    `json:"level"`
 	Operation         string `json:"operation,omitempty"`

--- a/tools/cli/internal/changelog/sunset.go
+++ b/tools/cli/internal/changelog/sunset.go
@@ -1,0 +1,118 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
+	"github.com/tufin/oasdiff/checker"
+)
+
+const endpointRemovedCode = "endpoint-removed"
+
+// newOasDiffEntriesFromSunsetEndpoints searches for resource versions marked for removal between
+// previous changelog run date and current date (inclusive), and that not already included in the changelog.
+// Returns a list of sunset endpoints with the same format as oasdiff results.
+func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
+	confs map[string]*outputfilter.OperationConfigs, 
+	version string) ([]*outputfilter.OasDiffEntry, error) {
+	changes := make([]*outputfilter.OasDiffEntry, 0)
+	for operationID, config := range confs {
+		markedForRemoval, err := isResourceVersionMarkedForRemoval(config, m.PreviousRunDate, m.RunDate)
+		if err != nil {
+			return nil, err
+		}
+
+		if  ! markedForRemoval{
+			continue
+		}
+
+		// Avoid adding duplicates in the changelog
+		if findChangelogEntry(m.BaseChangelog, config.Revision.Sunset, operationID, version, endpointRemovedCode) == nil {
+			changes = append(changes, &outputfilter.OasDiffEntry{
+				Date:        config.Revision.Sunset,
+				ID:          endpointRemovedCode,
+				Text:        "endpoint removed",
+				Level:       int(checker.ERR),
+				Operation:   config.Revision.HTTPMethod,
+				OperationID: operationID,
+				Path:        config.Revision.Path,
+			})
+		}
+	}
+
+	printSunsetLogChanges(changes, version, m.PreviousRunDate, m.RunDate)
+	return changes, nil
+}
+
+
+
+// isResourceVersionMarkedForRemoval checks if a resource sunset is marked for removal between previousRunDate and runDate.
+func isResourceVersionMarkedForRemoval(config *outputfilter.OperationConfigs, previousRunDate, runDate string) (bool, error) {
+	if config == nil || config.Revision == nil {
+		return false, nil
+	}
+
+	if config.Revision == nil || config.Revision.Sunset == "" {
+		return false, nil
+	}
+
+	return isEntryDateBetween(config.Revision.Sunset, previousRunDate, runDate)
+}
+
+func isEntryDateBetween(entryDateString, startDateString, endDateString string) (bool, error) {
+	startDate, err := newDateFromString(startDateString)
+    if err != nil {
+        return false, err
+    }
+	endDate, err := newDateFromString(endDateString)
+	if err != nil {
+		return false, err
+	}
+
+	entryDate, err := newDateFromString(entryDateString)
+	if err != nil {
+		return false, err
+	}
+
+	return  (entryDate.After(startDate) || entryDate.Equal(startDate)) && 
+	(entryDate.Before(endDate)|| entryDate.Equal(endDate)), nil
+}
+
+
+func newDateFromString(dateString string) (time.Time, error) {
+	return time.Parse("2006-01-02", dateString)
+}
+
+func printSunsetLogChanges(changes []*outputfilter.OasDiffEntry, version, previousRunDate, runDate string) {
+	if len(changes) == 0 {
+		log.Printf("No endpoints marked for removal between [%s, %s]\n", previousRunDate, runDate)
+		return
+	}
+
+	log.Printf("Detected %d v%s endpoints marked for removal between [%s, %s]\n  - %s",
+		len(changes), version, previousRunDate, runDate,
+		strings.Join(func() []string {
+			var result []string
+			for _, c := range changes {
+				result = append(result, fmt.Sprintf("%s %s %s", c.OperationID, c.Operation, c.Path))
+			}
+			return result
+		}(), "\n  - "))
+}

--- a/tools/cli/internal/changelog/sunset.go
+++ b/tools/cli/internal/changelog/sunset.go
@@ -29,12 +29,12 @@ const endpointRemovedCode = "endpoint-removed"
 // newOasDiffEntriesFromSunsetEndpoints searches for resource versions marked for removal between
 // previous changelog run date and current date (inclusive), and that not already included in the changelog.
 // Returns a list of sunset endpoints with the same format as oasdiff results.
-func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
+func (m *Changelog) newOasDiffEntriesFromSunsetEndpoints(
 	confs map[string]*outputfilter.OperationConfigs,
 	version string) ([]*outputfilter.OasDiffEntry, error) {
 	changes := make([]*outputfilter.OasDiffEntry, 0)
 	for operationID, config := range confs {
-		markedForRemoval, err := isResourceVersionMarkedForRemoval(config, m.PreviousRunDate, m.RunDate)
+		markedForRemoval, err := isResourceVersionMarkedForRemoval(config, m.BaseMetadata.RunDate, m.RevisionMetadata.RunDate)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +57,7 @@ func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
 		}
 	}
 
-	printSunsetLogChanges(changes, version, m.PreviousRunDate, m.RunDate)
+	printSunsetLogChanges(changes, version, m.BaseMetadata.RunDate, m.RevisionMetadata.RunDate)
 	return changes, nil
 }
 

--- a/tools/cli/internal/changelog/sunset.go
+++ b/tools/cli/internal/changelog/sunset.go
@@ -30,7 +30,7 @@ const endpointRemovedCode = "endpoint-removed"
 // previous changelog run date and current date (inclusive), and that not already included in the changelog.
 // Returns a list of sunset endpoints with the same format as oasdiff results.
 func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
-	confs map[string]*outputfilter.OperationConfigs, 
+	confs map[string]*outputfilter.OperationConfigs,
 	version string) ([]*outputfilter.OasDiffEntry, error) {
 	changes := make([]*outputfilter.OasDiffEntry, 0)
 	for operationID, config := range confs {
@@ -39,7 +39,7 @@ func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
 			return nil, err
 		}
 
-		if  ! markedForRemoval{
+		if !markedForRemoval {
 			continue
 		}
 
@@ -61,8 +61,6 @@ func (m *Metadata) newOasDiffEntriesFromSunsetEndpoints(
 	return changes, nil
 }
 
-
-
 // isResourceVersionMarkedForRemoval checks if a resource sunset is marked for removal between previousRunDate and runDate.
 func isResourceVersionMarkedForRemoval(config *outputfilter.OperationConfigs, previousRunDate, runDate string) (bool, error) {
 	if config == nil || config.Revision == nil {
@@ -78,9 +76,9 @@ func isResourceVersionMarkedForRemoval(config *outputfilter.OperationConfigs, pr
 
 func isEntryDateBetween(entryDateString, startDateString, endDateString string) (bool, error) {
 	startDate, err := newDateFromString(startDateString)
-    if err != nil {
-        return false, err
-    }
+	if err != nil {
+		return false, err
+	}
 	endDate, err := newDateFromString(endDateString)
 	if err != nil {
 		return false, err
@@ -91,10 +89,9 @@ func isEntryDateBetween(entryDateString, startDateString, endDateString string) 
 		return false, err
 	}
 
-	return  (entryDate.After(startDate) || entryDate.Equal(startDate)) && 
-	(entryDate.Before(endDate)|| entryDate.Equal(endDate)), nil
+	return (entryDate.After(startDate) || entryDate.Equal(startDate)) &&
+		(entryDate.Before(endDate) || entryDate.Equal(endDate)), nil
 }
-
 
 func newDateFromString(dateString string) (time.Time, error) {
 	return time.Parse("2006-01-02", dateString)

--- a/tools/cli/internal/changelog/sunset_test.go
+++ b/tools/cli/internal/changelog/sunset_test.go
@@ -121,13 +121,13 @@ func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
 
 	expectedChanges := []*outputfilter.OasDiffEntry{
 		{
-			Date: 	  runDate,
-			ID: 		"endpoint-removed",
-			Level: 		3,
-			Operation:  "GET",
+			Date:        runDate,
+			ID:          "endpoint-removed",
+			Level:       3,
+			Operation:   "GET",
 			OperationID: "listStreamInstances",
-			Path: 	  "/api/atlas/v2/groups/{id}/streams",
-			Text: 	  "endpoint removed",
+			Path:        "/api/atlas/v2/groups/{id}/streams",
+			Text:        "endpoint removed",
 		},
 	}
 

--- a/tools/cli/internal/changelog/sunset_test.go
+++ b/tools/cli/internal/changelog/sunset_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tufin/oasdiff/load"
 )
 
 func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
@@ -28,7 +27,7 @@ func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
 	runDate := "2023-07-12"
 	previousVersion := "2023-01-01"
 	version := "2023-02-01"
-	changelog := []*Entry{
+	baseChangelog := []*Entry{
 		{
 			Date: previousRunDate,
 			Paths: []*Path{
@@ -131,19 +130,20 @@ func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
 		},
 	}
 
-	changelogMetadata := &Metadata{
-		Base: &load.SpecInfo{
-			Version: version,
+	changelog := &Changelog{
+		BaseMetadata: &Metadata{
+			RunDate:       previousRunDate,
+			ActiveVersion: version,
 		},
-		Revision: &load.SpecInfo{
-			Version: version,
+		RevisionMetadata: &Metadata{
+			RunDate:       runDate,
+			ActiveVersion: version,
 		},
-		BaseChangelog:   changelog,
-		RunDate:         runDate,
-		PreviousRunDate: previousRunDate,
+		RunDate:       runDate,
+		BaseChangelog: baseChangelog,
 	}
 
-	changes, err := changelogMetadata.newOasDiffEntriesFromSunsetEndpoints(endpointsConfig, version)
+	changes, err := changelog.newOasDiffEntriesFromSunsetEndpoints(endpointsConfig, version)
 
 	require.NoError(t, err)
 	require.NotNil(t, changes)

--- a/tools/cli/internal/changelog/sunset_test.go
+++ b/tools/cli/internal/changelog/sunset_test.go
@@ -1,0 +1,151 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package changelog
+
+import (
+	"testing"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tufin/oasdiff/load"
+)
+
+func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
+	previousRunDate := "2023-07-10"
+	runDate := "2023-07-12"
+	previousVersion := "2023-01-01"
+	version := "2023-02-01"
+	changelog := []*Entry{
+		{
+			Date: previousRunDate,
+			Paths: []*Path{
+				{
+					URI:         "/api/atlas/v2/groups/{id}/clusters",
+					HTTPMethod:  "POST",
+					OperationID: "createCluster",
+					Tag:         "Multi-Cloud Clusters",
+					Versions: []*Version{
+						{
+							Version:        version,
+							StabilityLevel: "stable",
+							ChangeType:     "remove",
+							Changes: []*Change{
+								{
+									Description:        "endpoint removed",
+									Code:               "endpoint-removed",
+									BackwardCompatible: true,
+								},
+							},
+						},
+					},
+				},
+				{
+					URI:         "/api/atlas/v2/groups/{id}/streams",
+					HTTPMethod:  "GET",
+					OperationID: "listStreamInstances",
+					Tag:         "Streams",
+					Versions: []*Version{
+						{
+							Version:        previousVersion,
+							StabilityLevel: "stable",
+							ChangeType:     "remove",
+							Changes: []*Change{
+								{
+									Description:        "endpoint removed",
+									Code:               "endpoint-removed",
+									BackwardCompatible: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	endpointsConfig := map[string]*outputfilter.OperationConfigs{
+		"createCluster": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:                   "/api/atlas/v2/groups/{id}/clusters",
+				HTTPMethod:             "POST",
+				Tag:                    "Multi-Cloud Clusters",
+				Sunset:                 previousRunDate,
+				ManualChangelogEntries: map[string]interface{}{},
+			},
+		},
+		"getCluster": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:                   "/api/atlas/v2/groups/{id}/clusters",
+				HTTPMethod:             "GET",
+				Tag:                    "Multi-Cloud Clusters",
+				Sunset:                 "",
+				ManualChangelogEntries: map[string]interface{}{},
+			},
+		},
+		"listStreamInstances": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:                   "/api/atlas/v2/groups/{id}/streams",
+				HTTPMethod:             "GET",
+				Tag:                    "Streams",
+				Sunset:                 runDate,
+				ManualChangelogEntries: map[string]interface{}{},
+			},
+		},
+		"getStreamInstance": {
+			Base: nil,
+			Revision: &outputfilter.OperationConfig{
+				Path:                   "/api/atlas/v2/groups/{id}/streams/{tenantName}",
+				HTTPMethod:             "GET",
+				Tag:                    "Streams",
+				Sunset:                 "2023-07-13",
+				ManualChangelogEntries: map[string]interface{}{},
+			},
+		},
+	}
+
+	expectedChanges := []*outputfilter.OasDiffEntry{
+		{
+			Date: 	  runDate,
+			ID: 		"endpoint-removed",
+			Level: 		3,
+			Operation:  "GET",
+			OperationID: "listStreamInstances",
+			Path: 	  "/api/atlas/v2/groups/{id}/streams",
+			Text: 	  "endpoint removed",
+		},
+	}
+
+	changelogMetadata := &Metadata{
+		Base: &load.SpecInfo{
+			Version: version,
+		},
+		Revision: &load.SpecInfo{
+			Version: version,
+		},
+		BaseChangelog:   changelog,
+		RunDate:         runDate,
+		PreviousRunDate: previousRunDate,
+	}
+
+	changes, err := changelogMetadata.newOasDiffEntriesFromSunsetEndpoints(endpointsConfig, version)
+
+	require.NoError(t, err)
+	require.NotNil(t, changes)
+	assert.Equal(t, expectedChanges, changes)
+}

--- a/tools/cli/internal/cli/changelog/create.go
+++ b/tools/cli/internal/cli/changelog/create.go
@@ -17,7 +17,6 @@ package changelog
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/mongodb/openapi/tools/cli/internal/changelog"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
@@ -35,39 +34,14 @@ type Opts struct {
 }
 
 func (o *Opts) Run() error {
-	baseChangelog, err := changelog.NewChangelogEntries(fmt.Sprintf("%s/%s", o.basePath, "changelog.json"))
-	if err != nil {
-		return err
-	}
-
-	fmt.Print("Printing current changelog\n")
-	for _, check := range baseChangelog {
-		base, jsonErr := json.MarshalIndent(*check, "", "  ")
-		if jsonErr != nil {
-			return jsonErr
-		}
-
-		fmt.Println(string(base))
-	}
-
-	previousRunDate := time.Now().AddDate(0, -1, -1).Format("2006-01-02")
-	metadata, err := changelog.NewMetadata(
-		fmt.Sprintf("%s/%s", o.basePath, "v2.json"),
-		fmt.Sprintf("%s/%s", o.revisionPath, "v2.json"),
-		previousRunDate,
-		o.exceptionsPaths, baseChangelog)
+	entries, err := changelog.NewEntries(o.basePath, o.revisionPath)
 
 	if err != nil {
 		return err
 	}
 
-	checks, err := metadata.NewChangelogFromOasDiff()
-	if err != nil {
-		return err
-	}
-
-	fmt.Print("Printing the checks\n")
-	for _, check := range checks {
+	fmt.Print("Printing the entries\n")
+	for _, check := range entries {
 		base, jsonErr := json.MarshalIndent(*check, "", "  ")
 		if jsonErr != nil {
 			return jsonErr

--- a/tools/cli/internal/cli/changelog/create.go
+++ b/tools/cli/internal/cli/changelog/create.go
@@ -17,6 +17,7 @@ package changelog
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/mongodb/openapi/tools/cli/internal/changelog"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
@@ -49,16 +50,18 @@ func (o *Opts) Run() error {
 		fmt.Println(string(base))
 	}
 
+	previousRunDate := time.Now().AddDate(0, -1, -1).Format("2006-01-02")
 	metadata, err := changelog.NewMetadata(
 		fmt.Sprintf("%s/%s", o.basePath, "v2.json"),
 		fmt.Sprintf("%s/%s", o.revisionPath, "v2.json"),
+		previousRunDate,
 		o.exceptionsPaths, baseChangelog)
 
 	if err != nil {
 		return err
 	}
 
-	checks, err := metadata.MergeChangelog()
+	checks, err := metadata.NewChangelogFromOasDiff()
 	if err != nil {
 		return err
 	}

--- a/tools/cli/internal/openapi/openapi3.go
+++ b/tools/cli/internal/openapi/openapi3.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/tufin/oasdiff/flatten/allof"
 	"github.com/tufin/oasdiff/load"
 )
 
@@ -72,13 +71,8 @@ func CreateNormalizedOpenAPISpecFromPath(path string) (*load.SpecInfo, error) {
 		return nil, err
 	}
 
-	flattenAllOfSpec, err := allof.MergeSpec(spec)
-	if err != nil {
-		return nil, err
-	}
-
 	return &load.SpecInfo{
-		Spec: flattenAllOfSpec,
+		Spec: spec,
 		Url:  path,
 	}, nil
 }


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-267021


This PR migrates the changeAll logic (`_generate_changelog`  in **generate_changelog.py**)  to foascli