### PR TITLE
CLOUDP-283505: Allow empty removals

### DIFF
--- a/tools/cli/internal/changelog/outputfilter/squash.go
+++ b/tools/cli/internal/changelog/outputfilter/squash.go
@@ -11,7 +11,8 @@ import (
 var (
 	// identifierRegex matches text enclosed in single quotes.
 	// Example: it'll match "value" from the string "added the new required request property 'value'".
-	// Example: it'll match "" and "/items/dataProcessRegion/region" from the string removed the '' enum value from the '/items/dataProcessRegion/region' response property.
+	// Example: it'll match "" and "/items/dataProcessRegion/region" from the string
+	//"removed the '' enum value from the '/items/dataProcessRegion/region' response property".
 	identifierRegex = regexp.MustCompile(`'([^']*)'`)
 )
 

--- a/tools/cli/internal/changelog/outputfilter/squash.go
+++ b/tools/cli/internal/changelog/outputfilter/squash.go
@@ -11,7 +11,8 @@ import (
 var (
 	// identifierRegex matches text enclosed in single quotes.
 	// Example: it'll match "value" from the string "added the new required request property 'value'".
-	identifierRegex = regexp.MustCompile(`'([^']+)'`)
+	// Example: it'll match "" and "/items/dataProcessRegion/region" from the string removed the '' enum value from the '/items/dataProcessRegion/region' response property.
+	identifierRegex = regexp.MustCompile(`'([^']*)'`)
 )
 
 type SquashHandler interface {

--- a/tools/cli/internal/changelog/outputfilter/squash.go
+++ b/tools/cli/internal/changelog/outputfilter/squash.go
@@ -12,7 +12,7 @@ var (
 	// identifierRegex matches text enclosed in single quotes.
 	// Example: it'll match "value" from the string "added the new required request property 'value'".
 	// Example: it'll match "" and "/items/dataProcessRegion/region" from the string
-	//"removed the '' enum value from the '/items/dataProcessRegion/region' response property".
+	// "removed the '' enum value from the '/items/dataProcessRegion/region' response property".
 	identifierRegex = regexp.MustCompile(`'([^']*)'`)
 )
 


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-283505

### Description
Changelog generation failed with:
```shell
2024/11/04 16:14:51 Marked 414 changes hidden from the changelog.
Error: the pattern for response-property-enum-value-removed message was changed. Expecting exactly 2 values between apostrophes: removed the '' enum value from the 'results/items/oneOf[subschema #4: Host Metric Alerts]/currentValue/units' response property
 ```

However the info is valid, since there was an empty enum in the OpenAPI specification, see https://github.com/10gen/mms/pull/113043.

This PR updates the Regex so that we allow empty values.


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
