### PR TITLE
CLOUDP-274986: Remove rule for security to be set on all operations

### DIFF
--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -73,14 +73,6 @@ rules:
       functionOptions:
         notMatch: "/^body$/"
 
-  xgen-no-security:
-    description: "Operation MUST have security definition"
-    severity: error
-    given: "#OperationObject"
-    then:
-      field: "security"
-      function: truthy
-
   xgen-docs-tags-alphabetical:
     message: "Tags should be defined in alphabetical order."
     description: "Many documentation tools show tags in the order they are defined, so defining them not in alphabetical order can look funny to API consumers."
@@ -182,6 +174,7 @@ rules:
         functionOptions:
           match: "^(mms)$"
         message: "'additionalServices' must be 'mms' as no other services are supported."
+        
    no-slash-before-custom-method:
     description: "Custom methods (e.g., ':applyItem') should not be preceded by a '/'."
     message: "The path '{{path}}' contains a '/' before a custom method. Custom methods should not start with a '/'."
@@ -241,11 +234,6 @@ overrides:
       - "*.yaml#/components/schemas/ClusterProviderSettings/properties/providerName" # dynamic field which can't be documented
     rules:
       xgen-description: "off"
-  - files:
-      - "*.yaml#/paths/~1api~1atlas~1v2~1unauth~1controlPlaneIPAddresses/get"
-      - "*.yaml#/paths/~1api~1atlas~1v2~1unauth~1openapi~1versions/get"
-    rules:
-      xgen-no-security: "off"
   - files:
       - "**#/components/schemas/ApiError/properties/parameters" # see https://github.com/stoplightio/spectral/issues/2592
     rules:


### PR DESCRIPTION
## Proposed changes

Removing rule `xgen-no-security` for the changes in the OAS setting the security globally. After the OASes have been updated in all environments we can introduce the new rule here.

_Jira ticket: [CLOUDP-274986](https://jira.mongodb.org/browse/CLOUDP-274986)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
