### PR TITLE
CLOUDP-225860: add new changelog convert command to create a slack summary

### DIFF
--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -311,7 +311,7 @@ func newVersionedPaths(paths []*Path, version string) []*Path {
 func newChangelog(baseMetadata, revisionMetadata *Metadata, exceptionFilePath string, baseChangelog []*Entry) (*Changelog, error) {
 	var err error
 	if baseChangelog == nil {
-		baseChangelog, err = newEntriesFromPath(fmt.Sprintf("%s/%s", baseMetadata.Path, "changelog.json"))
+		baseChangelog, err = NewEntriesFromPath(fmt.Sprintf("%s/%s", baseMetadata.Path, "changelog.json"))
 		if err != nil {
 			return nil, err
 		}
@@ -340,7 +340,7 @@ func newChangelog(baseMetadata, revisionMetadata *Metadata, exceptionFilePath st
 	}, nil
 }
 
-func newEntriesFromPath(path string) ([]*Entry, error) {
+func NewEntriesFromPath(path string) ([]*Entry, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/tools/cli/internal/changelog/merge_test.go
+++ b/tools/cli/internal/changelog/merge_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMergeChangelogOneChange(t *testing.T) {
-	baseChangelog, err := newEntriesFromPath("../../test/data/changelog/changelog.json")
+	baseChangelog, err := NewEntriesFromPath("../../test/data/changelog/changelog.json")
 	require.NoError(t, err)
 
 	lastChangelogRunDate := baseChangelog[0].Date
@@ -99,7 +99,7 @@ func TestMergeChangelogOneChange(t *testing.T) {
 
 func TestMergeChangelogTwoVersionsNoDeprecations(t *testing.T) {
 	// arrange
-	baseChangelog, err := newEntriesFromPath("../../test/data/changelog/changelog.json")
+	baseChangelog, err := NewEntriesFromPath("../../test/data/changelog/changelog.json")
 	require.NoError(t, err)
 
 	lastChangelogRunDate := baseChangelog[0].Date
@@ -215,7 +215,7 @@ func TestMergeChangelogTwoVersionsNoDeprecations(t *testing.T) {
 }
 
 func TestMergeChangelogAddTwoEndpoints(t *testing.T) {
-	originalChangelog, err := newEntriesFromPath("../../test/data/changelog/changelog.json")
+	originalChangelog, err := NewEntriesFromPath("../../test/data/changelog/changelog.json")
 	require.NoError(t, err)
 
 	lastChangelogRunDate := originalChangelog[0].Date
@@ -468,7 +468,7 @@ func TestSortChangelog(t *testing.T) {
 
 func TestMergeChangelogTwoVersionsWithDeprecations(t *testing.T) {
 	// arrange
-	baseChangelog, err := newEntriesFromPath("../../test/data/changelog/changelog.json")
+	baseChangelog, err := NewEntriesFromPath("../../test/data/changelog/changelog.json")
 	require.NoError(t, err)
 
 	lastChangelogRunDate := baseChangelog[0].Date
@@ -596,7 +596,7 @@ func TestMergeChangelogTwoVersionsWithDeprecations(t *testing.T) {
 }
 
 func TestMergeChangelogWithDeprecations(t *testing.T) {
-	baseChangelog, err := newEntriesFromPath("../../test/data/changelog/changelog.json")
+	baseChangelog, err := NewEntriesFromPath("../../test/data/changelog/changelog.json")
 	require.NoError(t, err)
 
 	firstVersion := "2023-02-01"
@@ -718,7 +718,7 @@ func TestMergeChangelogWithDeprecations(t *testing.T) {
 }
 
 func TestMergeChangelogCompare(t *testing.T) {
-	baseChangelog, err := newEntriesFromPath("../../test/data/changelog/changelog.json")
+	baseChangelog, err := NewEntriesFromPath("../../test/data/changelog/changelog.json")
 	require.NoError(t, err)
 
 	firstVersion := "2023-01-01"

--- a/tools/cli/internal/cli/changelog/changelog_test.go
+++ b/tools/cli/internal/cli/changelog/changelog_test.go
@@ -24,7 +24,7 @@ func TestBuilder(t *testing.T) {
 	test.CmdValidator(
 		t,
 		Builder(),
-		2,
+		3,
 		[]string{},
 	)
 }

--- a/tools/cli/internal/cli/changelog/convert/convert.go
+++ b/tools/cli/internal/cli/changelog/convert/convert.go
@@ -12,28 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package changelog
+package convert
 
 import (
-	"github.com/mongodb/openapi/tools/cli/internal/cli/changelog/convert"
-	"github.com/mongodb/openapi/tools/cli/internal/cli/changelog/metadata"
 	"github.com/spf13/cobra"
 )
 
 func Builder() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "changelog",
-		Short: "Manage the API Changelog for the OpenAPI spec.",
+		Use:   "convert",
+		Short: "Convert API Changelog entries into another format.",
 		Annotations: map[string]string{
 			"toc": "true",
 		},
 	}
 
-	cmd.AddCommand(
-		CreateBuilder(),
-		metadata.Builder(),
-		convert.Builder(),
-	)
+	cmd.AddCommand(SlackBuilder())
 
 	return cmd
 }

--- a/tools/cli/internal/cli/changelog/convert/slack.go
+++ b/tools/cli/internal/cli/changelog/convert/slack.go
@@ -1,0 +1,152 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/mongodb/openapi/tools/cli/internal/changelog"
+	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
+	"github.com/mongodb/openapi/tools/cli/internal/cli/usage"
+	"github.com/spf13/cobra"
+)
+
+const (
+	backwardCompatibleColor    = "#47a249"
+	notBackwardCompatibleColor = "#b51818"
+	parseFull                  = "full"
+	attachmentTypeDefault      = "default"
+)
+
+// Message represents the overall structure of the SLACK message JSON.
+type Message struct {
+	Channel     string        `json:"channel"`
+	ThreadTS    string        `json:"thread_ts,omitempty"`
+	Parse       string        `json:"parse"`
+	Attachments []*Attachment `json:"attachments"`
+}
+
+// Attachment represents the structure of each attachment in the JSON.
+type Attachment struct {
+	Text           string `json:"text"`
+	Color          string `json:"color"`
+	AttachmentType string `json:"attachment_type"`
+}
+
+type SlackOpts struct {
+	path      string
+	messageID string
+	channelID string
+}
+
+func (o *SlackOpts) Run() error {
+	entries, err := changelog.NewEntriesFromPath(o.path)
+	if err != nil {
+		return err
+	}
+
+	message := o.generateMessage(entries)
+	metadataBytes, err := json.MarshalIndent(message, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(metadataBytes))
+	return nil
+}
+
+func (o *SlackOpts) generateMessage(entries []*changelog.Entry) *Message {
+	message := &Message{
+		Channel:  o.channelID,
+		ThreadTS: o.messageID,
+		Parse:    parseFull,
+	}
+
+	attachments := make([]*Attachment, 0)
+	for _, entry := range entries {
+		for _, path := range entry.Paths {
+			for _, version := range path.Versions {
+				attachments = append(attachments, newAttachmentFromVersion(path, version)...)
+			}
+		}
+	}
+
+	message.Attachments = orderAttachments(attachments)
+	return message
+}
+
+// orderAttachments orders the attachments by backward compatibility.
+// The attachments that are not backward compatible are shown first.
+func orderAttachments(attachments []*Attachment) []*Attachment {
+	sort.Slice(attachments, func(i, j int) bool {
+		return attachments[i].Color == notBackwardCompatibleColor && attachments[j].Color != notBackwardCompatibleColor
+	})
+	return attachments
+}
+
+func newAttachmentFromVersion(path *changelog.Path, version *changelog.Version) []*Attachment {
+	attachments := make([]*Attachment, 0)
+	for _, change := range version.Changes {
+		attachments = append(attachments, newAttachmentFromChange(version.Version, path.HTTPMethod, path.URI, change))
+	}
+
+	return attachments
+}
+
+func newAttachmentFromChange(version, method, path string, change *changelog.Change) *Attachment {
+	return &Attachment{
+		Text:           newAttachmentText(version, method, path, change.Code, change.Description, strconv.FormatBool(change.BackwardCompatible)),
+		Color:          newColorFromBackwardCompatible(change.BackwardCompatible),
+		AttachmentType: attachmentTypeDefault,
+	}
+}
+
+func newAttachmentText(version, method, path, changeCode, change, backwardCompatible string) string {
+	return fmt.Sprintf("\n• *Version*: `%s`\n• *Path*: `%s %s`\n• *Change Code*: `%s`\n• *Change*: `%s`\n• *Backward Compatible*: `%s`",
+		version, method, path, changeCode, change, backwardCompatible)
+}
+
+func newColorFromBackwardCompatible(backwardCompatible bool) string {
+	if backwardCompatible {
+		return backwardCompatibleColor
+	}
+	return notBackwardCompatibleColor
+}
+
+// SlackBuilder constructs the command for converting the changelog entries into a format that can be used with Slack APIs.
+// changelog convert slack -p path_to_changelog -m message_id 1503435956.000247 -c channel_id C061EG9SL
+func SlackBuilder() *cobra.Command {
+	opts := &SlackOpts{}
+
+	cmd := &cobra.Command{
+		Use:     "slack -b path_to_changelo -m message_id -c channel_id",
+		Aliases: []string{"generate"},
+		Short:   "Convert the changelog entries into a format that can be used with Slack APIs.",
+		Args:    cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.path, flag.Path, flag.PathShort, "", usage.Path)
+	cmd.Flags().StringVarP(&opts.channelID, flag.ChannelID, flag.ChannelIDShort, "", usage.SlackChannelID)
+	cmd.Flags().StringVar(&opts.messageID, flag.MessageID, "", usage.MessageID)
+	_ = cmd.MarkFlagRequired(flag.Path)
+	_ = cmd.MarkFlagRequired(flag.ChannelID)
+	return cmd
+}

--- a/tools/cli/internal/cli/changelog/convert/slack_test.go
+++ b/tools/cli/internal/cli/changelog/convert/slack_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAttachmentText(t *testing.T) {
+	tests := []struct {
+		name               string
+		version            string
+		method             string
+		path               string
+		changeCode         string
+		change             string
+		backwardCompatible string
+		expected           string
+	}{
+		{
+			name:               "Backward Compatible Change",
+			version:            "2024-08-05",
+			method:             "GET",
+			path:               "/api/atlas/v2/groups/{groupId}/clusters",
+			changeCode:         "response-property-enum-value-added",
+			change:             "added the new DUBLIN_IRL, FRANKFURT_DEU, LONDON_GBR enum values",
+			backwardCompatible: "true",
+			expected:           "\n• *Version*: `2024-08-05`\n• *Path*: `GET /api/atlas/v2/groups/{groupId}/clusters`\n• *Change Code*: `response-property-enum-value-added`\n• *Change*: `added the new DUBLIN_IRL, FRANKFURT_DEU, LONDON_GBR enum values`\n• *Backward Compatible*: `true`", //nolint:lll //Test string
+		},
+		{
+			name:               "Non-Backward Compatible Change",
+			version:            "2024-08-05",
+			method:             "POST",
+			path:               "/api/atlas/v2/groups/{groupId}/clusters",
+			changeCode:         "new-optional-request-property",
+			change:             "added the new optional request property replicaSetScalingStrategy",
+			backwardCompatible: "false",
+			expected:           "\n• *Version*: `2024-08-05`\n• *Path*: `POST /api/atlas/v2/groups/{groupId}/clusters`\n• *Change Code*: `new-optional-request-property`\n• *Change*: `added the new optional request property replicaSetScalingStrategy`\n• *Backward Compatible*: `false`", //nolint:lll //Test string
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := newAttachmentText(tt.version, tt.method, tt.path, tt.changeCode, tt.change, tt.backwardCompatible)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestNewColorFromBackwardCompatible(t *testing.T) {
+	tests := []struct {
+		name               string
+		backwardCompatible bool
+		expectedColor      string
+	}{
+		{
+			name:               "Backward Compatible True",
+			backwardCompatible: true,
+			expectedColor:      "#47a249",
+		},
+		{
+			name:               "Backward Compatible False",
+			backwardCompatible: false,
+			expectedColor:      "#b51818",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := newColorFromBackwardCompatible(tt.backwardCompatible)
+			assert.Equal(t, tt.expectedColor, actual)
+		})
+	}
+}

--- a/tools/cli/internal/cli/flag/flag.go
+++ b/tools/cli/internal/cli/flag/flag.go
@@ -40,4 +40,9 @@ const (
 	RunDateShort             = "d"
 	Versions                 = "versions"
 	VersionsShort            = "v"
+	Path                     = "path"
+	PathShort                = "p"
+	MessageID                = "msg-id"
+	ChannelID                = "channel-id"
+	ChannelIDShort           = "c"
 )

--- a/tools/cli/internal/cli/usage/usage.go
+++ b/tools/cli/internal/cli/usage/usage.go
@@ -31,5 +31,8 @@ const (
 	ExemptionFilePath   = "Path to the file containing the exemptions file."
 	DryRun              = "Dry run mode. The command will not write any files."
 	IgnoreExpiration    = "Ignore expiration date of the exemptions and consider the valid."
-	RunDate             = "Date when the changelog was generated. (Format: YYYY-MM-DD)"
+	RunDate             = "Date when the changelog was generated. (Format: YYYY-MM-DD)."
+	Path                = "Path to the changelog file."
+	MessageID           = "Message ID of the slack message. This ID is used to add the message as slack thread."
+	SlackChannelID      = "Slack Channel ID."
 )


### PR DESCRIPTION
## Proposed changes
CLOUDP-225860

This PR defines a new `changelog convert slack` command to convert the changelog to a format that can be used via Slack API.

# Next Steps
Create a GH action that uses the command to send weekly summary 

# Test 
I tested my changes locally using [slack staging](https://mdb-pc-staging.slack.com/archives/C07JPULFAAE/p1724778625960529)

![Screenshot 2024-08-27 at 18 16 13](https://github.com/user-attachments/assets/d6eaab90-5286-4e5d-a7d3-bec8c082e2da)

![Screenshot 2024-08-27 at 18 16 33](https://github.com/user-attachments/assets/2e3af866-bd53-4187-ba6b-74102f24c15f)


