### PR TITLE
fix: stop issue creating in the event of an issue with GH APIs

### DIFF
--- a/.github/workflows/failure-handler.yml
+++ b/.github/workflows/failure-handler.yml
@@ -39,12 +39,20 @@ jobs:
               run: |
                 query="(${TARGET_ENV}}) The ${RELEASE_NAME} Release has failed."
                 number_issue=$(gh search issues "${query}" --repo "${REPO}" --state open --label failed-release --json title | jq length)
+                
+                if [ -z "${number_issue}" ]; then
+                    echo "There was an issue with the GH APIs. Stopping execution."
+                    return 1
+                fi
+                
                 echo "number_issue=${number_issue}"
-                echo "found-issue=false" >> "${GITHUB_OUTPUT}"
                 if [ "${number_issue}" -gt 0 ]; then
                     echo "An issue already exists. Stopping execution."
                     echo "found-issue=true" >> "${GITHUB_OUTPUT}"
+                    return 0
                 fi
+                
+                echo "found-issue=false" >> "${GITHUB_OUTPUT}"
             - name: Create Issue # Create an issue in the repo if the release fails
               if: ${{ steps.check-issue.outputs.found-issue == 'false' }}
               id: create-issue


### PR DESCRIPTION
Fixes: #235 #233 #232 
## Proposed changes
Our failure handler is creating a new issue if the check to see whether an issue already exists fails. See [Logs](https://github.com/mongodb/openapi/actions/runs/11076277766/job/30780874487#step:3:17). 

This PR updates the logic to halt execution when it’s unclear whether an issue has already been created.