### PR TITLE
CLOUDP-279336: Avoid that squashing overrides hideFromChangelog

### DIFF
--- a/tools/cli/internal/changelog/outputfilter/squash.go
+++ b/tools/cli/internal/changelog/outputfilter/squash.go
@@ -135,11 +135,16 @@ func squashEntries(entries []*OasDiffEntry) ([]*OasDiffEntry, error) {
 	entriesMap := newEntriesMapPerIDAndOperationID(entries)
 	squashHandlers := newSquashHandlers()
 	squashedEntries := []*OasDiffEntry{}
+	hidddenSquashedEntries := []*OasDiffEntry{}
 
 	for _, entry := range entries {
 		// if no squash handlers implemented for entry's code,
 		// just append the entry to the result
 		if _, ok := findHandler(entry.ID); !ok {
+			if entry.HideFromChangelog {
+				hidddenSquashedEntries = append(hidddenSquashedEntries, entry)
+				continue
+			}
 			squashedEntries = append(squashedEntries, entry)
 			continue
 		}
@@ -156,6 +161,7 @@ func squashEntries(entries []*OasDiffEntry) ([]*OasDiffEntry, error) {
 			return nil, err
 		}
 
+		squashedEntries = append(squashedEntries, hidddenSquashedEntries...)
 		squashedEntries = append(squashedEntries, sortEntriesByDescription(entries)...)
 	}
 

--- a/tools/cli/internal/changelog/outputfilter/squash_test.go
+++ b/tools/cli/internal/changelog/outputfilter/squash_test.go
@@ -33,8 +33,7 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 					},
 				},
 			},
-			wantHidden: map[string]map[string][]*OasDiffEntry{
-				"response-write-only-property-enum-value-added": {}},
+			wantHidden: map[string]map[string][]*OasDiffEntry{},
 		},
 		{
 			name: "Multiple entries with same ID",
@@ -52,8 +51,7 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 					},
 				},
 			},
-			wantHidden: map[string]map[string][]*OasDiffEntry{
-				"response-write-only-property-enum-value-added": {}},
+			wantHidden: map[string]map[string][]*OasDiffEntry{},
 		},
 		{
 			name: "Multiple entries with same ID and OperationID",
@@ -69,8 +67,7 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 					},
 				},
 			},
-			wantHidden: map[string]map[string][]*OasDiffEntry{
-				"response-write-only-property-enum-value-added": {}},
+			wantHidden: map[string]map[string][]*OasDiffEntry{},
 		},
 		{
 			name: "Multiple entries with different IDs",
@@ -98,10 +95,7 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 					},
 				},
 			},
-			wantHidden: map[string]map[string][]*OasDiffEntry{
-				"response-write-only-property-enum-value-added": {},
-				"request-write-only-property-enum-value-added":  {},
-			},
+			wantHidden: map[string]map[string][]*OasDiffEntry{},
 		},
 		{
 			name: "Hidden entries",
@@ -109,8 +103,7 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 				{ID: "response-write-only-property-enum-value-added", OperationID: "op1", HideFromChangelog: true},
 				{ID: "response-write-only-property-enum-value-added", OperationID: "op2", HideFromChangelog: true},
 			},
-			want: map[string]map[string][]*OasDiffEntry{
-				"response-write-only-property-enum-value-added": {}},
+			want: map[string]map[string][]*OasDiffEntry{},
 			wantHidden: map[string]map[string][]*OasDiffEntry{
 				"response-write-only-property-enum-value-added": {
 					"op1": []*OasDiffEntry{

--- a/tools/cli/internal/changelog/outputfilter/squash_test.go
+++ b/tools/cli/internal/changelog/outputfilter/squash_test.go
@@ -2,6 +2,7 @@ package outputfilter
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,14 +10,16 @@ import (
 
 func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 	testCases := []struct {
-		name    string
-		entries []*OasDiffEntry
-		want    map[string]map[string][]*OasDiffEntry
+		name       string
+		entries    []*OasDiffEntry
+		want       map[string]map[string][]*OasDiffEntry
+		wantHidden map[string]map[string][]*OasDiffEntry
 	}{
 		{
-			name:    "Empty entries",
-			entries: []*OasDiffEntry{},
-			want:    map[string]map[string][]*OasDiffEntry{},
+			name:       "Empty entries",
+			entries:    []*OasDiffEntry{},
+			want:       map[string]map[string][]*OasDiffEntry{},
+			wantHidden: map[string]map[string][]*OasDiffEntry{},
 		},
 		{
 			name: "Single entry",
@@ -30,6 +33,8 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 					},
 				},
 			},
+			wantHidden: map[string]map[string][]*OasDiffEntry{
+				"response-write-only-property-enum-value-added": {}},
 		},
 		{
 			name: "Multiple entries with same ID",
@@ -47,8 +52,9 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 					},
 				},
 			},
+			wantHidden: map[string]map[string][]*OasDiffEntry{
+				"response-write-only-property-enum-value-added": {}},
 		},
-
 		{
 			name: "Multiple entries with same ID and OperationID",
 			entries: []*OasDiffEntry{
@@ -63,6 +69,8 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 					},
 				},
 			},
+			wantHidden: map[string]map[string][]*OasDiffEntry{
+				"response-write-only-property-enum-value-added": {}},
 		},
 		{
 			name: "Multiple entries with different IDs",
@@ -90,14 +98,69 @@ func TestNewEntriesMapPerIDAndOperationID(t *testing.T) {
 					},
 				},
 			},
+			wantHidden: map[string]map[string][]*OasDiffEntry{
+				"response-write-only-property-enum-value-added": {},
+				"request-write-only-property-enum-value-added":  {},
+			},
+		},
+		{
+			name: "Hidden entries",
+			entries: []*OasDiffEntry{
+				{ID: "response-write-only-property-enum-value-added", OperationID: "op1", HideFromChangelog: true},
+				{ID: "response-write-only-property-enum-value-added", OperationID: "op2", HideFromChangelog: true},
+			},
+			want: map[string]map[string][]*OasDiffEntry{
+				"response-write-only-property-enum-value-added": {}},
+			wantHidden: map[string]map[string][]*OasDiffEntry{
+				"response-write-only-property-enum-value-added": {
+					"op1": []*OasDiffEntry{
+						{ID: "response-write-only-property-enum-value-added", OperationID: "op1", HideFromChangelog: true},
+					},
+					"op2": []*OasDiffEntry{
+						{ID: "response-write-only-property-enum-value-added", OperationID: "op2", HideFromChangelog: true},
+					},
+				},
+			},
+		},
+		{
+			name: "Mixed hidden and non-hidden entries",
+			entries: []*OasDiffEntry{
+				{ID: "response-write-only-property-enum-value-added", OperationID: "op1"},
+				{ID: "response-write-only-property-enum-value-added", OperationID: "op2", HideFromChangelog: true},
+				{ID: "response-write-only-property-enum-value-added", OperationID: "op3"},
+				{ID: "response-write-only-property-enum-value-added", OperationID: "op4", HideFromChangelog: true},
+			},
+			want: map[string]map[string][]*OasDiffEntry{
+				"response-write-only-property-enum-value-added": {
+					"op1": []*OasDiffEntry{
+						{ID: "response-write-only-property-enum-value-added", OperationID: "op1"},
+					},
+					"op3": []*OasDiffEntry{
+						{ID: "response-write-only-property-enum-value-added", OperationID: "op3"},
+					},
+				},
+			},
+			wantHidden: map[string]map[string][]*OasDiffEntry{
+				"response-write-only-property-enum-value-added": {
+					"op2": []*OasDiffEntry{
+						{ID: "response-write-only-property-enum-value-added", OperationID: "op2", HideFromChangelog: true},
+					},
+					"op4": []*OasDiffEntry{
+						{ID: "response-write-only-property-enum-value-added", OperationID: "op4", HideFromChangelog: true},
+					},
+				},
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := newEntriesMapPerIDAndOperationID(tc.entries)
+			got, gotHidden := newEntriesMapPerIDAndOperationID(tc.entries)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("got %v, want %v", got, tc.want)
+			}
+			if !reflect.DeepEqual(gotHidden, tc.wantHidden) {
+				t.Errorf("gotHidden %v, wantHidden %v", gotHidden, tc.wantHidden)
 			}
 		})
 	}
@@ -237,4 +300,169 @@ func TestNewSquashMap(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSquashEntries(t *testing.T) {
+	testCases := []struct {
+		name    string
+		entries []*OasDiffEntry
+		want    []*OasDiffEntry
+	}{
+		{
+			name:    "Empty entries",
+			entries: []*OasDiffEntry{},
+			want:    []*OasDiffEntry{},
+		},
+		{
+			name: "Single entry",
+			entries: []*OasDiffEntry{
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM1' enum value to the 'region' response write-only property",
+				},
+			},
+			want: []*OasDiffEntry{
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM1' enum value to the 'region' response write-only property",
+				},
+			},
+		},
+		{
+			name: "Multiple entries with same ID and OperationID",
+			entries: []*OasDiffEntry{
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM1' enum value to the 'region' response write-only property",
+				},
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM2' enum value to the 'region' response write-only property",
+				},
+			},
+			want: []*OasDiffEntry{
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM1, ENUM2' enum values to the 'region' response write-only property",
+				},
+			},
+		},
+		{
+			name: "Multiple entries with different IDs",
+			entries: []*OasDiffEntry{
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM1' enum value to the 'region' response write-only property",
+				},
+				{
+					ID:          "request-write-only-property-enum-value-added",
+					OperationID: "op2",
+					Text:        "added the new 'ENUM2' enum value to the 'region' request write-only property",
+				},
+			},
+			want: []*OasDiffEntry{
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM1' enum value to the 'region' response write-only property",
+				},
+				{
+					ID:          "request-write-only-property-enum-value-added",
+					OperationID: "op2",
+					Text:        "added the new 'ENUM2' enum value to the 'region' request write-only property",
+				},
+			},
+		},
+		{
+			name: "Hidden entries",
+			entries: []*OasDiffEntry{
+				{
+					ID:                "response-write-only-property-enum-value-added",
+					OperationID:       "op1",
+					Text:              "added the new 'ENUM1' enum value to the 'region' response write-only property",
+					HideFromChangelog: true,
+				},
+				{
+					ID:                "response-write-only-property-enum-value-added",
+					OperationID:       "op1",
+					Text:              "added the new 'ENUM2' enum value to the 'region' response write-only property",
+					HideFromChangelog: true,
+				},
+			},
+			want: []*OasDiffEntry{
+				{
+					ID:                "response-write-only-property-enum-value-added",
+					OperationID:       "op1",
+					Text:              "added the new 'ENUM1, ENUM2' enum values to the 'region' response write-only property",
+					HideFromChangelog: true,
+				},
+			},
+		},
+		{
+			name: "Mixed hidden and non-hidden entries",
+			entries: []*OasDiffEntry{
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM1' enum value to the 'region' response write-only property",
+				},
+				{
+					ID:                "response-write-only-property-enum-value-added",
+					OperationID:       "op1",
+					Text:              "added the new 'ENUM2' enum value to the 'region' response write-only property",
+					HideFromChangelog: true,
+				},
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM3' enum value to the 'region' response write-only property",
+				},
+				{
+					ID:                "response-write-only-property-enum-value-added",
+					OperationID:       "op1",
+					Text:              "added the new 'ENUM4' enum value to the 'region' response write-only property",
+					HideFromChangelog: true,
+				},
+			},
+			want: []*OasDiffEntry{
+				{
+					ID:          "response-write-only-property-enum-value-added",
+					OperationID: "op1",
+					Text:        "added the new 'ENUM1, ENUM3' enum values to the 'region' response write-only property",
+				},
+				{
+					ID:                "response-write-only-property-enum-value-added",
+					OperationID:       "op1",
+					Text:              "added the new 'ENUM2, ENUM4' enum values to the 'region' response write-only property",
+					HideFromChangelog: true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := squashEntries(tc.entries)
+			require.NoError(t, err)
+			sortEntries(got)
+			sortEntries(tc.want)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// sortEntries sorts the entries by their ID and OperationID.
+func sortEntries(entries []*OasDiffEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].ID != entries[j].ID {
+			return entries[i].ID < entries[j].ID
+		}
+		return entries[i].OperationID < entries[j].OperationID
+	})
 }


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-279336

Similar to this: https://github.com/10gen/mms/blob/2bdd398c7ede9d7d1e58519c6931fb1dbae13a36/scripts/api_versioning/changelog/generate_changelog.py#L197-L204

As part of investigating exemptions, I also noticed we weren't accounting for hiddenFromChangelog values while squashing, which could end up overriding the hide value. I'm following a similar logic to the one in current changelog above to fix it and updated all tests. 

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
