### PR TITLE
CLOUDP-278958: trasformation test

### DIFF
--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -39,7 +39,8 @@ jobs:
           BASE_URL: ${{ inputs.atlas_prod_base_url }}
         working-directory: ./tools/postman
         run: |
-          make transform_collection
+          make transform_collection 
+          make transform_collection_test
 
       - name: Upload Collection to Postman
         env:

--- a/tools/postman/Makefile
+++ b/tools/postman/Makefile
@@ -17,6 +17,10 @@ convert_to_collection:
 transform_collection:
 	./scripts/transform-for-api.sh
 
+.PHONY: transform_collection_test
+transform_collection_test:
+	./scripts/transform-for-api-test.sh
+
 .PHONY: upload_collection
 upload_collection:
 	./scripts/upload-collection.sh

--- a/tools/postman/README.md
+++ b/tools/postman/README.md
@@ -85,9 +85,10 @@ The OpenAPI path for Postman generation and configured feature flags can also be
 
 Once env vars are configured, the setup scripts can be run locally using the Make following commands:
 - `make fetch_openapi`
-- `make convert_to_collection`
-- `make transform_collection`
-- `make upload_collection`
+- `make convert_to_collection` - covert OpenAPI to Postman collection
+- `make transform_collection` - transform Postman collection to fix common issues
+- `make transform_collection_test` - test collection.
+- `make upload_collection` - uploads collection to the Postman
 
 ## Automatic updates
 

--- a/tools/postman/scripts/transform-for-api-test.sh
+++ b/tools/postman/scripts/transform-for-api-test.sh
@@ -18,70 +18,26 @@ if [[ ! -f "$COLLECTION_FILE_NAME" ]]; then
   exit 1
 fi
 
-
-# Test: Wrap Collection in "collection" tag
-echo "Wrapping Collection $COLLECTION_FILE_NAME in \"collection\" tag"
-jq '{"collection": .}' "$COLLECTION_FILE_NAME" > intermediateCollectionWrapped.json
-
-if jq -e '.collection' intermediateCollectionWrapped.json > /dev/null; then
-  echo "Test Passed: Collection wrapped successfully."
-else
-  echo "Test Failed: Collection wrapping failed."
-fi
-
 # Test: Disable query params by default
-echo "Disabling query params by default"
-# jq '(.. | select(.request? != null).request.url.query[].disabled) = true' \
-#   intermediateCollectionWrapped.json > intermediateCollectionDisableQueryParam.json
-
-if jq -e '.. | select(.request? != null).request.url.query[] | select(.disabled == true)' intermediateCollectionDisableQueryParam.json > /dev/null; then
+echo "Disabling query params by default test"
+if jq -e '.. | select(.request? != null).request.url.query[] | select(.disabled == true)' $COLLECTION_TRANSFORMED_FILE_NAME > /dev/null; then
   echo "Test Passed: Query params disabled successfully."
 else
   echo "Test Failed: Query params disabling failed."
 fi
 
 # Test: Remove _postman_id
-# echo "Removing _postman_id"
-# jq 'del(.collection.info._postman_id)' \
-#   intermediateCollectionDisableQueryParam.json > intermediateCollectionNoPostmanID.json
-
-if ! jq -e '.collection.info._postman_id' intermediateCollectionNoPostmanID.json > /dev/null; then
+if ! jq -e '.collection.info._postman_id' $COLLECTION_TRANSFORMED_FILE_NAME > /dev/null; then
   echo "Test Passed: _postman_id removed successfully."
 else
   echo "Test Failed: _postman_id removal failed."
 fi
 
-# Test: Remove circular references
-echo "Removing circular references"
-sed 's/\\"value\\": \\"<Circular reference to #[^>"]* detected>\\"//g' intermediateCollectionNoPostmanID.json > intermediateCollectionNoCircular.json
-
-if ! grep -q '<Circular reference to #' intermediateCollectionNoCircular.json; then
-  echo "Test Passed: Circular references removed successfully."
-else
-  echo "Test Failed: Circular references removal failed."
-fi
-
-# Test: Remove all variables
-echo "Removing all variables. We use environment for variables instead"
-jq '.collection.variable = []' \
-  intermediateCollectionWithDescription.json > intermediateCollectionWithNoVarjson.json
-
-if jq -e '.collection.variable | length == 0' intermediateCollectionWithNoVarjson.json > /dev/null; then
-  echo "Test Passed: Variables removed successfully."
-else
-  echo "Test Failed: Variables removal failed."
-fi
-
 # Test : Add baseUrl property
-echo "Adding baseUrl property $BASE_URL"
-jq --arg base_url "$BASE_URL" \
-  '.collection.variable[0].value = $base_url' \
-  intermediateCollectionWithNoVarjson.json > intermediateCollectionWithBaseURL.json
-
-if jq -e --arg base_url "$BASE_URL" '.collection.variable[0].value == $base_url' intermediateCollectionWithBaseURL.json > /dev/null; then
-  echo "Test Passed: baseUrl property added successfully."
+echo "Adding baseUrl property test"
+if jq -e '.collection.variable[0] | (.key == "baseUrl" and has("value"))' $COLLECTION_TRANSFORMED_FILE_NAME > /dev/null; then
+  echo "Test Passed: The first item in the variable array has key set to \"baseUrl\" and has a value property."
 else
-  echo "Test Failed: baseUrl property addition failed."
+  echo "Test Failed: The first item in the variable array does not have the expected key or value properties."
 fi
 
-# End of test script

--- a/tools/postman/scripts/transform-for-api-test.sh
+++ b/tools/postman/scripts/transform-for-api-test.sh
@@ -20,14 +20,14 @@ fi
 
 # Test: Disable query params by default
 echo "Disabling query params by default test"
-if jq -e '.. | select(.request? != null).request.url.query[] | select(.disabled == true)' $COLLECTION_TRANSFORMED_FILE_NAME > /dev/null; then
+if jq -e '.. | select(.request? != null).request.url.query[] | select(.disabled == true)' "$COLLECTION_TRANSFORMED_FILE_NAME" > /dev/null; then
   echo "Test Passed: Query params disabled successfully."
 else
   echo "Test Failed: Query params disabling failed."
 fi
 
 # Test: Remove _postman_id
-if ! jq -e '.collection.info._postman_id' $COLLECTION_TRANSFORMED_FILE_NAME > /dev/null; then
+if ! jq -e '.collection.info._postman_id' "$COLLECTION_TRANSFORMED_FILE_NAME" > /dev/null; then
   echo "Test Passed: _postman_id removed successfully."
 else
   echo "Test Failed: _postman_id removal failed."
@@ -35,7 +35,7 @@ fi
 
 # Test : Add baseUrl property
 echo "Adding baseUrl property test"
-if jq -e '.collection.variable[0] | (.key == "baseUrl" and has("value"))' $COLLECTION_TRANSFORMED_FILE_NAME > /dev/null; then
+if jq -e '.collection.variable[0] | (.key == "baseUrl" and has("value"))' "$COLLECTION_TRANSFORMED_FILE_NAME" > /dev/null; then
   echo "Test Passed: The first item in the variable array has key set to \"baseUrl\" and has a value property."
 else
   echo "Test Failed: The first item in the variable array does not have the expected key or value properties."

--- a/tools/postman/scripts/transform-for-api-test.sh
+++ b/tools/postman/scripts/transform-for-api-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#########################################################
+#  Test for transformation 
+#  To be run after transformation is done
+#########################################################
+
+COLLECTION_FILE_NAME=${COLLECTION_FILE_NAME:-"collection.json"}
+TMP_FOLDER=${TMP_FOLDER:-"../tmp"}
+COLLECTION_TRANSFORMED_FILE_NAME=${COLLECTION_TRANSFORMED_FILE_NAME:-"collection-transformed.json"}
+
+pushd "${TMP_FOLDER}"
+
+# Ensure the necessary files exist
+if [[ ! -f "$COLLECTION_FILE_NAME" ]]; then
+  echo "Error: Collection file not found at $COLLECTION_FILE_NAME"
+  exit 1
+fi
+
+
+# Test: Wrap Collection in "collection" tag
+echo "Wrapping Collection $COLLECTION_FILE_NAME in \"collection\" tag"
+jq '{"collection": .}' "$COLLECTION_FILE_NAME" > intermediateCollectionWrapped.json
+
+if jq -e '.collection' intermediateCollectionWrapped.json > /dev/null; then
+  echo "Test Passed: Collection wrapped successfully."
+else
+  echo "Test Failed: Collection wrapping failed."
+fi
+
+# Test: Disable query params by default
+echo "Disabling query params by default"
+# jq '(.. | select(.request? != null).request.url.query[].disabled) = true' \
+#   intermediateCollectionWrapped.json > intermediateCollectionDisableQueryParam.json
+
+if jq -e '.. | select(.request? != null).request.url.query[] | select(.disabled == true)' intermediateCollectionDisableQueryParam.json > /dev/null; then
+  echo "Test Passed: Query params disabled successfully."
+else
+  echo "Test Failed: Query params disabling failed."
+fi
+
+# Test: Remove _postman_id
+# echo "Removing _postman_id"
+# jq 'del(.collection.info._postman_id)' \
+#   intermediateCollectionDisableQueryParam.json > intermediateCollectionNoPostmanID.json
+
+if ! jq -e '.collection.info._postman_id' intermediateCollectionNoPostmanID.json > /dev/null; then
+  echo "Test Passed: _postman_id removed successfully."
+else
+  echo "Test Failed: _postman_id removal failed."
+fi
+
+# Test: Remove circular references
+echo "Removing circular references"
+sed 's/\\"value\\": \\"<Circular reference to #[^>"]* detected>\\"//g' intermediateCollectionNoPostmanID.json > intermediateCollectionNoCircular.json
+
+if ! grep -q '<Circular reference to #' intermediateCollectionNoCircular.json; then
+  echo "Test Passed: Circular references removed successfully."
+else
+  echo "Test Failed: Circular references removal failed."
+fi
+
+# Test: Remove all variables
+echo "Removing all variables. We use environment for variables instead"
+jq '.collection.variable = []' \
+  intermediateCollectionWithDescription.json > intermediateCollectionWithNoVarjson.json
+
+if jq -e '.collection.variable | length == 0' intermediateCollectionWithNoVarjson.json > /dev/null; then
+  echo "Test Passed: Variables removed successfully."
+else
+  echo "Test Failed: Variables removal failed."
+fi
+
+# Test : Add baseUrl property
+echo "Adding baseUrl property $BASE_URL"
+jq --arg base_url "$BASE_URL" \
+  '.collection.variable[0].value = $base_url' \
+  intermediateCollectionWithNoVarjson.json > intermediateCollectionWithBaseURL.json
+
+if jq -e --arg base_url "$BASE_URL" '.collection.variable[0].value == $base_url' intermediateCollectionWithBaseURL.json > /dev/null; then
+  echo "Test Passed: baseUrl property added successfully."
+else
+  echo "Test Failed: baseUrl property addition failed."
+fi
+
+# End of test script


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-278958

## Descriptions

Adding test to the customization mechanism we use to track possible regressions and issues when postman tooling is updated.

## Impact

Releases will require tests to pass. I intentionally made test simple to cover happy path/critical changes only.  

## Reason
 Transformation engine is currently done as set of bash jq commands that are tricky to test and validate. 
 Transformation files are not committed to the repository and visible during PRs.
 We release postman automatically (postman does validation for correctness on backend) but it does not validate our customizations. 

## Testing

- Run locally:
```
▶ make transform_collection_test
./scripts/transform-for-api-test.sh
~/Projects/sandbox/openapi/tools/postman/tmp ~/Projects/sandbox/openapi/tools/postman
Test Passed: Query params disabled successfully.
Test Passed: _postman_id removed successfully.
Test Passed: The first item in the variable array has key set to "baseUrl" and has a value property.
````

- CI/CD will be tested after merge.
 
## Future considerations

To fully streamline the experience for postman, we would need to move all the org and group variables to the global level for user convenience.  I initially tried to do that, but bash approach does show it's limit:

- It is difficult to test jq commands which do not fail if entries are missing 
- long execution time - added loop in bash took 610 seconds to run transformation.

In the long run we should look to see if we can migrate transformation engine into scripting language like python, js etc.
