### PR TITLE
CLOUDP-288860: Require .js extension on imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,17 @@
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
 import globals from 'globals';
+import { FlatCompat } from '@eslint/eslintrc';
 import pluginJs from '@eslint/js';
 import pluginJest from 'eslint-plugin-jest';
 import jest from 'eslint-plugin-jest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -23,4 +33,9 @@ export default [
     files: ['**/*.test.js'],
     ...jest.configs['flat/recommended'],
   },
+  ...compat.config({
+    plugins: ['require-extensions'],
+    extends: 'plugin:require-extensions/recommended',
+    ignorePatterns: ['**/*.test.js'],
+  }),
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@eslint/js": "^9.16.0",
                 "@jest/globals": "^29.7.0",
                 "eslint": "^9.17.0",
+                "eslint-plugin-require-extensions": "^0.1.3",
                 "globals": "^15.13.0",
                 "jest": "^29.7.0",
                 "prettier": "3.4.2"
@@ -4735,6 +4736,19 @@
                 "jest": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-plugin-require-extensions": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-require-extensions/-/eslint-plugin-require-extensions-0.1.3.tgz",
+            "integrity": "sha512-T3c1PZ9PIdI3hjV8LdunfYI8gj017UQjzAnCrxuo3wAjneDbTPHdE3oNWInOjMA+z/aBkUtlW5vC0YepYMZIug==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=16"
+            },
+            "peerDependencies": {
+                "eslint": "*"
             }
         },
         "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@eslint/js": "^9.16.0",
         "@jest/globals": "^29.7.0",
         "eslint": "^9.17.0",
+        "eslint-plugin-require-extensions": "^0.1.3",
         "globals": "^15.13.0",
         "jest": "^29.7.0",
         "prettier": "3.4.2"

--- a/tools/spectral/ipa/rulesets/functions/eachPathAlternatesBetweenResourceNameAndPathParam.js
+++ b/tools/spectral/ipa/rulesets/functions/eachPathAlternatesBetweenResourceNameAndPathParam.js
@@ -1,5 +1,5 @@
 import { isPathParam } from './utils/pathUtils.js';
-import { hasException } from './utils/exceptions';
+import { hasException } from './utils/exceptions.js';
 
 const RULE_NAME = 'xgen-IPA-102-path-alternate-resource-name-path-param';
 const ERROR_MESSAGE = 'API paths must alternate between resource name and path params.';

--- a/tools/spectral/ipa/rulesets/functions/eachResourceHasGetMethod.js
+++ b/tools/spectral/ipa/rulesets/functions/eachResourceHasGetMethod.js
@@ -6,7 +6,7 @@ import {
   isSingletonResource,
   getResourcePaths,
 } from './utils/resourceEvaluation.js';
-import { hasException } from './utils/exceptions';
+import { hasException } from './utils/exceptions.js';
 
 const RULE_NAME = 'xgen-IPA-104-resource-has-GET';
 const ERROR_MESSAGE = 'APIs must provide a get method for resources.';


### PR DESCRIPTION
## Proposed changes

Added eslint plugin to check that imports have .js extensions. No .js extension will cause issues in external repos importing the spectral rulesets with custom .js functions.

_Jira ticket:_ [CLOUDP-288860](https://jira.mongodb.org/browse/CLOUDP-288860)
