### PR TITLE
Revert "CLOUDP-274986: Update OAS security validation for global security"

### DIFF
--- a/.github/workflows/spectral-lint.yml
+++ b/.github/workflows/spectral-lint.yml
@@ -27,9 +27,9 @@ jobs:
           sparse-checkout: |
             openapi/
             tools/spectral
-#      - name: Spectral action
-#        uses: stoplightio/spectral-action@2ad0b9302e32a77c1caccf474a9b2191a8060d83
-#        with:
-#          # Path to the OpenAPI spec files and openapi/v2.yaml
-#          file_glob: openapi/v2.yaml
-#          spectral_ruleset: tools/spectral/.spectral.yaml #If updated, need to update in MMS too.
+      - name: Spectral action
+        uses: stoplightio/spectral-action@2ad0b9302e32a77c1caccf474a9b2191a8060d83
+        with:
+          # Path to the OpenAPI spec files and openapi/v2.yaml
+          file_glob: openapi/v2.yaml
+          spectral_ruleset: tools/spectral/.spectral.yaml #If updated, need to update in MMS too.

--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -73,6 +73,14 @@ rules:
       functionOptions:
         notMatch: "/^body$/"
 
+  xgen-no-security:
+    description: "Operation MUST have security definition"
+    severity: error
+    given: "#OperationObject"
+    then:
+      field: "security"
+      function: truthy
+
   xgen-docs-tags-alphabetical:
     message: "Tags should be defined in alphabetical order."
     description: "Many documentation tools show tags in the order they are defined, so defining them not in alphabetical order can look funny to API consumers."
@@ -174,8 +182,7 @@ rules:
         functionOptions:
           match: "^(mms)$"
         message: "'additionalServices' must be 'mms' as no other services are supported."
-
-  no-slash-before-custom-method:
+   no-slash-before-custom-method:
     description: "Custom methods (e.g., ':applyItem') should not be preceded by a '/'."
     message: "The path '{{path}}' contains a '/' before a custom method. Custom methods should not start with a '/'."
     severity: error
@@ -185,20 +192,6 @@ rules:
       function: pattern
       functionOptions:
         notMatch: "/[^/]+/:[a-zA-Z]+$"
-
-  xgen-security-override:
-    description: "Security must not be set at resource or method level because it is set globally. Use @Unauthenticated annotation to set no security. https://go/openapi-unauthenticated-annotation"
-    severity: error
-    given: "#OperationObject.security"
-    then:
-      function: schema
-      functionOptions:
-        schema:
-          type: array
-          items:
-            type: object
-          minItems: 0
-          maxItems: 0
 
 overrides:
   - files: # load sample data has an issue with different path param names for different VERBS
@@ -248,6 +241,11 @@ overrides:
       - "*.yaml#/components/schemas/ClusterProviderSettings/properties/providerName" # dynamic field which can't be documented
     rules:
       xgen-description: "off"
+  - files:
+      - "*.yaml#/paths/~1api~1atlas~1v2~1unauth~1controlPlaneIPAddresses/get"
+      - "*.yaml#/paths/~1api~1atlas~1v2~1unauth~1openapi~1versions/get"
+    rules:
+      xgen-no-security: "off"
   - files:
       - "**#/components/schemas/ApiError/properties/parameters" # see https://github.com/stoplightio/spectral/issues/2592
     rules:


### PR DESCRIPTION
Reverts mongodb/openapi#251

Validation is failing with the last changes: https://github.com/mongodb/openapi/issues/253