### PR TITLE
CLOUDP-291457: IPA-123 ArraySchema fix

### DIFF
--- a/tools/spectral/ipa/__tests__/eachEnumValueMustBeUpperSnakeCase.test.js
+++ b/tools/spectral/ipa/__tests__/eachEnumValueMustBeUpperSnakeCase.test.js
@@ -22,7 +22,7 @@ testRule('xgen-IPA-123-enum-values-must-be-upper-snake-case', [
                 items: {
                   type: 'string',
                   enum: ['EXAMPLE_A', 'EXAMPLE_B'],
-                }
+                },
               },
             },
           },

--- a/tools/spectral/ipa/__tests__/eachEnumValueMustBeUpperSnakeCase.test.js
+++ b/tools/spectral/ipa/__tests__/eachEnumValueMustBeUpperSnakeCase.test.js
@@ -7,11 +7,22 @@ testRule('xgen-IPA-123-enum-values-must-be-upper-snake-case', [
     document: {
       components: {
         schemas: {
-          SchemaName: {
+          SchemaName1: {
             properties: {
               exampleProperty: {
                 enum: ['EXAMPLE_A', 'EXAMPLE_B'],
                 type: 'string',
+              },
+            },
+          },
+          SchemaName2: {
+            properties: {
+              exampleProperty: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['EXAMPLE_A', 'EXAMPLE_B'],
+                }
               },
             },
           },
@@ -36,6 +47,20 @@ testRule('xgen-IPA-123-enum-values-must-be-upper-snake-case', [
               },
             },
           },
+          SchemaName2: {
+            properties: {
+              exampleProperty: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['exampleA', 'exampleB'],
+                },
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-123-enum-values-must-be-upper-snake-case': 'reason',
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -54,6 +79,17 @@ testRule('xgen-IPA-123-enum-values-must-be-upper-snake-case', [
               },
             },
           },
+          SchemaName2: {
+            properties: {
+              exampleProperty: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['exampleA', 'exampleB'],
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -68,6 +104,18 @@ testRule('xgen-IPA-123-enum-values-must-be-upper-snake-case', [
         code: 'xgen-IPA-123-enum-values-must-be-upper-snake-case',
         message: 'enum[1]:exampleB enum value must be UPPER_SNAKE_CASE.  http://go/ipa/123',
         path: ['components', 'schemas', 'SchemaName', 'properties', 'exampleProperty'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-123-enum-values-must-be-upper-snake-case',
+        message: 'enum[0]:exampleA enum value must be UPPER_SNAKE_CASE.  http://go/ipa/123',
+        path: ['components', 'schemas', 'SchemaName2', 'properties', 'exampleProperty'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-123-enum-values-must-be-upper-snake-case',
+        message: 'enum[1]:exampleB enum value must be UPPER_SNAKE_CASE.  http://go/ipa/123',
+        path: ['components', 'schemas', 'SchemaName2', 'properties', 'exampleProperty'],
         severity: DiagnosticSeverity.Warning,
       },
     ],

--- a/tools/spectral/ipa/rulesets/functions/eachEnumValueMustBeUpperSnakeCase.js
+++ b/tools/spectral/ipa/rulesets/functions/eachEnumValueMustBeUpperSnakeCase.js
@@ -6,10 +6,10 @@ const RULE_NAME = 'xgen-IPA-123-enum-values-must-be-upper-snake-case';
 const ERROR_MESSAGE = 'enum value must be UPPER_SNAKE_CASE.';
 
 export function getSchemaPathFromEnumPath(path) {
-  if(path.includes('items')) {
-    path = path.slice(0, - 1);
+  if (path.includes('items')) {
+    path = path.slice(0, -1);
   }
-  return path.slice(0, - 1);
+  return path.slice(0, -1);
 }
 
 export default (input, _, { path, documentInventory }) => {

--- a/tools/spectral/ipa/rulesets/functions/eachEnumValueMustBeUpperSnakeCase.js
+++ b/tools/spectral/ipa/rulesets/functions/eachEnumValueMustBeUpperSnakeCase.js
@@ -6,7 +6,10 @@ const RULE_NAME = 'xgen-IPA-123-enum-values-must-be-upper-snake-case';
 const ERROR_MESSAGE = 'enum value must be UPPER_SNAKE_CASE.';
 
 export function getSchemaPathFromEnumPath(path) {
-  return path.slice(0, path.length - 1);
+  if(path.includes('items')) {
+    path = path.slice(0, - 1);
+  }
+  return path.slice(0, - 1);
 }
 
 export default (input, _, { path, documentInventory }) => {

--- a/tools/spectral/ipa/rulesets/functions/eachEnumValueMustBeUpperSnakeCase.js
+++ b/tools/spectral/ipa/rulesets/functions/eachEnumValueMustBeUpperSnakeCase.js
@@ -5,11 +5,12 @@ import { casing } from '@stoplight/spectral-functions';
 const RULE_NAME = 'xgen-IPA-123-enum-values-must-be-upper-snake-case';
 const ERROR_MESSAGE = 'enum value must be UPPER_SNAKE_CASE.';
 
-export function getSchemaPathFromEnumPath(path) {
-  if (path.includes('items')) {
-    path = path.slice(0, -1);
+function getSchemaPathFromEnumPath(path) {
+  const enumIndex = path.lastIndexOf('enum');
+  if (path[enumIndex - 1] === 'items') {
+    return path.slice(0, enumIndex - 1);
   }
-  return path.slice(0, -1);
+  return path.slice(0, enumIndex);
 }
 
 export default (input, _, { path, documentInventory }) => {


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

In scope of _Jira ticket:_ [CLOUDP-291457](https://jira.mongodb.org/browse/CLOUDP-291457)

This PR addresses the handling of exceptions defined on array schema definitions. Specifically, exceptions applied at the schema level preceding `items.enum` are not properly matched.

Changes:
- Updated the logic to remove enum from the path when it directly follows items.
- This ensures that exceptions defined at the array schema level (before items.enum) are correctly recognized during validation.

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

<!--## Further comments-->

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
