### PR TITLE
CLOUDP-269500: Add logic to create jira ticket when we file an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+---
+title: "({{env.TARGET_ENV}}) The {{env.RELEASE_NAME}} Release has failed. :scream_cat:"
+labels: failed-release
+---
+See https://github.com/{{tools.context.issue}}/actions/runs/{{env.GITHUB_RUN_ID}}
+

--- a/.github/scripts/create_jira_ticket.sh
+++ b/.github/scripts/create_jira_ticket.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -eou pipefail
+
+json_response=$(curl --request POST \
+--url 'https://jira.mongodb.org/rest/api/2/issue' \
+--header 'Authorization: Bearer '"${JIRA_API_TOKEN:?}" \
+--header 'Accept: application/json' \
+--header 'Content-Type: application/json' \
+--data '{
+    "fields": {
+        "project": {
+            "id": "10984"
+        },
+        "summary": "('"${TARGET_ENV}"') The mongodb/openapi release has failed",
+        "issuetype": {
+            "id": "12"
+        },
+        "customfield_12751": [{
+                "id": "22223"
+        }],                  
+        "description": "The release process in [mongodb/openapi|https://github.com/mongodb/openapi] has failed. Please, look at the [issue-'"${ISSUE_ID}"'|https://github.com/mongodb/openapi/issues/'"${ISSUE_ID}"'] for more details.",
+        "components": [
+            {
+                "id": "35986"
+            }
+        ]
+    }
+}')
+
+echo "Response: ${json_response}"
+
+JIRA_TICKET_ID=$(echo "${json_response}" | jq -r '.key')
+
+echo "The following JIRA ticket has been created: ${JIRA_TICKET_ID}"
+echo "jira-ticket-id=${JIRA_TICKET_ID}" >> "${GITHUB_OUTPUT}"

--- a/.github/scripts/create_jira_ticket.sh
+++ b/.github/scripts/create_jira_ticket.sh
@@ -11,14 +11,14 @@ json_response=$(curl --request POST \
         "project": {
             "id": "10984"
         },
-        "summary": "('"${TARGET_ENV}"') The mongodb/openapi release has failed",
+        "summary": "('"${TARGET_ENV:?}"') The '"${RELEASE_NAME:?}"' release has failed",
         "issuetype": {
             "id": "12"
         },
         "customfield_12751": [{
                 "id": "22223"
         }],                  
-        "description": "The release process in [mongodb/openapi|https://github.com/mongodb/openapi] has failed. Please, look at the [issue-'"${ISSUE_ID}"'|https://github.com/mongodb/openapi/issues/'"${ISSUE_ID}"'] for more details.",
+        "description": "The release process "'"${RELEASE_NAME:?}"'" in [mongodb/openapi|https://github.com/mongodb/openapi] has failed. Please, look at the [issue-'"${ISSUE_ID:?}"'|https://github.com/mongodb/openapi/issues/'"${ISSUE_ID}"'] for more details.",
         "components": [
             {
                 "id": "35986"

--- a/.github/scripts/create_jira_ticket.sh
+++ b/.github/scripts/create_jira_ticket.sh
@@ -18,7 +18,7 @@ json_response=$(curl --request POST \
         "customfield_12751": [{
                 "id": "22223"
         }],                  
-        "description": "The release process "'"${RELEASE_NAME:?}"'" in [mongodb/openapi|https://github.com/mongodb/openapi] has failed. Please, look at the [issue-'"${ISSUE_ID:?}"'|https://github.com/mongodb/openapi/issues/'"${ISSUE_ID}"'] for more details.",
+        "description": "The release process '"${RELEASE_NAME:?}"' in [mongodb/openapi|https://github.com/mongodb/openapi] has failed. Please, look at the [issue-'"${ISSUE_ID:?}"'|https://github.com/mongodb/openapi/issues/'"${ISSUE_ID}"'] for more details.",
         "components": [
             {
                 "id": "35986"

--- a/.github/workflows/failure-handler.yml
+++ b/.github/workflows/failure-handler.yml
@@ -61,7 +61,8 @@ jobs:
               if: ${{ steps.create-issue.outputs.number != null }}
               id: create-jira-ticket
               env:
-                TARGET_ENV: "prod"
+                TARGET_ENV: ${{ inputs.env }}
+                RELEASE_NAME: ${{ inputs.release_name }}
                 JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
                 ISSUE_ID: ${{ steps.create-issue.outputs.number }}
               run: .github/scripts/create_jira_ticket.sh

--- a/.github/workflows/failure-handler.yml
+++ b/.github/workflows/failure-handler.yml
@@ -39,7 +39,7 @@ jobs:
               run: |
                 query="(${TARGET_ENV}}) The ${RELEASE_NAME} Release has failed."
                 number_issue=$(gh search issues "${query}" --repo "${REPO}" --state open --label failed-release --json title | jq length)
-                
+                echo "number_issue=${number_issue}"
                 echo "found-issue=false" >> "${GITHUB_OUTPUT}"
                 if [ "${number_issue}" -gt 0 ]; then
                     echo "An issue already exists. Stopping execution."
@@ -55,7 +55,7 @@ jobs:
                 GITHUB_RUN_ID: ${{ github.run_id }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 update_existing: false
-                with:
+              with:
                 filename: .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
             - name: Create JIRA Ticket
               if: ${{ steps.create-issue.outputs.number != null }}

--- a/.github/workflows/failure-handler.yml
+++ b/.github/workflows/failure-handler.yml
@@ -19,7 +19,7 @@ permissions:
   issues: write
 
 jobs:
-    notify:
+    failure-handler:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout repository

--- a/.github/workflows/failure-handler.yml
+++ b/.github/workflows/failure-handler.yml
@@ -73,6 +73,3 @@ jobs:
                 ISSUE_URL: ${{ steps.create-issue.outputs.url }}
               run: |
                 gh issue comment ${{ env.ISSUE_URL }} -b "The ticket [${{env.JIRA_TICKET_ID}}](https://jira.mongodb.org/browse/${{env.JIRA_TICKET_ID}}) was created for internal tracking."
-
-
-

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,78 @@
+name: 'Handle failures in the workflow'
+on:
+  workflow_call:
+    inputs:
+      env:
+        description: 'Environment to generate the OpenAPI Spec for.'
+        required: true
+        type: string
+      release_name:
+        description: 'Name of the release.'
+        required: true
+        type: string
+    secrets: # all secrets are passed explicitly in this workflow
+      jira_api_token:
+        required: true
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+    notify:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+              with:
+                sparse-checkout: |
+                    .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
+                    .github/scripts/create_jira_ticket.sh
+
+            - name: Check if an issue already exists 
+              id: check-issue
+              env: 
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                TARGET_ENV: ${{ inputs.env }}
+                RELEASE_NAME: ${{ inputs.release_name }}
+                REPO: ${{ github.repository }}
+              run: |
+                query="(${TARGET_ENV}}) The ${RELEASE_NAME} Release has failed."
+                number_issue=$(gh search issues "${query}" --repo "${REPO}" --state open --label failed-release --json title | jq length)
+                
+                echo "found-issue=false" >> "${GITHUB_OUTPUT}"
+                if [ "${number_issue}" -gt 0 ]; then
+                    echo "An issue already exists. Stopping execution."
+                    echo "found-issue=true" >> "${GITHUB_OUTPUT}"
+                fi
+            - name: Create Issue # Create an issue in the repo if the release fails
+              if: ${{ steps.check-issue.outputs.found-issue == 'false' }}
+              id: create-issue
+              uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
+              env:
+                TARGET_ENV: ${{ inputs.env }}
+                RELEASE_NAME: ${{ inputs.release_name }}
+                GITHUB_RUN_ID: ${{ github.run_id }}
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                update_existing: false
+                with:
+                filename: .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
+            - name: Create JIRA Ticket
+              if: ${{ steps.create-issue.outputs.number != null }}
+              id: create-jira-ticket
+              env:
+                TARGET_ENV: "prod"
+                JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
+                ISSUE_ID: ${{ steps.create-issue.outputs.number }}
+              run: .github/scripts/create_jira_ticket.sh
+            - name: Add comment to GH Issue
+              if: ${{ steps.create-issue.outputs.number != null }}
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
+                ISSUE_URL: ${{ steps.create-issue.outputs.url }}
+              run: |
+                gh issue comment ${{ env.ISSUE_URL }} -b "The ticket [${{env.JIRA_TICKET_ID}}](https://jira.mongodb.org/browse/${{env.JIRA_TICKET_ID}}) was created for internal tracking."
+
+
+

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -119,13 +119,3 @@ jobs:
             commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
             branch: ${{env.target_branch}}
             file_pattern: "changelog/*"
-        # - name: Create Issue To enable in CLOUDP-269500
-        #   if: ${{ failure() }}
-        #   uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
-        #   env:
-        #     target_env: ${{ inputs.env }}
-        #   with:
-        #     labels: failed-release
-        #     title: "(${{env.target_env}}) The API Changelog Release has failed. :scream_cat:"
-        #     body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        #     token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -72,61 +72,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  notify: 
-    runs-on: ubuntu-latest
+  failure-handler: 
+    name: Failure Handler
     needs: [ release ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          token: ${{secrets.api_bot_pat}}
-          sparse-checkout: |
-            .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
-            .github/scripts/create_jira_ticket.sh
-
-      - name: Check if an issue already exists 
-        id: check-issue
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_ENV: "prod"
-          RELEASE_NAME: "FOASCLI"
-          REPO: ${{ github.repository }}
-        run: |
-          query="(${TARGET_ENV}}) The ${RELEASE_NAME} Release has failed."
-          number_issue=$(gh search issues "${query}" --repo "${REPO}" --state open --label failed-release --json title | jq length)
-          
-          echo "found-issue=false" >> "${GITHUB_OUTPUT}"
-          if [ "${number_issue}" -gt 0 ]; then
-            echo "An issue already exists. Stopping execution."
-            echo "found-issue=true" >> "${GITHUB_OUTPUT}"
-          fi
-      - name: Create Issue # Create an issue in the repo if the release fails
-        if: ${{ steps.check-issue.outputs.found-issue == 'false' }}
-        id: create-issue
-        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
-        env:
-          TARGET_ENV: "prod"
-          RELEASE_NAME: "FOASCLI"
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          update_existing: false
-        with:
-          filename: .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
-      - name: Create JIRA Ticket
-        if: ${{ steps.create-issue.outputs.number != null }}
-        id: create-jira-ticket
-        env:
-          TARGET_ENV: "prod"
-          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-          ISSUE_ID: ${{ steps.create-issue.outputs.number }}
-        run: .github/scripts/create_jira_ticket.sh
-      - name: Add comment to GH Issue
-        if: ${{ steps.create-issue.outputs.number != null }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
-          ISSUE_URL: ${{ steps.create-issue.outputs.url }}
-        run: |
-          gh issue comment ${{ env.ISSUE_URL }} -b "The ticket [${{env.JIRA_TICKET_ID}}](https://jira.mongodb.org/browse/${{env.JIRA_TICKET_ID}}) was created for internal tracking."
-
+    uses: ./.github/workflows/issue.yml
+    with:
+      env: "prod"
+      release_name: "FOASCLI"
+    secrets:
+      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -76,7 +76,7 @@ jobs:
     name: Failure Handler
     needs: [ release ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    uses: ./.github/workflows/issue.yml
+    uses: ./.github/workflows/failure-handler.yml
     with:
       env: "prod"
       release_name: "FOASCLI"

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -37,15 +37,6 @@ jobs:
           commit_sha: ${{ steps.get-sha.outputs.sha }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.PASSPHRASE }}
-      - name: Create Issue
-        if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: failed-release
-          title: "Releasing foascli v${{ inputs.version_number }} failed at the tag creation step :scream_cat:"
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   run-tests:
     needs: [ create-tag ]
@@ -80,12 +71,62 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Issue
-        if: ${{ failure() }}
-        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
+
+  notify: 
+    runs-on: ubuntu-latest
+    needs: [ release ]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          token: ${{secrets.api_bot_pat}}
+          sparse-checkout: |
+            .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
+            .github/scripts/create_jira_ticket.sh
+
+      - name: Check if an issue already exists 
+        id: check-issue
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_ENV: "prod"
+          RELEASE_NAME: "FOASCLI"
+          REPO: ${{ github.repository }}
+        run: |
+          query="(${TARGET_ENV}}) The ${RELEASE_NAME} Release has failed."
+          number_issue=$(gh search issues "${query}" --repo "${REPO}" --state open --label failed-release --json title | jq length)
+          
+          echo "found-issue=false" >> "${GITHUB_OUTPUT}"
+          if [ "${number_issue}" -gt 0 ]; then
+            echo "An issue already exists. Stopping execution."
+            echo "found-issue=true" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Create Issue # Create an issue in the repo if the release fails
+        if: ${{ steps.check-issue.outputs.found-issue == 'false' }}
+        id: create-issue
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
+        env:
+          TARGET_ENV: "prod"
+          RELEASE_NAME: "FOASCLI"
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          update_existing: false
+        with:
+          filename: .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
+      - name: Create JIRA Ticket
+        if: ${{ steps.create-issue.outputs.number != null }}
+        id: create-jira-ticket
+        env:
+          TARGET_ENV: "prod"
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          ISSUE_ID: ${{ steps.create-issue.outputs.number }}
+        run: .github/scripts/create_jira_ticket.sh
+      - name: Add comment to GH Issue
+        if: ${{ steps.create-issue.outputs.number != null }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          labels: failed-release
-          title: "Releasing foascli ${{ inputs.version_number }} failed at the goreleaser step :scream_cat:"
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
+          ISSUE_URL: ${{ steps.create-issue.outputs.url }}
+        run: |
+          gh issue comment ${{ env.ISSUE_URL }} -b "The ticket [${{env.JIRA_TICKET_ID}}](https://jira.mongodb.org/browse/${{env.JIRA_TICKET_ID}}) was created for internal tracking."
+

--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -33,15 +33,6 @@ jobs:
         run: |
           make convert_to_collection
 
-      - name: Create Issue
-        if: ${{ failure() && steps.convert.outcome == 'failure' }}
-        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
-        with:
-          labels: failed-release
-          title: "Postman Release: `make convert_to_collection` command failed :scream_cat:"
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Transform Postman Collection 
         id: transform
         env:
@@ -49,15 +40,6 @@ jobs:
         working-directory: ./tools/postman
         run: |
           make transform_collection
-
-      - name: Create Issue
-        if: ${{ failure() && steps.transform.outcome == 'failure' }}
-        uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
-        with:
-          labels: failed-release
-          title: "Postman Release: `make transform_collection` command failed :scream_cat:"
-          body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Collection to Postman
         env:

--- a/.github/workflows/release-spec-runner.yml
+++ b/.github/workflows/release-spec-runner.yml
@@ -52,6 +52,7 @@ jobs:
       api_bot_pat: ${{ secrets.API_BOT_PAT }}
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
+      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
     with:
       aws_default_region: ${{ vars.AWS_DEFAULT_REGION}}
       aws_s3_bucket: ${{ vars.S3_BUCKET_DEV}}
@@ -69,6 +70,7 @@ jobs:
         api_bot_pat: ${{ secrets.API_BOT_PAT }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_QA }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_QA }}
+        jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
     with:
         aws_default_region: ${{ vars.AWS_DEFAULT_REGION}}
         aws_s3_bucket: ${{ vars.S3_BUCKET_QA}}
@@ -86,6 +88,7 @@ jobs:
         api_bot_pat: ${{ secrets.API_BOT_PAT }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+        jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
     with:
         aws_default_region: ${{ vars.AWS_DEFAULT_REGION}}
         aws_s3_bucket: ${{ vars.S3_BUCKET_STAGING}}
@@ -105,6 +108,7 @@ jobs:
         aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
         postman_api_key: ${{ secrets.POSTMAN_API_KEY }}
         workspace_id: ${{ secrets.WORKSPACE_ID }}
+        jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
     with:
         aws_default_region: ${{ vars.AWS_DEFAULT_REGION}}
         aws_s3_bucket: ${{ vars.S3_BUCKET_PROD}}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -120,8 +120,7 @@ jobs:
             run-id: ${{ github.run_id }}
             path: release-scripts
         - name: Add permissions to execute scripts
-          run: |
-            chmod +x release-scripts/*.sh
+          run: chmod +x release-scripts/*.sh
         - name: Install FOASCLI
           env:
             foascli_version: ${{ inputs.foascli_version }}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -182,7 +182,7 @@ jobs:
 
   failure-handler: 
     name: Failure Handler
-    needs: [ release ]
+    needs: [ release, release-postman, release-changelog ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/failure-handler.yml
     with:

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -41,6 +41,8 @@ on:
         required: false
       workspace_id:
         required: false
+      jira_api_token:
+        required: true
 
 permissions:
   contents: write
@@ -150,16 +152,6 @@ jobs:
             commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
             branch: ${{env.target_branch}}
             file_pattern: "openapi/*"
-        - name: Create Issue
-          if: ${{ failure() }}
-          uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd
-          env:
-            target_env: ${{ inputs.env }}
-          with:
-            labels: failed-release
-            title: "(${{env.target_env}}) The OpenAPI Release has failed. :scream_cat:"
-            body: See https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            token: ${{ secrets.GITHUB_TOKEN }}
   
   release-postman:
       name: Release Postman
@@ -187,3 +179,61 @@ jobs:
         env: ${{ inputs.env }}
         branch: ${{ inputs.branch }}
         foascli_version: ${{ inputs.foascli_version }}
+
+  notify: 
+    runs-on: ubuntu-latest
+    needs: [ release, release-postman, release-changelog ]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          token: ${{secrets.api_bot_pat}}
+          sparse-checkout: |
+            .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
+            .github/scripts/create_jira_ticket.sh
+
+      - name: Check if an issue already exists 
+        id: check-issue
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_ENV: ${{ inputs.env }}
+          RELEASE_NAME: "OpenAPI"
+          REPO: ${{ github.repository }}
+        run: |
+          query="(${TARGET_ENV}}) The ${RELEASE_NAME} Release has failed."
+          number_issue=$(gh search issues "${query}" --repo "${REPO}" --state open --label failed-release --json title | jq length)
+          
+          echo "found-issue=false" >> "${GITHUB_OUTPUT}"
+          if [ "${number_issue}" -gt 0 ]; then
+            echo "An issue already exists. Stopping execution."
+            echo "found-issue=true" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Create Issue # Create an issue in the repo if the release fails
+        if: ${{ steps.check-issue.outputs.found-issue == 'false' }}
+        id: create-issue
+        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
+        env:
+          TARGET_ENV: ${{ inputs.env }}
+          RELEASE_NAME: "OpenAPI"
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          update_existing: false
+        with:
+          filename: .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
+      - name: Create JIRA Ticket
+        if: ${{ steps.create-issue.outputs.number != null }}
+        id: create-jira-ticket
+        env:
+          TARGET_ENV: ${{ inputs.env }}
+          JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
+          ISSUE_ID: ${{ steps.create-issue.outputs.number }}
+        run: .github/scripts/create_jira_ticket.sh
+      - name: Add comment to GH Issue
+        if: ${{ steps.create-issue.outputs.number != null }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
+          ISSUE_URL: ${{ steps.create-issue.outputs.url }}
+        run: |
+          gh issue comment ${{ env.ISSUE_URL }} -b "The ticket [${{env.JIRA_TICKET_ID}}](https://jira.mongodb.org/browse/${{env.JIRA_TICKET_ID}}) was created for internal tracking."

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -184,7 +184,7 @@ jobs:
     name: Failure Handler
     needs: [ release ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    uses: ./.github/workflows/issue.yml
+    uses: ./.github/workflows/failure-handler.yml
     with:
       env: ${{ inputs.env }}
       release_name: "OpenAPI Spec"

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -180,60 +180,13 @@ jobs:
         branch: ${{ inputs.branch }}
         foascli_version: ${{ inputs.foascli_version }}
 
-  notify: 
-    runs-on: ubuntu-latest
-    needs: [ release, release-postman, release-changelog ]
+  failure-handler: 
+    name: Failure Handler
+    needs: [ release ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          token: ${{secrets.api_bot_pat}}
-          sparse-checkout: |
-            .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
-            .github/scripts/create_jira_ticket.sh
-
-      - name: Check if an issue already exists 
-        id: check-issue
-        env: 
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_ENV: ${{ inputs.env }}
-          RELEASE_NAME: "OpenAPI"
-          REPO: ${{ github.repository }}
-        run: |
-          query="(${TARGET_ENV}}) The ${RELEASE_NAME} Release has failed."
-          number_issue=$(gh search issues "${query}" --repo "${REPO}" --state open --label failed-release --json title | jq length)
-          
-          echo "found-issue=false" >> "${GITHUB_OUTPUT}"
-          if [ "${number_issue}" -gt 0 ]; then
-            echo "An issue already exists. Stopping execution."
-            echo "found-issue=true" >> "${GITHUB_OUTPUT}"
-          fi
-      - name: Create Issue # Create an issue in the repo if the release fails
-        if: ${{ steps.check-issue.outputs.found-issue == 'false' }}
-        id: create-issue
-        uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
-        env:
-          TARGET_ENV: ${{ inputs.env }}
-          RELEASE_NAME: "OpenAPI"
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          update_existing: false
-        with:
-          filename: .github/ISSUE_TEMPLATE/GH_ACTION_ISSUE_TEMPLATE.md
-      - name: Create JIRA Ticket
-        if: ${{ steps.create-issue.outputs.number != null }}
-        id: create-jira-ticket
-        env:
-          TARGET_ENV: ${{ inputs.env }}
-          JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
-          ISSUE_ID: ${{ steps.create-issue.outputs.number }}
-        run: .github/scripts/create_jira_ticket.sh
-      - name: Add comment to GH Issue
-        if: ${{ steps.create-issue.outputs.number != null }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
-          ISSUE_URL: ${{ steps.create-issue.outputs.url }}
-        run: |
-          gh issue comment ${{ env.ISSUE_URL }} -b "The ticket [${{env.JIRA_TICKET_ID}}](https://jira.mongodb.org/browse/${{env.JIRA_TICKET_ID}}) was created for internal tracking."
+    uses: ./.github/workflows/issue.yml
+    with:
+      env: ${{ inputs.env }}
+      release_name: "OpenAPI Spec"
+    secrets:
+      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-269500

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

This PR adds the logic to handle failures in the release process.
Logic:

- Check if there is already an issue for it
- If not, file a new GH issue in the repo
- Create a new Jira ticket
- Append the Jira ticket to the GH issue

I tested the logic in a fork: https://github.com/andreaangiolillo/openapi-test/issues/54
