### PR TITLE
CLOUDP-286235: Update dependabot to cover package.json in root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     reviewers:
       - "mongodb/apix-2"
   - package-ecosystem: npm
-    directory: "/tools/postman"
+    directory: "/"
     schedule:
       interval: weekly
       day: tuesday


### PR DESCRIPTION
## Proposed changes

Follow up update to dependabot configuration from [previous PR](https://github.com/mongodb/openapi/pull/290) which moved package.json to the root.

_Jira ticket:_ [CLOUDP-286235](https://jira.mongodb.org/browse/CLOUDP-286235)
