### PR TITLE
Remove static version in Postman collection documentation

### DIFF
--- a/tools/postman/collection-description.md
+++ b/tools/postman/collection-description.md
@@ -1,4 +1,4 @@
-## MongoDB Atlas Administration API 2024-05-30
+## MongoDB Atlas Administration API
 
 This collection is an introduction to the [MongoDB Atlas Administration API](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/). The MongoDB Atlas Administration API offers a method to manage your [MongoDB Atlas clusters](https://www.mongodb.com/resources/products/fundamentals/clusters) following the principles of the REST architectural style. To learn more, visit the [MongoDB Atlas Administration API documentation](https://www.mongodb.com/docs/atlas/api/atlas-admin-api-ref/).
 


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

The static version date in the template file is out of date. This conflicts with the version in the title. Since ideally it would be a duplicate of the title anyway, it might as well be removed. The image below shows the conflict.

![image](https://github.com/user-attachments/assets/f85839bf-b1b1-4a67-80cf-0cfd4eca412c)

