### PR TITLE
fix: postman release is faling with `collection_id: unbound variable`

### DIFF
--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -54,12 +54,14 @@ if [  "$collection_exists" = "false" ]; then
 else
   # Find collection ID and update collection
   echo "Updating remote collection ${current_collection_name}"
+  collection_id=$(jq -r '.collections | map(select(.name=="'"${current_collection_name}"'").id)[0]' "${COLLECTIONS_LIST_FILE}")
+
   echo "curl --request PUT
      --location 'https://api.getpostman.com/collections/${collection_id}'
      --header 'Content-Type: application/json'
      --header 'X-API-Key: **********'
      --data ${collection_transformed_path}"
-  collection_id=$(jq -r '.collections | map(select(.name=="'"${current_collection_name}"'").id)[0]' "${COLLECTIONS_LIST_FILE}")
+
   curl --show-error --fail --retry 5 --retry-all-errors --silent --request PUT \
        --location "https://api.getpostman.com/collections/${collection_id}" \
        --header "Content-Type: application/json" \


### PR DESCRIPTION
## Proposed changes
Postman release is failing with the error:
```
./scripts/upload-collection.sh: line 61: collection_id: unbound variable
```
See: https://github.com/mongodb/openapi/actions/runs/11296408238/job/31421320420#step:6:15

