### PR TITLE
CLOUDP-269114: Change release postman trigger

### DIFF
--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -1,6 +1,20 @@
 name: Postman Release
 on:
   workflow_call:
+    inputs:
+      spectral_version:
+        description: 'Version of Spectral to use.'
+        required: true
+        type: string
+      atlas_prod_base_url:
+        description: 'Base URL of Atlas.'
+        required: true
+        type: string
+    secrets: # all secrets are passed explicitly in this workflow
+      postman_api_key:
+        required: true
+      workspace_id:
+        required: true
   workflow_dispatch:
 permissions:
   issues: write
@@ -35,7 +49,7 @@ jobs:
       - name: Transform Postman Collection 
         id: transform
         env:
-          BASE_URL: ${{ vars.ATLAS_PROD_BASE_URL }}
+          BASE_URL: ${{ inputs.atlas_prod_base_url }}
         working-directory: ./tools/postman
         run: |
           make transform_collection

--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -1,17 +1,12 @@
 name: Postman Release
 on:
-  pull_request:
-    branches: 
-      - main
-    types:
-      - closed
+  workflow_call:
   workflow_dispatch:
 permissions:
   issues: write
 
 jobs:
   release-postman:
-    if: ${{ github.head_ref == 'api-bot-update' && github.event.pull_request.merged }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -2,10 +2,6 @@ name: Postman Release
 on:
   workflow_call:
     inputs:
-      spectral_version:
-        description: 'Version of Spectral to use.'
-        required: true
-        type: string
       atlas_prod_base_url:
         description: 'Base URL of Atlas.'
         required: true
@@ -65,8 +61,8 @@ jobs:
 
       - name: Upload Collection to Postman
         env:
-          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
-          WORKSPACE_ID: ${{ secrets.WORKSPACE_ID }}
+          POSTMAN_API_KEY: ${{ secrets.postman_api_key }}
+          WORKSPACE_ID: ${{ secrets.postman_api_key }}
         working-directory: ./tools/postman
         run: |
           make upload_collection

--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Upload Collection to Postman
         env:
           POSTMAN_API_KEY: ${{ secrets.postman_api_key }}
-          WORKSPACE_ID: ${{ secrets.postman_api_key }}
+          WORKSPACE_ID: ${{ secrets.workspace_id }}
         working-directory: ./tools/postman
         run: |
           make upload_collection

--- a/.github/workflows/release-spec-runner.yml
+++ b/.github/workflows/release-spec-runner.yml
@@ -58,6 +58,8 @@ jobs:
         api_bot_pat: ${{ secrets.API_BOT_PAT }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+        postman_api_key: ${{ secrets.POSTMAN_API_KEY }}
+        workspace_id: ${{ secrets.WORKSPACE_ID }}
     with:
         aws_default_region: ${{ vars.AWS_DEFAULT_REGION}}
         aws_s3_bucket: ${{ vars.S3_BUCKET_PROD}}
@@ -65,3 +67,4 @@ jobs:
         branch: main
         spectral_version: ${{ vars.SPECTRAL_VERSION }}
         foascli_version: ${{ vars.FOASCLI_VERSION }}
+        atlas_prod_base_url: ${{ vars.ATLAS_PROD_BASE_URL }}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -162,7 +162,6 @@ jobs:
   
   release-postman:
       name: Release Postman
-      runs-on: ubuntu-latest
       needs: [release]
       if: ${{ inputs.env == 'Prod' && needs.release.outputs.changes_detected == 'true' }}
       uses: ./.github/workflows/release-postman.yml

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -163,7 +163,7 @@ jobs:
   release-postman:
       name: Release Postman
       needs: [release]
-      if: ${{ inputs.env == 'Prod' && needs.release.outputs.changes_detected == 'true' }}
+      if: ${{ inputs.env == 'prod' && needs.release.outputs.changes_detected == 'true' }}
       uses: ./.github/workflows/release-postman.yml
       secrets:
         postman_api_key: ${{ secrets.postman_api_key }}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -149,3 +149,7 @@ jobs:
             title: "(${{env.target_env}}) Release: the Commit Changes step failed :scream_cat:"
             body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
             token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Release Postman
+          if: ${{ inputs.env == 'Prod' && steps.commit.outputs.changes_detected == 'true' }}
+          uses: ./.github/workflows/release-postman.yml
+

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -169,5 +169,4 @@ jobs:
         postman_api_key: ${{ secrets.postman_api_key }}
         workspace_id: ${{ secrets.workspace_id }}
       with:
-        spectral_version: ${{ inputs.spectral_version }}
         atlas_prod_base_url: ${{ inputs.atlas_prod_base_url}}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -165,3 +165,4 @@ jobs:
             workspace_id: ${{ secrets.workspace_id }}
           with:
             spectral_version: ${{ inputs.spectral_version }}
+            atlas_prod_base_url: ${{ inputs.atlas_prod_base_url}}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -85,6 +85,8 @@ jobs:
       name: Release OpenAPI Spec
       runs-on: ubuntu-latest
       needs: [run-required-validations]
+      outputs:
+        changes_detected: ${{ steps.commit.outputs.changes_detected }}
       steps:
         - name: Checkout repository
           uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -157,12 +159,16 @@ jobs:
             title: "(${{env.target_env}}) Release: the Commit Changes step failed :scream_cat:"
             body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
             token: ${{ secrets.GITHUB_TOKEN }}
-        - name: Release Postman
-          if: ${{ inputs.env == 'Prod' && steps.commit.outputs.changes_detected == 'true' }}
-          uses: ./.github/workflows/release-postman.yml
-          secrets:
-            postman_api_key: ${{ secrets.postman_api_key }}
-            workspace_id: ${{ secrets.workspace_id }}
-          with:
-            spectral_version: ${{ inputs.spectral_version }}
-            atlas_prod_base_url: ${{ inputs.atlas_prod_base_url}}
+  
+  release-postman:
+      name: Release Postman
+      runs-on: ubuntu-latest
+      needs: [release]
+      if: ${{ inputs.env == 'Prod' && needs.release.outputs.changes_detected == 'true' }}
+      uses: ./.github/workflows/release-postman.yml
+      secrets:
+        postman_api_key: ${{ secrets.postman_api_key }}
+        workspace_id: ${{ secrets.workspace_id }}
+      with:
+        spectral_version: ${{ inputs.spectral_version }}
+        atlas_prod_base_url: ${{ inputs.atlas_prod_base_url}}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -26,6 +26,10 @@ on:
         description: 'Version of FOASCLI to use.'
         required: true
         type: string
+      atlas_prod_base_url:
+        description: 'Base URL of Atlas.'
+        required: false
+        type: string
     secrets: # all secrets are passed explicitly in this workflow
       api_bot_pat:
         required: true
@@ -33,7 +37,11 @@ on:
         required: true
       aws_secret_access_key:
         required: true
-      
+      postman_api_key:
+        required: false
+      workspace_id:
+        required: false
+
 permissions:
   contents: write
   issues: write
@@ -152,4 +160,8 @@ jobs:
         - name: Release Postman
           if: ${{ inputs.env == 'Prod' && steps.commit.outputs.changes_detected == 'true' }}
           uses: ./.github/workflows/release-postman.yml
-
+          secrets:
+            postman_api_key: ${{ secrets.postman_api_key }}
+            workspace_id: ${{ secrets.workspace_id }}
+          with:
+            spectral_version: ${{ inputs.spectral_version }}

--- a/tools/postman/collection-description.md
+++ b/tools/postman/collection-description.md
@@ -13,3 +13,5 @@ Once you have your cluster up and running, follow [this guide](https://www.mongo
 - private API key as the value for a key named  \`mongodb-private-api-key\`
 
 You can now explore the various endpoints. For each endpoint, edit the query and path variables such as group ID and organization ID. For some requests, like POST requests, editing the body of the request is also required. 
+
+For more details, you can follow along with the [Configuring Atlas in Postman With the Atlas Administration API](https://www.mongodb.com/developer/products/atlas/admin-api-postman/) blog.


### PR DESCRIPTION
## Proposed changes

- Change release postman workflow from being triggered on Prod release PR merge to instead be called by the release openapi workflow

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-269114

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works


<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
