### PR TITLE
CLOUDP-288860: Update IPA exception format

### DIFF
--- a/tools/spectral/ipa/__tests__/exceptionExtensionFormat.test.js
+++ b/tools/spectral/ipa/__tests__/exceptionExtensionFormat.test.js
@@ -8,17 +8,13 @@ testRule('xgen-IPA-005-exception-extension-format', [
       paths: {
         '/path': {
           'x-xgen-IPA-exception': {
-            'xgen-IPA-100-rule-name': {
-              reason: 'Exception',
-            },
+            'xgen-IPA-100-rule-name': 'Exception',
           },
         },
         '/nested': {
           post: {
             'x-xgen-IPA-exception': {
-              'xgen-IPA-100-rule-name': {
-                reason: 'Exception',
-              },
+              'xgen-IPA-100-rule-name': 'Exception',
             },
           },
         },
@@ -35,39 +31,17 @@ testRule('xgen-IPA-005-exception-extension-format', [
         },
         '/path2': {
           'x-xgen-IPA-exception': {
-            'xgen-IPA-100-rule-name': 'Exception',
-          },
-        },
-        '/path3': {
-          'x-xgen-IPA-exception': {
             'xgen-IPA-100-rule-name': {
               reason: '',
             },
           },
         },
+        '/path3': {
+          'x-xgen-IPA-exception': {
+            'invalid-rule-name': 'Exception',
+          },
+        },
         '/path4': {
-          'x-xgen-IPA-exception': {
-            'invalid-rule-name': {
-              reason: 'Exception',
-            },
-          },
-        },
-        '/path5': {
-          'x-xgen-IPA-exception': {
-            'xgen-IPA-100-rule-name': {
-              wrongKey: 'Exception',
-            },
-          },
-        },
-        '/path6': {
-          'x-xgen-IPA-exception': {
-            'xgen-IPA-100-rule-name': {
-              reason: 'Exception',
-              excessKey: 'Exception',
-            },
-          },
-        },
-        '/path7': {
           'x-xgen-IPA-exception': {
             'xgen-IPA-100-rule-name': {},
           },
@@ -90,31 +64,13 @@ testRule('xgen-IPA-005-exception-extension-format', [
       {
         code: 'xgen-IPA-005-exception-extension-format',
         message: 'IPA exceptions must have a valid rule name and a reason. http://go/ipa/5',
-        path: ['paths', '/path3', 'x-xgen-IPA-exception', 'xgen-IPA-100-rule-name'],
+        path: ['paths', '/path3', 'x-xgen-IPA-exception', 'invalid-rule-name'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-005-exception-extension-format',
         message: 'IPA exceptions must have a valid rule name and a reason. http://go/ipa/5',
-        path: ['paths', '/path4', 'x-xgen-IPA-exception', 'invalid-rule-name'],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        code: 'xgen-IPA-005-exception-extension-format',
-        message: 'IPA exceptions must have a valid rule name and a reason. http://go/ipa/5',
-        path: ['paths', '/path5', 'x-xgen-IPA-exception', 'xgen-IPA-100-rule-name'],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        code: 'xgen-IPA-005-exception-extension-format',
-        message: 'IPA exceptions must have a valid rule name and a reason. http://go/ipa/5',
-        path: ['paths', '/path6', 'x-xgen-IPA-exception', 'xgen-IPA-100-rule-name'],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        code: 'xgen-IPA-005-exception-extension-format',
-        message: 'IPA exceptions must have a valid rule name and a reason. http://go/ipa/5',
-        path: ['paths', '/path7', 'x-xgen-IPA-exception', 'xgen-IPA-100-rule-name'],
+        path: ['paths', '/path4', 'x-xgen-IPA-exception', 'xgen-IPA-100-rule-name'],
         severity: DiagnosticSeverity.Warning,
       },
     ],

--- a/tools/spectral/ipa/__tests__/utils/exceptions.test.js
+++ b/tools/spectral/ipa/__tests__/utils/exceptions.test.js
@@ -5,47 +5,35 @@ const TEST_RULE_NAME_100 = 'xgen-IPA-100';
 
 const objectWithIpa100Exception = {
   'x-xgen-IPA-exception': {
-    'xgen-IPA-100': {
-      reason: 'test',
-    },
+    'xgen-IPA-100': 'reason',
   },
 };
 
 const objectWithNestedIpa100Exception = {
   get: {
     'x-xgen-IPA-exception': {
-      'xgen-IPA-100': {
-        reason: 'test',
-      },
+      'xgen-IPA-100': 'reason',
     },
   },
 };
 
 const objectWithIpa100ExceptionAndOwnerExtension = {
   'x-xgen-IPA-exception': {
-    'xgen-IPA-100': {
-      reason: 'test',
-    },
+    'xgen-IPA-100': 'reason',
   },
   'x-xgen-owner-team': 'apix',
 };
 
 const objectWithIpa101Exception = {
   'x-xgen-IPA-exception': {
-    'xgen-IPA-101': {
-      reason: 'test',
-    },
+    'xgen-IPA-101': 'reason',
   },
 };
 
 const objectWithIpa100And101Exception = {
   'x-xgen-IPA-exception': {
-    'xgen-IPA-101': {
-      reason: 'test',
-    },
-    'xgen-IPA-100': {
-      reason: 'test',
-    },
+    'xgen-IPA-101': 'reason',
+    'xgen-IPA-100': 'reason',
   },
 };
 

--- a/tools/spectral/ipa/rulesets/functions/exceptionExtensionFormat.js
+++ b/tools/spectral/ipa/rulesets/functions/exceptionExtensionFormat.js
@@ -1,6 +1,5 @@
 const ERROR_MESSAGE = 'IPA exceptions must have a valid rule name and a reason.';
 const RULE_NAME_PREFIX = 'xgen-IPA-';
-const REASON_KEY = 'reason';
 
 // Note: This rule does not allow exceptions
 export default (input, _, { path }) => {
@@ -8,8 +7,8 @@ export default (input, _, { path }) => {
   const errors = [];
 
   exemptedRules.forEach((ruleName) => {
-    const exception = input[ruleName];
-    if (!isValidException(ruleName, exception)) {
+    const reason = input[ruleName];
+    if (!isValidException(ruleName, reason)) {
       errors.push({
         path: path.concat([ruleName]),
         message: ERROR_MESSAGE,
@@ -20,12 +19,6 @@ export default (input, _, { path }) => {
   return errors;
 };
 
-function isValidException(ruleName, exception) {
-  const exceptionObjectKeys = Object.keys(exception);
-  return (
-    ruleName.startsWith(RULE_NAME_PREFIX) &&
-    exceptionObjectKeys.length === 1 &&
-    exceptionObjectKeys.includes(REASON_KEY) &&
-    exception[REASON_KEY] !== ''
-  );
+function isValidException(ruleName, reason) {
+  return ruleName.startsWith(RULE_NAME_PREFIX) && typeof reason === 'string' && reason !== '';
 }


### PR DESCRIPTION
## Proposed changes

Updated the spec with a change to the exception format, now the exceptions are formatted as follows:

```
"x-xgen-IPA-exception": {
  "xgen-IPA-104-resource-has-GET": "Legacy API, not used by infrastructure-as-code tooling",
  "xgen-IPA-105-resource-has-LIST": "Legacy API, not used by infrastructure-as-code tooling"
},
```

Previously: 
```
"x-xgen-IPA-exception": {
  "xgen-IPA-104-resource-has-GET": {
    "reason": "Legacy API, not used by infrastructure-as-code tooling"
  },
  "xgen-IPA-105-resource-has-LIST": {
    "reason": "Legacy API, not used by infrastructure-as-code tooling"
  }
},
```

- Updated the exception format validation to validate the new format
- Updated exceptions in tests

_Jira ticket:_ [CLOUDP-288860](https://jira.mongodb.org/browse/CLOUDP-288860)