### PR TITLE
CLOUDP-287245: IPA-109: Validate custom method must be GET or POST

### DIFF
--- a/tools/spectral/ipa/__tests__/eachCustomMethodMustBeGetOrPost.test.js
+++ b/tools/spectral/ipa/__tests__/eachCustomMethodMustBeGetOrPost.test.js
@@ -1,0 +1,114 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-109-custom-method-must-be-GET-or-POST', [
+  {
+    name: 'valid methods',
+    document: {
+      paths: {
+        '/a/{exampleId}:method': {
+          post: {},
+        },
+        '/a:method': {
+          post: {},
+        },
+        '/b/{exampleId}:method': {
+          get: {},
+        },
+        '/b:method': {
+          get: {},
+        }
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid methods',
+    document: {
+      paths: {
+        '/a/{exampleId}:method': {
+          put: {},
+        },
+        '/a:method': {
+          put: {},
+        },
+        '/b/{exampleId}:method': {
+          get: {},
+          put: {},
+        },
+        '/b:method': {
+          get: {},
+          put: {},
+        },
+        '/c/{exampleId}:method': {
+          post: {},
+          get: {},
+          put: {},
+        },
+        '/c:method': {
+          post: {},
+          get: {},
+          put: {},
+        },
+        '/d/{exampleId}:method': {
+          post: {},
+          get: {},
+        },
+        '/d:method': {
+          post: {},
+          get: {},
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-109-custom-method-must-be-GET-or-POST',
+        message: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109',
+        path: ['paths', '/a/{exampleId}:method'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-109-custom-method-must-be-GET-or-POST',
+        message: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109',
+        path: ['paths', '/a:method'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-109-custom-method-must-be-GET-or-POST',
+        message: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109',
+        path: ['paths', '/b/{exampleId}:method'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-109-custom-method-must-be-GET-or-POST',
+        message: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109',
+        path: ['paths', '/b:method'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-109-custom-method-must-be-GET-or-POST',
+        message: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109',
+        path: ['paths', '/c/{exampleId}:method'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-109-custom-method-must-be-GET-or-POST',
+        message: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109',
+        path: ['paths', '/c:method'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-109-custom-method-must-be-GET-or-POST',
+        message: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109',
+        path: ['paths', '/d/{exampleId}:method'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-109-custom-method-must-be-GET-or-POST',
+        message: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109',
+        path: ['paths', '/d:method'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/eachCustomMethodMustBeGetOrPost.test.js
+++ b/tools/spectral/ipa/__tests__/eachCustomMethodMustBeGetOrPost.test.js
@@ -20,11 +20,11 @@ testRule('xgen-IPA-109-custom-method-must-be-GET-or-POST', [
         },
         '/c/{exampleId}:method': {
           get: {},
-          'x-xgen-IPA-exception': {}
+          'x-xgen-IPA-exception': {},
         },
         '/c:method': {
           get: {},
-          'x-xgen-IPA-exception': {}
+          'x-xgen-IPA-exception': {},
         },
       },
     },

--- a/tools/spectral/ipa/__tests__/eachCustomMethodMustBeGetOrPost.test.js
+++ b/tools/spectral/ipa/__tests__/eachCustomMethodMustBeGetOrPost.test.js
@@ -18,6 +18,14 @@ testRule('xgen-IPA-109-custom-method-must-be-GET-or-POST', [
         '/b:method': {
           get: {},
         },
+        '/c/{exampleId}:method': {
+          get: {},
+          'x-xgen-IPA-exception': {}
+        },
+        '/c:method': {
+          get: {},
+          'x-xgen-IPA-exception': {}
+        },
       },
     },
     errors: [],

--- a/tools/spectral/ipa/__tests__/eachCustomMethodMustBeGetOrPost.test.js
+++ b/tools/spectral/ipa/__tests__/eachCustomMethodMustBeGetOrPost.test.js
@@ -17,7 +17,7 @@ testRule('xgen-IPA-109-custom-method-must-be-GET-or-POST', [
         },
         '/b:method': {
           get: {},
-        }
+        },
       },
     },
     errors: [],

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -1,2 +1,3 @@
 extends:
   - ./rulesets/IPA-104.yaml
+  - ./rulesets/IPA-109.yaml

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -3,4 +3,3 @@ extends:
   - ./rulesets/IPA-102.yaml
   - ./rulesets/IPA-104.yaml
   - ./rulesets/IPA-109.yaml
-

--- a/tools/spectral/ipa/rulesets/IPA-109.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-109.yaml
@@ -13,7 +13,3 @@ rules:
     then:
       field: '@key'
       function: 'eachCustomMethodMustBeGetOrPost'
-      functionOptions:
-        requiredMethods:
-          - get
-          - post

--- a/tools/spectral/ipa/rulesets/IPA-109.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-109.yaml
@@ -1,0 +1,19 @@
+# IPA-109: Custom Methods
+# http://go/ipa/109
+
+functions:
+  - eachCustomMethodMustBeGetOrPost
+
+rules:
+  xgen-IPA-109-custom-method-must-be-GET-or-POST:
+    description: "The HTTP method for custom methods must be GET or POST. http://go/ipa/109"
+    message: "{{error}} http://go/ipa/109"
+    severity: warn
+    given: "$.paths"
+    then:
+      field: "@key"
+      function: "eachCustomMethodMustBeGetOrPost"
+      functionOptions:
+        requiredMethods:
+          - get
+          - post

--- a/tools/spectral/ipa/rulesets/IPA-109.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-109.yaml
@@ -6,13 +6,13 @@ functions:
 
 rules:
   xgen-IPA-109-custom-method-must-be-GET-or-POST:
-    description: "The HTTP method for custom methods must be GET or POST. http://go/ipa/109"
-    message: "{{error}} http://go/ipa/109"
+    description: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109'
+    message: '{{error}} http://go/ipa/109'
     severity: warn
-    given: "$.paths"
+    given: '$.paths'
     then:
-      field: "@key"
-      function: "eachCustomMethodMustBeGetOrPost"
+      field: '@key'
+      function: 'eachCustomMethodMustBeGetOrPost'
       functionOptions:
         requiredMethods:
           - get

--- a/tools/spectral/ipa/rulesets/IPA-109.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-109.yaml
@@ -9,6 +9,6 @@ rules:
     description: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109'
     message: '{{error}} http://go/ipa/109'
     severity: warn
-    given: '$.paths'
+    given: '$.paths[*]'
     then:
       function: 'eachCustomMethodMustBeGetOrPost'

--- a/tools/spectral/ipa/rulesets/IPA-109.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-109.yaml
@@ -9,6 +9,6 @@ rules:
     description: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109'
     message: '{{error}} http://go/ipa/109'
     severity: warn
-    given: '$.paths[*]'
+    given: "$.paths[*]"
     then:
       function: 'eachCustomMethodMustBeGetOrPost'

--- a/tools/spectral/ipa/rulesets/IPA-109.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-109.yaml
@@ -11,5 +11,4 @@ rules:
     severity: warn
     given: '$.paths'
     then:
-      field: '@key'
       function: 'eachCustomMethodMustBeGetOrPost'

--- a/tools/spectral/ipa/rulesets/IPA-109.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-109.yaml
@@ -9,6 +9,6 @@ rules:
     description: 'The HTTP method for custom methods must be GET or POST. http://go/ipa/109'
     message: '{{error}} http://go/ipa/109'
     severity: warn
-    given: "$.paths[*]"
+    given: '$.paths[*]'
     then:
       function: 'eachCustomMethodMustBeGetOrPost'

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -1,33 +1,26 @@
 import { isCustomMethod } from './utils/resourceEvaluation.js';
 
 const ERROR_MESSAGE = 'The HTTP method for custom methods must be GET or POST.';
+const ERROR_RESULT = [{ message: ERROR_MESSAGE }];
 const VALID_METHODS = ['get', 'post'];
 
-export default (paths) => {
-  // Collect all errors
-  const errors = [];
+export default (input, opts, { path }) => {
+  // Extract the path key (e.g., '/a/{exampleId}:method') from the JSONPath.
+  let pathKey = path[1];
 
-  // Iterate through each path key and its corresponding path item
-  for (const [pathKey, pathItem] of Object.entries(paths)) {
-    // Skip if not a custom method
-    if (!isCustomMethod(pathKey)) continue;
+  if (!isCustomMethod(pathKey)) return;
 
-    // Get HTTP methods for this path
-    const httpMethods = Object.keys(pathItem);
+  const httpMethods = Object.keys(input);
 
-    // Check for invalid methods
-    if (httpMethods.some((method) => !VALID_METHODS.includes(method))) {
-      errors.push({ path: ['paths', pathKey], message: ERROR_MESSAGE });
-      continue;
-    }
-
-    // Check for multiple valid methods
-    const validMethodCount = httpMethods.filter((method) => VALID_METHODS.includes(method)).length;
-
-    if (validMethodCount > 1) {
-      errors.push({ path: ['paths', pathKey], message: ERROR_MESSAGE });
-    }
+  // Check for invalid methods
+  if (httpMethods.some((method) => !VALID_METHODS.includes(method))) {
+    return ERROR_RESULT;
   }
 
-  return errors;
+  // Check for multiple valid methods
+  const validMethodCount = httpMethods.filter((method) => VALID_METHODS.includes(method)).length;
+
+  if (validMethodCount > 1) {
+    return ERROR_RESULT;
+  }
 };

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -1,0 +1,25 @@
+import { isCustomMethod } from './utils/resourceEvaluation';
+
+const ERROR_MESSAGE = 'The HTTP method for custom methods must be GET or POST.';
+const ERROR_RESULT = [{ message: ERROR_MESSAGE }];
+const validMethods = ["get", "post"];
+
+export default (input, _, { documentInventory }) => {
+  if(!isCustomMethod(input)) {
+    return;
+  }
+
+  const oas = documentInventory.resolved;
+  let httpMethods = Object.keys(oas.paths[input]);
+
+  const invalidMethodsFound = httpMethods.some((key) => !validMethods.includes(key));
+  if(invalidMethodsFound) {
+    return ERROR_RESULT;
+  }
+
+  const validMethodsFound = httpMethods.filter((key) => validMethods.includes(key));
+  if(validMethodsFound.length > 1) {
+    return ERROR_RESULT;
+  }
+
+}

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -1,4 +1,4 @@
-import { isCustomMethod } from './utils/resourceEvaluation';
+import { isCustomMethod } from './utils/resourceEvaluation.js';
 
 const ERROR_MESSAGE = 'The HTTP method for custom methods must be GET or POST.';
 const ERROR_RESULT = [{ message: ERROR_MESSAGE }];

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -3,7 +3,7 @@ import { isCustomMethod } from './utils/resourceEvaluation.js';
 const ERROR_MESSAGE = 'The HTTP method for custom methods must be GET or POST.';
 const ERROR_RESULT = [{ message: ERROR_MESSAGE }];
 const VALID_METHODS = ['get', 'post'];
-const EXCEPTION_EXTENSION_KEY = 'x-xgen-IPA-exception';
+const HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 
 export default (input, opts, { path }) => {
   // Extract the path key (e.g., '/a/{exampleId}:method') from the JSONPath.
@@ -11,9 +11,9 @@ export default (input, opts, { path }) => {
 
   if (!isCustomMethod(pathKey)) return;
 
-  //Exclude exception extension key
+  //Extract the keys which are equivalent of the http methods
   let keys = Object.keys(input);
-  const httpMethods = keys.filter((key) => key !== EXCEPTION_EXTENSION_KEY);
+  const httpMethods = keys.filter((key) => HTTP_METHODS.includes(key));
 
   // Check for invalid methods
   if (httpMethods.some((method) => !VALID_METHODS.includes(method))) {

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -13,7 +13,7 @@ export default (input, opts, { path }) => {
 
   //Exclude exception extension key
   let keys = Object.keys(input);
-  const httpMethods = keys.filter(key => key !== EXCEPTION_EXTENSION_KEY);
+  const httpMethods = keys.filter((key) => key !== EXCEPTION_EXTENSION_KEY);
 
   // Check for invalid methods
   if (httpMethods.some((method) => !VALID_METHODS.includes(method))) {

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -16,15 +16,13 @@ export default (paths) => {
     const httpMethods = Object.keys(pathItem);
 
     // Check for invalid methods
-    if (httpMethods.some(method => !VALID_METHODS.includes(method))) {
+    if (httpMethods.some((method) => !VALID_METHODS.includes(method))) {
       errors.push({ path: ['paths', pathKey], message: ERROR_MESSAGE });
       continue;
     }
 
     // Check for multiple valid methods
-    const validMethodCount = httpMethods.filter(method =>
-      VALID_METHODS.includes(method)
-    ).length;
+    const validMethodCount = httpMethods.filter((method) => VALID_METHODS.includes(method)).length;
 
     if (validMethodCount > 1) {
       errors.push({ path: ['paths', pathKey], message: ERROR_MESSAGE });
@@ -32,5 +30,4 @@ export default (paths) => {
   }
 
   return errors;
-
 };

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -1,24 +1,36 @@
 import { isCustomMethod } from './utils/resourceEvaluation.js';
 
 const ERROR_MESSAGE = 'The HTTP method for custom methods must be GET or POST.';
-const ERROR_RESULT = [{ message: ERROR_MESSAGE }];
-const validMethods = ['get', 'post'];
+const VALID_METHODS = ['get', 'post'];
 
-export default (input, _, { documentInventory }) => {
-  if (!isCustomMethod(input)) {
-    return;
+export default (paths) => {
+  // Collect all errors
+  const errors = [];
+
+  // Iterate through each path key and its corresponding path item
+  for (const [pathKey, pathItem] of Object.entries(paths)) {
+    // Skip if not a custom method
+    if (!isCustomMethod(pathKey)) continue;
+
+    // Get HTTP methods for this path
+    const httpMethods = Object.keys(pathItem);
+
+    // Check for invalid methods
+    if (httpMethods.some(method => !VALID_METHODS.includes(method))) {
+      errors.push({ path: ['paths', pathKey], message: ERROR_MESSAGE });
+      continue;
+    }
+
+    // Check for multiple valid methods
+    const validMethodCount = httpMethods.filter(method =>
+      VALID_METHODS.includes(method)
+    ).length;
+
+    if (validMethodCount > 1) {
+      errors.push({ path: ['paths', pathKey], message: ERROR_MESSAGE });
+    }
   }
 
-  const oas = documentInventory.resolved;
-  let httpMethods = Object.keys(oas.paths[input]);
+  return errors;
 
-  const invalidMethodsFound = httpMethods.some((key) => !validMethods.includes(key));
-  if (invalidMethodsFound) {
-    return ERROR_RESULT;
-  }
-
-  const validMethodsFound = httpMethods.filter((key) => validMethods.includes(key));
-  if (validMethodsFound.length > 1) {
-    return ERROR_RESULT;
-  }
 };

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -3,6 +3,7 @@ import { isCustomMethod } from './utils/resourceEvaluation.js';
 const ERROR_MESSAGE = 'The HTTP method for custom methods must be GET or POST.';
 const ERROR_RESULT = [{ message: ERROR_MESSAGE }];
 const VALID_METHODS = ['get', 'post'];
+const EXCEPTION_EXTENSION_KEY = 'x-xgen-IPA-exception';
 
 export default (input, opts, { path }) => {
   // Extract the path key (e.g., '/a/{exampleId}:method') from the JSONPath.
@@ -10,7 +11,9 @@ export default (input, opts, { path }) => {
 
   if (!isCustomMethod(pathKey)) return;
 
-  const httpMethods = Object.keys(input);
+  //Exclude exception extension key
+  let keys = Object.keys(input);
+  const httpMethods = keys.filter(key => key !== EXCEPTION_EXTENSION_KEY);
 
   // Check for invalid methods
   if (httpMethods.some((method) => !VALID_METHODS.includes(method))) {

--- a/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
+++ b/tools/spectral/ipa/rulesets/functions/eachCustomMethodMustBeGetOrPost.js
@@ -2,10 +2,10 @@ import { isCustomMethod } from './utils/resourceEvaluation';
 
 const ERROR_MESSAGE = 'The HTTP method for custom methods must be GET or POST.';
 const ERROR_RESULT = [{ message: ERROR_MESSAGE }];
-const validMethods = ["get", "post"];
+const validMethods = ['get', 'post'];
 
 export default (input, _, { documentInventory }) => {
-  if(!isCustomMethod(input)) {
+  if (!isCustomMethod(input)) {
     return;
   }
 
@@ -13,13 +13,12 @@ export default (input, _, { documentInventory }) => {
   let httpMethods = Object.keys(oas.paths[input]);
 
   const invalidMethodsFound = httpMethods.some((key) => !validMethods.includes(key));
-  if(invalidMethodsFound) {
+  if (invalidMethodsFound) {
     return ERROR_RESULT;
   }
 
   const validMethodsFound = httpMethods.filter((key) => validMethods.includes(key));
-  if(validMethodsFound.length > 1) {
+  if (validMethodsFound.length > 1) {
     return ERROR_RESULT;
   }
-
-}
+};


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-287245](https://jira.mongodb.org/browse/CLOUDP-287245)

Implements a rule that the HTTP method for custom methods must be either GET or POST (https://docs.devprod.prod.corp.mongodb.com/ipa/109).

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->
## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [x] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
