### PR TITLE
CLOUDP-276602: FOASCLI: Improve the error message in the event of conflicts

### DIFF
--- a/tools/cli/internal/openapi/errors/merge_conflict_error.go
+++ b/tools/cli/internal/openapi/errors/merge_conflict_error.go
@@ -52,16 +52,21 @@ type SchemaConflictError struct {
 }
 
 func (e SchemaConflictError) Error() string {
-	return fmt.Sprintf("there was a conflict on a Schema component: %q. Base Spec: %q, External Spec: %q", e.Entry, e.BaseSpecLocation, e.ExternalSpecLocation)
+	return fmt.Sprintf("there was a conflict on a Schema component: %q. Base Spec: %q, External Spec: %q",
+		e.Entry, e.BaseSpecLocation, e.ExternalSpecLocation)
 }
 
 type TagConflictError struct {
-	Entry       string
-	Description string
+	Entry                string
+	Description          string
+	BaseSpecLocation     string
+	ExternalSpecLocation string
 }
 
 func (e TagConflictError) Error() string {
-	return fmt.Sprintf("there was a conflict with the Tag %q with the description: %q", e.Entry, e.Description)
+	return fmt.Sprintf(
+		"there was a conflict with the Tag %q with the description: %q. Base Spec: %q, External Spec: %q",
+		e.Entry, e.Description, e.BaseSpecLocation, e.ExternalSpecLocation)
 }
 
 type PathDocsDiffConflictError struct {

--- a/tools/cli/internal/openapi/errors/merge_conflict_error.go
+++ b/tools/cli/internal/openapi/errors/merge_conflict_error.go
@@ -46,11 +46,13 @@ func (e ResponseConflictError) Error() string {
 }
 
 type SchemaConflictError struct {
-	Entry string
+	Entry                string
+	BaseSpecLocation     string
+	ExternalSpecLocation string
 }
 
 func (e SchemaConflictError) Error() string {
-	return fmt.Sprintf("there was a conflict on a Schema component: %q", e.Entry)
+	return fmt.Sprintf("there was a conflict on a Schema component: %q. Base Spec: %q, External Spec: %q", e.Entry, e.BaseSpecLocation, e.ExternalSpecLocation)
 }
 
 type TagConflictError struct {

--- a/tools/cli/internal/openapi/oasdiff.go
+++ b/tools/cli/internal/openapi/oasdiff.go
@@ -297,8 +297,10 @@ func (o OasDiff) mergeTags() error {
 			baseTags = append(baseTags, v)
 		} else {
 			return errors.TagConflictError{
-				Entry:       v.Name,
-				Description: v.Description,
+				Entry:                v.Name,
+				Description:          v.Description,
+				BaseSpecLocation:     o.base.Url,
+				ExternalSpecLocation: o.external.Url,
 			}
 		}
 	}

--- a/tools/cli/internal/openapi/oasdiff.go
+++ b/tools/cli/internal/openapi/oasdiff.go
@@ -419,7 +419,9 @@ func (o OasDiff) mergeSchemas() error {
 
 			// The schemas have the same name but different definitions
 			return errors.SchemaConflictError{
-				Entry: k,
+				Entry:                k,
+				BaseSpecLocation:     o.base.Url,
+				ExternalSpecLocation: o.external.Url,
 			}
 		}
 	}

--- a/tools/cli/internal/openapi/openapi3.go
+++ b/tools/cli/internal/openapi/openapi3.go
@@ -48,6 +48,7 @@ func (o *OpenAPI3) WithExcludedPrivatePaths() *OpenAPI3 {
 func (o *OpenAPI3) CreateOpenAPISpecFromPath(path string) (*load.SpecInfo, error) {
 	o.Loader.IsExternalRefsAllowed = o.IsExternalRefsAllowed
 	spec, err := load.NewSpecInfo(o.Loader, load.NewSource(path))
+	spec.Url = path
 	if err != nil {
 		return nil, err
 	}

--- a/tools/cli/test/e2e/cli/merge_test.go
+++ b/tools/cli/test/e2e/cli/merge_test.go
@@ -103,7 +103,7 @@ func TestMerge(t *testing.T) {
 		require.Error(t, err, stringResponse)
 		assert.Contains(t, stringResponse, fmt.Sprintf("Error: there was a conflict with the Tag \"Events\""+
 			" with the description: \"Returns information about the MongoDB Atlas Specification.\"."+
-			" Base Spec: %q, External Spec: %q", base, apiRegistrySpec))
+			" Base Spec: %q, External Spec: %q", base, authnSpec))
 	})
 
 	t.Run("Expecting Error: not identical component", func(t *testing.T) {

--- a/tools/cli/test/e2e/cli/merge_test.go
+++ b/tools/cli/test/e2e/cli/merge_test.go
@@ -101,7 +101,9 @@ func TestMerge(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		stringResponse := string(resp)
 		require.Error(t, err, stringResponse)
-		assert.Contains(t, stringResponse, "Error: there was a conflict with the Tag \"Events\" with the description: \"Returns information about the MongoDB Atlas Specification.\"") //nolint:lll // Line is over 120 characters
+		assert.Contains(t, stringResponse, fmt.Sprintf("Error: there was a conflict with the Tag \"Events\""+
+			" with the description: \"Returns information about the MongoDB Atlas Specification.\"."+
+			" Base Spec: %q, External Spec: %q", base, apiRegistrySpec))
 	})
 
 	t.Run("Expecting Error: not identical component", func(t *testing.T) {
@@ -124,6 +126,8 @@ func TestMerge(t *testing.T) {
 		stringResponse := string(resp)
 		require.Error(t, err, stringResponse)
 		assert.Contains(t, stringResponse,
-			fmt.Sprintf("Error: there was a conflict on a Schema component: \"ApiError\". Base Spec: %q, External Spec: %q", base, apiRegistrySpec))
+			fmt.Sprintf(
+				"Error: there was a conflict on a Schema component: \"ApiError\". Base Spec: %q, "+
+					"External Spec: %q", base, apiRegistrySpec))
 	})
 }

--- a/tools/cli/test/e2e/cli/merge_test.go
+++ b/tools/cli/test/e2e/cli/merge_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -122,6 +123,7 @@ func TestMerge(t *testing.T) {
 		resp, err := cmd.CombinedOutput()
 		stringResponse := string(resp)
 		require.Error(t, err, stringResponse)
-		assert.Contains(t, stringResponse, "Error: there was a conflict on a Schema component: \"ApiError\"")
+		assert.Contains(t, stringResponse,
+			fmt.Sprintf("Error: there was a conflict on a Schema component: \"ApiError\". Base Spec: %q, External Spec: %q", base, apiRegistrySpec))
 	})
 }


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-276602](https://jira.mongodb.org/browse/CLOUDP-276602)

This PR proposes to update the conflict error messages to include the Base and external spec locations to help debug where the issue is.