### PR TITLE
fix: update `changelog metadata create` command to save the correct struct

### DIFF
--- a/tools/cli/internal/cli/changelog/metadata/create.go
+++ b/tools/cli/internal/cli/changelog/metadata/create.go
@@ -40,17 +40,18 @@ func (o *Opts) Run() error {
 		o.runDate = time.Now().Format("2006-01-02")
 	}
 
-	metadataBytes, err := json.MarshalIndent(*o.newMetadata(), "", "  ")
-	if err != nil {
-		return err
-	}
-
+	metadata := *o.newMetadata()
 	if o.outputPath == "" {
+		metadataBytes, err := json.MarshalIndent(metadata, "", "  ")
+		if err != nil {
+			return err
+		}
+
 		fmt.Println(string(metadataBytes))
 		return nil
 	}
 
-	return openapi.SaveToFile(o.outputPath, openapi.JSON, *o.newMetadata(), o.fs)
+	return openapi.SaveToFile(o.outputPath, openapi.JSON, metadata, o.fs)
 }
 
 func (o *Opts) newMetadata() *changelog.Metadata {

--- a/tools/cli/internal/cli/changelog/metadata/create.go
+++ b/tools/cli/internal/cli/changelog/metadata/create.go
@@ -50,7 +50,7 @@ func (o *Opts) Run() error {
 		return nil
 	}
 
-	return openapi.SaveToFile(o.outputPath, openapi.JSON, metadataBytes, o.fs)
+	return openapi.SaveToFile(o.outputPath, openapi.JSON, *o.newMetadata(), o.fs)
 }
 
 func (o *Opts) newMetadata() *changelog.Metadata {


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug with the `changelog metadata create` command where the command was saving bytes into the output file when the -o flag was used.

I tested my changes locally.

### Bug
```bash
 ./bin/foascli changelog metadata create --sha e624d716e86f6910757b60cefdf3aa3181582d38 --versions=2024-01-01,2024-09-22 --output metadata.json
2024/08/22 12:06:24
File was saved in 'metadata.json'.

 cat metadata.json  
"ewogICJydW5EYXRlIjogIjIwMjQtMDgtMjIiLAogICJzcGVjUmV2aXNpb24iOiAiZTYyNGQ3MTZlODZmNjkxMDc1N2I2MGNlZmRmM2FhMzE4MTU4MmQzOCIsCiAgInNwZWNSZXZpc2lvblNob3J0IjogImU2MjRkNzE2ZTg2IiwKICAidmVyc2lvbnMiOiBbCiAgICAiMjAyNC0wMS0wMSIsCiAgICAiMjAyNC0wOS0yMiIKICBdCn0="
```

### With PR changes:
```bash
 ./bin/foascli changelog metadata create --sha e624d716e86f6910757b60cefdf3aa3181582d38 --versions=2024-01-01,2024-09-22 --output metadata.json
2024/08/22 12:06:24
File was saved in 'metadata.json'.

 cat metadata.json                                                                                                                         
{
  "runDate": "2024-08-22",
  "specRevision": "e624d716e86f6910757b60cefdf3aa3181582d38",
  "specRevisionShort": "e624d716e86",
  "versions": [
    "2024-01-01",
    "2024-09-22"
  ]
}
```