### PR TITLE
CLOUDP-290332: Run IPA validation and Jest tests as workflow

### DIFF
--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           sparse-checkout: |
             .github
-            tools
+            tools/spectral/ipa
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -46,6 +46,25 @@ jobs:
       - name: Run unit tests
         working-directory: tools/cli
         run: make unit-test
+  js-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          sparse-checkout: |
+            .github
+            tools
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+      - name: Install npm dependencies
+        run: npm install
+      - name: Run Jest tests
+        run: |
+          npm run test
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/spectral-lint.yml
+++ b/.github/workflows/spectral-lint.yml
@@ -7,6 +7,7 @@ on:
       - 'tools/spectral/**'
       - 'openapi/**.yaml'
       - '.spectral.yaml'
+      - 'ipa-spectral.yaml'
   push:
     branches:
       - main
@@ -14,6 +15,7 @@ on:
       - 'tools/spectral/**'
       - 'openapi/**.yaml'
       - '.spectral.yaml'
+      - 'ipa-spectral.yaml'
 
 jobs:
   spectral-lint:
@@ -33,3 +35,8 @@ jobs:
           # Path to the OpenAPI spec files and openapi/v2.yaml
           file_glob: openapi/v2.yaml
           spectral_ruleset: tools/spectral/.spectral.yaml #If updated, need to update in MMS too.
+      - name: IPA validation action
+        uses: stoplightio/spectral-action@2ad0b9302e32a77c1caccf474a9b2191a8060d83
+        with:
+          file_glob: openapi/v2.yaml
+          spectral_ruleset: tools/spectral/ipa/ipa-spectral.yaml

--- a/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
+++ b/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
@@ -59,6 +59,9 @@ describe('tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js', ()
     it('returns false for a nested singleton resource', () => {
       expect(isStandardResource(nestedSingletonResourcePaths)).toBe(false);
     });
+    it('testing that this test fails', () => {
+      expect(isStandardResource(nestedSingletonResourcePaths)).toBe(true);
+    });
   });
   describe('isSingletonResource', () => {
     it('returns true for a singleton resource', () => {

--- a/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
+++ b/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
@@ -59,9 +59,6 @@ describe('tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js', ()
     it('returns false for a nested singleton resource', () => {
       expect(isStandardResource(nestedSingletonResourcePaths)).toBe(false);
     });
-    it('testing that this test fails', () => {
-      expect(isStandardResource(nestedSingletonResourcePaths)).toBe(true);
-    });
   });
   describe('isSingletonResource', () => {
     it('returns true for a singleton resource', () => {


### PR DESCRIPTION
## Proposed changes

- Run IPA validation on PRs when there are changes to `/tools` (`js-test`)
- Run Jest unit tests on PRs when there are changes to `/tools` (`IPA validation action`). Should not fail as the rules are currently warning

_Jira ticket:_ [CLOUDP-290332](https://jira.mongodb.org/browse/CLOUDP-290332)

Testing:

- Example [fail run](https://github.com/mongodb/openapi/actions/runs/12355771014/job/34480142676?pr=311) for js-tests
- Example [IPA validations run](https://github.com/mongodb/openapi/pull/311/checks?check_run_id=34480205762) with warnings (expected)
