### PR TITLE
chore: Add spectral lint rule

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -156,6 +156,17 @@ rules:
         functionOptions:
           match: "^(dev|qa|stage|prod)(,(dev|qa|stage|prod))*$"
 
+  no-slash-before-custom-method:
+  description: "Custom methods (e.g., ':applyItem') should not be preceded by a '/'."
+  message: "The path '{{path}}' contains a '/' before a custom method. Custom methods should not start with a '/'."
+  severity: error
+  given: "$.paths"
+  then:
+    field: "@key"
+    function: pattern
+    functionOptions:
+      notMatch: "^/[^/]+/:[a-zA-Z]+$"
+
 overrides:
   - files: # load sample data has an issue with different path param names for different VERBS
       - "*.yaml#/paths/~1api~1atlas~1v1.0~1groups~1%7BgroupId%7D~1sampleDatasetLoad~1%7BsampleDatasetId%7D"

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -165,7 +165,7 @@ rules:
     field: "@key"
     function: pattern
     functionOptions:
-      notMatch: "^/[^/]+/:[a-zA-Z]+$"
+      notMatch: "/[^/]+/:[a-zA-Z]+$"
 
 overrides:
   - files: # load sample data has an issue with different path param names for different VERBS


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->
Add spectral lint to validate custom methods


Example:
```shell
INFO: Build completed successfully, 1 total action
Running spectral linter
6.11.1
 - linting /Users/bianca.lisle/workplace/mms/server/openapi/services/openapi-mms.yaml

/<redacted>/openapi-mms.yaml
 1640:69  error  no-slash-before-custom-method  Ensure that paths do not contain a '/' immediately before a custom method (e.g., ':applyItem').  paths./api/atlas/v2/orgs/{orgId}/invoices/{invoiceId}/lineItems/:search
```

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
