### PR TITLE
feat: add `x-xgen-sha` to the generated federated open api spec

### DIFF
--- a/.github/scripts/download_specs.sh
+++ b/.github/scripts/download_specs.sh
@@ -10,5 +10,9 @@ jq -c '.services[]' foas-metadata.json | while read -r service; do
 
     echo "Downloading the OpenAPI Spec for ${name} with sha ${sha}"
     aws s3 cp "s3://${S3_BUCKET}/openapi/oas/${name}/${sha}.json" "openapi-${name}.json"
+
+    if [[ "${name}" == "mms" ]]; then
+        echo "FOAS_SHA=${sha}" >> "${GITHUB_ENV:?}"
+    fi
 done
 

--- a/.github/scripts/generate_federated_spec.sh
+++ b/.github/scripts/generate_federated_spec.sh
@@ -8,6 +8,6 @@ service_array+=("-e" "openapi-${service}.json")
 done < <(jq -r '.services[] | select(.name != "mms") | .name' foas-metadata.json)
 
 echo "Running FOAS CLI merge command with the following services: " "${service_array[@]}"
-foascli merge -b openapi-mms.json "${service_array[@]}" -o openapi-foas.json -x -f json
-foascli merge -b openapi-mms.json "${service_array[@]}" -o openapi-foas.yaml -x -f yaml
+foascli merge -b openapi-mms.json "${service_array[@]}" -o openapi-foas.json -x -f json --sha "${FOAS_SHA}"
+foascli merge -b openapi-mms.json "${service_array[@]}" -o openapi-foas.yaml -x -f yaml --sha "${FOAS_SHA}"
 


### PR DESCRIPTION
## Proposed changes

This PR adds `x-xgen-sha` to the generated openapi spec. The release logic uses the mms deployed sha as `x-xgen-sha` for the FOAS.

I tested my changes in a fork: https://github.com/andreaangiolillo/openapi-test/pull/38/files