### PR TITLE
CLOUDP-268216: Fix failing postman release run

### DIFF
--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -48,10 +48,27 @@ jobs:
           body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Transform Postman Collection 
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        id: transform
+        env:
+          BASE_URL: ${{ vars.ATLAS_PROD_BASE_URL }}
+        working-directory: ./tools/postman
+        run: |
+          make transform_collection
+
+      - name: Create Issue
+        if: ${{ failure() && steps.transform.outcome == 'failure' }}
+        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
+        with:
+          labels: failed-release
+          title: "Postman Release: `make transform_collection` command failed :scream_cat:"
+          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload Collection to Postman
         if: steps.check-cache.outputs.cache-hit != 'true'
         env:
-          BASE_URL: ${{ vars.ATLAS_PROD_BASE_URL }}
           POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
           WORKSPACE_ID: ${{ secrets.WORKSPACE_ID }}
         working-directory: ./tools/postman

--- a/tools/postman/Makefile
+++ b/tools/postman/Makefile
@@ -16,14 +16,14 @@ transform_collection:
 	./scripts/transform-for-api.sh
 
 .PHONY: upload_collection
-upload_collection: transform_collection
+upload_collection:
 	./scripts/upload-collection.sh
 
 .PHONY: build
 build: fetch_openapi convert_to_collection
 
 .PHONY: build_and_upload
-build_and_upload: build upload_collection
+build_and_upload: build transform_collection upload_collection
 
 .PHONY: fetch_forks
 fetch_forks: 

--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -36,7 +36,7 @@ collection_exists=$(jq '.collections | any(.name=="'"${current_collection_name}"
 if [  "$collection_exists" = "false" ]; then
   # Create new collection
   echo "Creating new remote collection ${current_collection_name}"
-  curl --show-error --fail --retry 5 --retry-connrefused --silent \
+  curl --show-error --fail --retry 5 --retry-connrefused --retry-on-http-error 400 --silent \
        --location "https://api.getpostman.com/collections?workspace=${WORKSPACE_ID}" \
        --header "Content-Type: application/json" \
        --header "X-API-Key: ${POSTMAN_API_KEY}" \
@@ -46,7 +46,7 @@ else
   # Find collection ID and update collection
   echo "Updating remote collection ${current_collection_name}"
   collection_id=$(jq -r '.collections | map(select(.name=="'"${current_collection_name}"'").id)[0]' "${COLLECTIONS_LIST_FILE}")
-  curl --show-error --fail --retry 5 --retry-connrefused --silent --request PUT \
+  curl --show-error --fail --retry 5 --retry-connrefused --retry-on-http-error 400 --silent --request PUT \
        --location "https://api.getpostman.com/collections/${collection_id}" \
        --header "Content-Type: application/json" \
        --header "X-API-Key: ${POSTMAN_API_KEY}" \


### PR DESCRIPTION
## Proposed changes

- Last [Postman Release workflow run failed](https://github.com/mongodb/openapi/actions/runs/10418257689/attempts/1)
  - It was caused by a 504 error into a 400 error upon retry
- Upon rerun of the workflow it succeeded without the OAS changing.
- Added retry on 400 error 
- Also separated transformation and upload into separate steps 

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-268216

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
