### PR TITLE
fix: Revert "chore: Add spectral lint rule (#183)

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -156,17 +156,6 @@ rules:
         functionOptions:
           match: "^(dev|qa|stage|prod)(,(dev|qa|stage|prod))*$"
 
-  no-slash-before-custom-method:
-  description: "Custom methods (e.g., ':applyItem') should not be preceded by a '/'."
-  message: "The path '{{path}}' contains a '/' before a custom method. Custom methods should not start with a '/'."
-  severity: error
-  given: "$.paths"
-  then:
-    field: "@key"
-    function: pattern
-    functionOptions:
-      notMatch: "/[^/]+/:[a-zA-Z]+$"
-
 overrides:
   - files: # load sample data has an issue with different path param names for different VERBS
       - "*.yaml#/paths/~1api~1atlas~1v1.0~1groups~1%7BgroupId%7D~1sampleDatasetLoad~1%7BsampleDatasetId%7D"


### PR DESCRIPTION
This reverts commit 744edaa878e98e46a266a07e84d1f651c0e1b8fc.

Foas Release process started to fail after #183 was merged. Reverting the PR for now. 