### PR TITLE
CLOUDP-271222: Update spectral linting

### DIFF
--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -158,32 +158,30 @@ rules:
   
   soa-migration-extension:
     description: "Ensure the x-xgen-soa-migration extension is valid."
-    message: "The x-xgen-soa-migration extension must include 'service_name', 'allow_diff', and 'source_service' should only be present when 'allow_diff' is true."
+    message: "The x-xgen-soa-migration extension must include 'additionalServices', 'targetService', 'allowDocsDiff', and 'docsSource'."
     formats: ["oas3"]
     given: "$.paths[*][*].x-xgen-soa-migration"
     severity: error
     then:
-      - field: service_name
+      - field: targetService
         function: truthy
-        message: "'service_name' must be provided."
-      - field: allow_diff
+        message: "'targetService' must be provided."
+      - field: allowDocsDiff
         function: pattern
         functionOptions:
           match: "^(true|false)$"
-        message: "'allow_diff' must be true or false."
-      - function: falsy
-        field: source_service
-        message: "'source_service' should not exist when 'allow_diff' is false."
-        when:
-          field: allow_diff
-          pattern: "^false$"
-      - function: truthy
-        field: source_service
-        message: "'source_service' must be provided when 'allow_diff' is true."
-        when:
-          field: allow_diff
-          pattern: "^true$"
-
+        message: "'allowDocsDiff' must be true or false."
+      - field: docsSource
+        function: truthy
+        message: "'docsSource' must be provided."
+      - field: additionalServices
+        function: truthy
+        message: "'additionalServices' must be provided."
+      - field: additionalServices
+        function: pattern
+        functionOptions:
+          match: "^(mms)$"
+        message: "'additionalServices' must be 'mms' as no other services are supported."
    no-slash-before-custom-method:
     description: "Custom methods (e.g., ':applyItem') should not be preceded by a '/'."
     message: "The path '{{path}}' contains a '/' before a custom method. Custom methods should not start with a '/'."


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-271222


- Updates spectral linting for the x-xgen-soa-migration annotation values updated in the technical design according to SRE recommendation.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
