### PR TITLE
CLOUDP-277321: extend sunset date on e2e spec files

### DIFF
--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3587,7 +3587,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "description" : "Returns the details for one cluster in the specified project. Clusters contain a group of hosts that maintain the same data set. The response includes clusters with asymmetrically-sized shards. To use this resource, the requesting API Key must have the Project Read Only role. This feature is not available for serverless clusters.",
@@ -5308,7 +5308,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5381,7 +5381,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5592,7 +5592,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6823,7 +6823,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7068,7 +7068,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7119,7 +7119,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7184,7 +7184,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7249,7 +7249,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7749,7 +7749,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10467,7 +10467,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10521,7 +10521,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10569,7 +10569,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10617,7 +10617,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10668,7 +10668,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10731,7 +10731,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11010,7 +11010,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11050,7 +11050,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11071,7 +11071,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11111,7 +11111,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3587,7 +3587,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "description" : "Returns the details for one cluster in the specified project. Clusters contain a group of hosts that maintain the same data set. The response includes clusters with asymmetrically-sized shards. To use this resource, the requesting API Key must have the Project Read Only role. This feature is not available for serverless clusters.",
@@ -5308,7 +5308,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5381,7 +5381,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5592,7 +5592,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6823,7 +6823,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7068,7 +7068,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7119,7 +7119,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7184,7 +7184,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7249,7 +7249,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7749,7 +7749,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10467,7 +10467,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10521,7 +10521,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10569,7 +10569,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10617,7 +10617,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10668,7 +10668,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10731,7 +10731,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11010,7 +11010,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11050,7 +11050,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11071,7 +11071,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11111,7 +11111,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2099-10-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3587,7 +3587,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "description" : "Returns the details for one cluster in the specified project. Clusters contain a group of hosts that maintain the same data set. The response includes clusters with asymmetrically-sized shards. To use this resource, the requesting API Key must have the Project Read Only role. This feature is not available for serverless clusters.",
@@ -5308,7 +5308,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5381,7 +5381,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5592,7 +5592,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6823,7 +6823,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7068,7 +7068,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7119,7 +7119,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7184,7 +7184,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7249,7 +7249,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7749,7 +7749,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10467,7 +10467,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10521,7 +10521,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10569,7 +10569,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10617,7 +10617,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10668,7 +10668,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10731,7 +10731,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11010,7 +11010,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11050,7 +11050,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11071,7 +11071,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11111,7 +11111,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -5362,7 +5362,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5435,7 +5435,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5503,7 +5503,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5566,7 +5566,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5646,7 +5646,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7120,7 +7120,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7171,7 +7171,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7236,7 +7236,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7301,7 +7301,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10517,7 +10517,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10571,7 +10571,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10619,7 +10619,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10667,7 +10667,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10718,7 +10718,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10781,7 +10781,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11060,7 +11060,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11100,7 +11100,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11121,7 +11121,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11161,7 +11161,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2099-10-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -5362,7 +5362,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5435,7 +5435,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5503,7 +5503,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5566,7 +5566,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5646,7 +5646,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7120,7 +7120,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7171,7 +7171,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7236,7 +7236,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7301,7 +7301,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10517,7 +10517,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10571,7 +10571,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10619,7 +10619,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10667,7 +10667,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10718,7 +10718,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10781,7 +10781,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11060,7 +11060,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11100,7 +11100,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11121,7 +11121,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11161,7 +11161,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -5362,7 +5362,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5435,7 +5435,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5503,7 +5503,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5566,7 +5566,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5646,7 +5646,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7120,7 +7120,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7171,7 +7171,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7236,7 +7236,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7301,7 +7301,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10517,7 +10517,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10571,7 +10571,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10619,7 +10619,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10667,7 +10667,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10718,7 +10718,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10781,7 +10781,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11060,7 +11060,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11100,7 +11100,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11121,7 +11121,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11161,7 +11161,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -5357,7 +5357,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5430,7 +5430,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5498,7 +5498,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5561,7 +5561,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5641,7 +5641,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7115,7 +7115,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7166,7 +7166,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7231,7 +7231,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7296,7 +7296,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10512,7 +10512,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10566,7 +10566,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10614,7 +10614,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10662,7 +10662,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10713,7 +10713,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10776,7 +10776,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11055,7 +11055,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11095,7 +11095,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11116,7 +11116,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11156,7 +11156,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -5357,7 +5357,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5430,7 +5430,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5498,7 +5498,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5561,7 +5561,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5641,7 +5641,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7115,7 +7115,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7166,7 +7166,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7231,7 +7231,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7296,7 +7296,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10512,7 +10512,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10566,7 +10566,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10614,7 +10614,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10662,7 +10662,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10713,7 +10713,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10776,7 +10776,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11055,7 +11055,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11095,7 +11095,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11116,7 +11116,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11156,7 +11156,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -5357,7 +5357,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5430,7 +5430,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5498,7 +5498,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5561,7 +5561,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5641,7 +5641,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7115,7 +7115,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7166,7 +7166,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7231,7 +7231,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7296,7 +7296,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10512,7 +10512,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10566,7 +10566,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10614,7 +10614,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10662,7 +10662,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10713,7 +10713,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10776,7 +10776,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11055,7 +11055,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11095,7 +11095,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11116,7 +11116,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11156,7 +11156,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -5757,7 +5757,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5830,7 +5830,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5898,7 +5898,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5961,7 +5961,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6041,7 +6041,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7515,7 +7515,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7566,7 +7566,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7631,7 +7631,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7696,7 +7696,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11100,7 +11100,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11154,7 +11154,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11202,7 +11202,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11250,7 +11250,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -11301,7 +11301,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11364,7 +11364,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11643,7 +11643,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11683,7 +11683,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11704,7 +11704,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11744,7 +11744,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -5757,7 +5757,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5830,7 +5830,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5898,7 +5898,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5961,7 +5961,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6041,7 +6041,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7515,7 +7515,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7566,7 +7566,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7631,7 +7631,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7696,7 +7696,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11100,7 +11100,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11154,7 +11154,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11202,7 +11202,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11250,7 +11250,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -11301,7 +11301,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11364,7 +11364,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11643,7 +11643,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11683,7 +11683,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11704,7 +11704,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11744,7 +11744,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -5757,7 +5757,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5830,7 +5830,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5898,7 +5898,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5961,7 +5961,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6041,7 +6041,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -7515,7 +7515,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7566,7 +7566,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7631,7 +7631,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7696,7 +7696,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11100,7 +11100,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11154,7 +11154,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -11202,7 +11202,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11250,7 +11250,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -11301,7 +11301,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11364,7 +11364,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11643,7 +11643,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11683,7 +11683,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11704,7 +11704,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11744,7 +11744,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2024-05-30.json
@@ -5828,7 +5828,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5901,7 +5901,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6032,7 +6032,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6112,7 +6112,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11850,7 +11850,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11904,7 +11904,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11952,7 +11952,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12000,7 +12000,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12051,7 +12051,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12114,7 +12114,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2024-05-30.json
@@ -5828,7 +5828,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5901,7 +5901,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6032,7 +6032,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6112,7 +6112,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11850,7 +11850,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11904,7 +11904,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11952,7 +11952,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12000,7 +12000,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -12051,7 +12051,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -12114,7 +12114,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/new-api-version/base/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/new-api-version/base/openapi-2024-05-30.json
@@ -5828,7 +5828,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5901,7 +5901,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -6032,7 +6032,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6112,7 +6112,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11850,7 +11850,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11904,7 +11904,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -11952,7 +11952,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12000,7 +12000,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -12051,7 +12051,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -12114,7 +12114,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2099-10-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2099-10-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/new-api-version/revision/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2099-10-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2099-10-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/same-api-version/base/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2099-10-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-01-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-01-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2166,7 +2166,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2711,7 +2711,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2730,7 +2730,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2870,7 +2870,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2912,7 +2912,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       },
       "put" : {
         "deprecated" : true,
@@ -2939,7 +2939,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2976,7 +2976,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3288,7 +3288,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3348,7 +3348,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3591,7 +3591,7 @@
         } ],
         "summary" : "Remove One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -3645,7 +3645,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3713,7 +3713,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4175,7 +4175,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4223,7 +4223,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4285,7 +4285,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5322,7 +5322,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5395,7 +5395,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5463,7 +5463,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5526,7 +5526,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5606,7 +5606,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5780,7 +5780,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5851,7 +5851,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5920,7 +5920,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6734,7 +6734,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6804,7 +6804,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -6851,7 +6851,7 @@
         } ],
         "summary" : "Test Failover for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" : {
@@ -7096,7 +7096,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7147,7 +7147,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7212,7 +7212,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7277,7 +7277,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -7777,7 +7777,7 @@
         } ],
         "summary" : "Download Logs for One Cluster Host in One Project",
         "tags" : [ "Monitoring and Logs" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/containers" : {
@@ -10495,7 +10495,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10549,7 +10549,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10597,7 +10597,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10645,7 +10645,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10696,7 +10696,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10759,7 +10759,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11038,7 +11038,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11078,7 +11078,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11099,7 +11099,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11139,7 +11139,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2099-10-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-02-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-02-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -2968,7 +2968,7 @@
         } ],
         "summary" : "Return the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       },
       "put" : {
         "deprecated" : true,
@@ -2995,7 +2995,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DataProtectionSettings"
               },
-              "x-sunset" : "2099-10-01",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -3032,7 +3032,7 @@
         } ],
         "summary" : "Update or enable the Backup Compliance Policy settings",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2099-10-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/cloudProviderAccess" : {
@@ -3344,7 +3344,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3404,7 +3404,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3699,7 +3699,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3767,7 +3767,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4229,7 +4229,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4277,7 +4277,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4339,7 +4339,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5376,7 +5376,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5449,7 +5449,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5517,7 +5517,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5580,7 +5580,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5660,7 +5660,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5714,7 +5714,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5768,7 +5768,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5834,7 +5834,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5905,7 +5905,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5974,7 +5974,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6788,7 +6788,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6858,7 +6858,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7148,7 +7148,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7199,7 +7199,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7264,7 +7264,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7329,7 +7329,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10545,7 +10545,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10599,7 +10599,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10647,7 +10647,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10695,7 +10695,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10746,7 +10746,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10809,7 +10809,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11088,7 +11088,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11149,7 +11149,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11189,7 +11189,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01,
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-10-01.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-10-01.json
@@ -946,7 +946,7 @@
         } ],
         "summary" : "Return One Identity Provider by ID",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -1007,7 +1007,7 @@
         } ],
         "summary" : "Update One Identity Provider",
         "tags" : [ "Federated Authentication" ],
-        "x-sunset" : "2025-01-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}/metadata.xml" : {
@@ -2222,7 +2222,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2767,7 +2767,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -2786,7 +2786,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2823,7 +2823,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -2926,7 +2926,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3339,7 +3339,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -3399,7 +3399,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3694,7 +3694,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -3762,7 +3762,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4224,7 +4224,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -4272,7 +4272,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -4334,7 +4334,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5371,7 +5371,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5444,7 +5444,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5512,7 +5512,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -5575,7 +5575,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -5655,7 +5655,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -5709,7 +5709,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -5763,7 +5763,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5829,7 +5829,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -5900,7 +5900,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -5969,7 +5969,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -6783,7 +6783,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -6853,7 +6853,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7143,7 +7143,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -7194,7 +7194,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -7259,7 +7259,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -10540,7 +10540,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10594,7 +10594,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "post" : {
         "deprecated" : true,
@@ -10642,7 +10642,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -10690,7 +10690,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "get" : {
         "deprecated" : true,
@@ -10741,7 +10741,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       },
       "patch" : {
         "deprecated" : true,
@@ -10804,7 +10804,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11083,7 +11083,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11123,7 +11123,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11144,7 +11144,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01,
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11184,7 +11184,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01 : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01 : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01 : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01 : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01 : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01 : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01 : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01 : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01 : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01 : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01 : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01 : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset" : "2025-05-30",
+              "x-sunset": "2099-01-01",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset" : "2025-05-30"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-11-15.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2023-11-15.json
@@ -2363,7 +2363,7 @@
         } ],
         "summary" : "Acknowledge One Alert from One Project",
         "tags" : [ "Alerts" ],
-        "x-sunset": "2099-01-01 : "2025-05-30"
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/alerts/{alertId}/alertConfigs" : {
@@ -2908,7 +2908,7 @@
         } ],
         "summary" : "Return All AWS S3 Buckets and Azure Blob Storage Containers Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-05-30"
+        "x-sunset" : "2025-05-30"
       },
       "post" : {
         "deprecated" : true,
@@ -2927,7 +2927,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/DiskBackupSnapshotAWSExportBucket"
               },
-              "x-sunset": "2099-01-01 : "2025-05-30",
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -2964,7 +2964,7 @@
         } ],
         "summary" : "Grant Access to AWS S3 Bucket or Azure Blob Storage Container for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-05-30"
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backup/exportBuckets/{exportBucketId}" : {
@@ -3067,7 +3067,7 @@
         } ],
         "summary" : "Return One AWS S3 Bucket or Azure Blob Storage Container Used for Cloud Backup Snapshot Exports",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-05-30"
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" : {
@@ -3480,7 +3480,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3540,7 +3540,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3835,7 +3835,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3903,7 +3903,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4365,7 +4365,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-08-05"
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4413,7 +4413,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-08-05"
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4475,7 +4475,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-08-05"
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5771,7 +5771,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5844,7 +5844,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5912,7 +5912,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -5975,7 +5975,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6055,7 +6055,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6109,7 +6109,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6163,7 +6163,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6229,7 +6229,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6369,7 +6369,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7183,7 +7183,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7253,7 +7253,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -7543,7 +7543,7 @@
         } ],
         "summary" : "Delete Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "get" : {
         "deprecated" : true,
@@ -7594,7 +7594,7 @@
         } ],
         "summary" : "Return Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7659,7 +7659,7 @@
         } ],
         "summary" : "Update Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -7724,7 +7724,7 @@
         } ],
         "summary" : "Create Search Nodes",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" : {
@@ -11128,7 +11128,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11182,7 +11182,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11230,7 +11230,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -11278,7 +11278,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -11329,7 +11329,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11392,7 +11392,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {
@@ -11671,7 +11671,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01 : "2025-05-30",
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11711,7 +11711,7 @@
         } ],
         "summary" : "Migrate One Local Managed Cluster to MongoDB Atlas",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01 : "2025-05-30"
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate" : {
@@ -11732,7 +11732,7 @@
               "schema" : {
                 "$ref" : "#/components/schemas/LiveMigrationRequest"
               },
-              "x-sunset": "2099-01-01 : "2025-05-30",
+              "x-sunset" : "2025-05-30",
               "x-xgen-version" : "2023-01-01"
             }
           },
@@ -11772,7 +11772,7 @@
         } ],
         "summary" : "Validate One Migration Request",
         "tags" : [ "Cloud Migration Service" ],
-        "x-sunset": "2099-01-01 : "2025-05-30"
+        "x-sunset" : "2025-05-30"
       }
     },
     "/api/atlas/v2/groups/{groupId}/liveMigrations/validate/{validationId}" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-08-05"
+        "x-sunset" : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-08-05"
+        "x-sunset" : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset": "2099-01-01 : "2025-08-05"
+        "x-sunset" : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset": "2099-01-01 : "2026-03-01"
+        "x-sunset" : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-05-30.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-05-30.json
@@ -3551,7 +3551,7 @@
         } ],
         "summary" : "Return All Clusters in One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -3611,7 +3611,7 @@
         } ],
         "summary" : "Create One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/provider/regions" : {
@@ -3906,7 +3906,7 @@
         } ],
         "summary" : "Return One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -3974,7 +3974,7 @@
         } ],
         "summary" : "Modify One Cluster from One Project",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" : {
@@ -4436,7 +4436,7 @@
         } ],
         "summary" : "Remove All Cloud Backup Schedules",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01 : "2025-08-05"
       },
       "get" : {
         "deprecated" : true,
@@ -4484,7 +4484,7 @@
         } ],
         "summary" : "Return One Cloud Backup Schedule",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01 : "2025-08-05"
       },
       "patch" : {
         "deprecated" : true,
@@ -4546,7 +4546,7 @@
         } ],
         "summary" : "Update Cloud Backup Schedule for One Cluster",
         "tags" : [ "Cloud Backups" ],
-        "x-sunset" : "2025-08-05"
+        "x-sunset": "2099-01-01 : "2025-08-05"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" : {
@@ -5842,7 +5842,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5915,7 +5915,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5983,7 +5983,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6046,7 +6046,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6126,7 +6126,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -6180,7 +6180,7 @@
         } ],
         "summary" : "Return One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" : {
@@ -6234,7 +6234,7 @@
         } ],
         "summary" : "Remove All Custom Zone Mappings from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6300,7 +6300,7 @@
         } ],
         "summary" : "Add One Entry to One Custom Zone Mapping",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" : {
@@ -6371,7 +6371,7 @@
         } ],
         "summary" : "Remove One Managed Namespace from One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "post" : {
         "deprecated" : true,
@@ -6440,7 +6440,7 @@
         } ],
         "summary" : "Create One Managed Namespace in One Global Cluster",
         "tags" : [ "Global Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" : {
@@ -7254,7 +7254,7 @@
         } ],
         "summary" : "Return One Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -7324,7 +7324,7 @@
         } ],
         "summary" : "Update Advanced Configuration Options for One Cluster",
         "tags" : [ "Clusters" ],
-        "x-sunset" : "2026-03-01"
+        "x-sunset": "2099-01-01 : "2026-03-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" : {
@@ -11878,7 +11878,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11932,7 +11932,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11980,7 +11980,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12028,7 +12028,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12079,7 +12079,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12142,7 +12142,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset" : "2025-06-01"
+        "x-sunset": "2099-01-01 : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset" : "2099-10-04"
+        "x-sunset": "2099-01-01 : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {

--- a/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-08-05.json
+++ b/tools/cli/test/data/changelog/same-api-version/revision/openapi-2024-08-05.json
@@ -5836,7 +5836,7 @@
         } ],
         "summary" : "Create One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{databaseName}/{collectionName}" : {
@@ -5909,7 +5909,7 @@
         } ],
         "summary" : "Return All Atlas Search Indexes for One Collection",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" : {
@@ -5977,7 +5977,7 @@
         } ],
         "summary" : "Remove One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       },
       "get" : {
         "deprecated" : true,
@@ -6040,7 +6040,7 @@
         } ],
         "summary" : "Return One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       },
       "patch" : {
         "deprecated" : true,
@@ -6120,7 +6120,7 @@
         } ],
         "summary" : "Update One Atlas Search Index",
         "tags" : [ "Atlas Search" ],
-        "x-sunset": "2099-01-01 : "2025-06-01"
+        "x-sunset" : "2025-06-01"
       }
     },
     "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites" : {
@@ -11860,7 +11860,7 @@
         } ],
         "summary" : "Return All Project Invitations",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -11914,7 +11914,7 @@
         } ],
         "summary" : "Update One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "post" : {
         "deprecated" : true,
@@ -11962,7 +11962,7 @@
         } ],
         "summary" : "Invite One MongoDB Cloud User to Join One Project",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/invites/{invitationId}" : {
@@ -12010,7 +12010,7 @@
         } ],
         "summary" : "Cancel One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "get" : {
         "deprecated" : true,
@@ -12061,7 +12061,7 @@
         } ],
         "summary" : "Return One Project Invitation",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       },
       "patch" : {
         "deprecated" : true,
@@ -12124,7 +12124,7 @@
         } ],
         "summary" : "Update One Project Invitation by Invitation ID",
         "tags" : [ "Projects" ],
-        "x-sunset": "2099-01-01 : "2099-10-04"
+        "x-sunset" : "2099-10-04"
       }
     },
     "/api/atlas/v2/groups/{groupId}/ipAddresses" : {


### PR DESCRIPTION
## Proposed changes

This PR fixes the changelog e2e tests to extend the sunset date of the specs used in the e2e tests to 2099.

Conversation: https://github.com/mongodb/openapi/pull/238#discussion_r1789986879
