### PR TITLE
feat: update changelog convert format to move Backward Compatible as last item

### DIFF
--- a/tools/cli/internal/cli/changelog/convert/slack.go
+++ b/tools/cli/internal/cli/changelog/convert/slack.go
@@ -150,8 +150,8 @@ func newAttachmentFromChange(version, method, path string, change *changelog.Cha
 
 func newAttachmentText(version, method, path, changeCode, change, backwardCompatible, hiddenFromChangelog string) string {
 	return fmt.Sprintf(
-		"\n• *Version*: `%s`\n• *Path*: `%s %s`\n• *Backward Compatible*: `%s`\n• *Hidden from Changelog*: `%s`\n• *Change Code*: `%s`\n• *Change*: `%s`",
-		version, method, path, backwardCompatible, hiddenFromChangelog, changeCode, change)
+		"\n• *Version*: `%s`\n• *Path*: `%s %s`\n• *Hidden from Changelog*: `%s`\n• *Change Code*: `%s`\n• *Change*: `%s`\n• *Backward Compatible*: `%s`",
+		version, method, path, hiddenFromChangelog, changeCode, change, backwardCompatible)
 }
 
 func newColorFromBackwardCompatible(backwardCompatible bool) string {

--- a/tools/cli/internal/cli/changelog/convert/slack_test.go
+++ b/tools/cli/internal/cli/changelog/convert/slack_test.go
@@ -41,7 +41,7 @@ func TestNewAttachmentText(t *testing.T) {
 			change:              "added the new DUBLIN_IRL, FRANKFURT_DEU, LONDON_GBR enum values",
 			backwardCompatible:  "true",
 			hiddenFromChangelog: "false",
-			expected:            "\n• *Version*: `2024-08-05`\n• *Path*: `GET /api/atlas/v2/groups/{groupId}/clusters`\n• *Backward Compatible*: `true`\n• *Hidden from Changelog*: `false`\n• *Change Code*: `response-property-enum-value-added`\n• *Change*: `added the new DUBLIN_IRL, FRANKFURT_DEU, LONDON_GBR enum values`", //nolint:lll //Test string
+			expected:            "\n• *Version*: `2024-08-05`\n• *Path*: `GET /api/atlas/v2/groups/{groupId}/clusters`\n• *Hidden from Changelog*: `false`\n• *Change Code*: `response-property-enum-value-added`\n• *Change*: `added the new DUBLIN_IRL, FRANKFURT_DEU, LONDON_GBR enum values`\n• *Backward Compatible*: `true`", //nolint:lll //Test string
 		},
 		{
 			name:                "Non-Backward Compatible Change",
@@ -52,7 +52,7 @@ func TestNewAttachmentText(t *testing.T) {
 			change:              "added the new optional request property replicaSetScalingStrategy",
 			hiddenFromChangelog: "true",
 			backwardCompatible:  "false",
-			expected:            "\n• *Version*: `2024-08-05`\n• *Path*: `POST /api/atlas/v2/groups/{groupId}/clusters`\n• *Backward Compatible*: `false`\n• *Hidden from Changelog*: `true`\n• *Change Code*: `new-optional-request-property`\n• *Change*: `added the new optional request property replicaSetScalingStrategy`", //nolint:lll //Test string
+			expected:            "\n• *Version*: `2024-08-05`\n• *Path*: `POST /api/atlas/v2/groups/{groupId}/clusters`\n• *Hidden from Changelog*: `true`\n• *Change Code*: `new-optional-request-property`\n• *Change*: `added the new optional request property replicaSetScalingStrategy`\n• *Backward Compatible*: `false`", //nolint:lll //Test string
 		},
 	}
 


### PR DESCRIPTION
This PR updates the format of the Changelog report that we send via slack message to move backward compatible as the last item 