### PR TITLE
CLOUDP-292660: Update `api-versions-reminder.yml` to send a slack reminder and create jira ticket when APIs are approaching sunset 

### DIFF
--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -93,7 +93,8 @@ jobs:
             # This approach ensures we create a new jira ticket only if the there is not already a ticket 
             # with the same title
             hash_code_sunset_apis=$(echo "$sunset_apis" | jq -cS . | md5sum | awk '{print $1}')
-            
+            echo "hash: ${hash_code_sunset_apis}"
+          
             echo sunset_apis="${sunset_apis}" >> "${GITHUB_OUTPUT:?}"
             echo hash_code_sunset_apis="${hash_code_sunset_apis}" >> "${GITHUB_OUTPUT:?}"
             

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -127,6 +127,7 @@ jobs:
           
           sleep 2 # wait for 2 seconds to avoid slack rate limit
           
+          # Add the JSON array as a reply to message thread
           curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
           -H 'Content-type: application/json' \
           --data '{"channel":"'"${SLACK_CHANNEL_ID}"'",{"thread_ts":"'"${message_id}"'","text":"'"${SUNSET_APIS}"'","parse": "full",}' https://slack.com/api/chat.postMessage

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -55,9 +55,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+
+      - name: Install Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
-          sparse-checkout:
-            .github/scripts/upcoming_api_releases.sh
+          python-version: '3.12'
 
       - name: Install FOASCLI
         env:
@@ -84,20 +86,23 @@ jobs:
             three_weeks_date=$(date --date="3 weeks" +"%Y-%m-%d")
           fi
           
-          current_date=$(date +%s)
+          echo "three_weeks_date: ${three_weeks_date}"
+          
+          current_date=$(date +"%Y-%m-%d")
+          echo "current_date: ${current_date}"
+          
           sunset_apis=$(foascli sunset ls -s "${openapi_spec_url}" --from "${current_date}" --to "${three_weeks_date}")
           if [[ "$(sunset_apis)" != "null" ]]; then
             echo "API Versions that will be sunsets in the next 3 weeks: ${sunset_apis}"
-            
+          
             # We calculate the md5sum of the JSON object which will be included in the Jira ticket title. 
             # This approach ensures we create a new jira ticket only if the there is not already a ticket 
             # with the same title
             hash_code_sunset_apis=$(echo "$sunset_apis" | jq -cS . | md5sum | awk '{print $1}')
             echo "hash: ${hash_code_sunset_apis}"
-          
-            echo sunset_apis="${sunset_apis}" >> "${GITHUB_OUTPUT:?}"
             echo hash_code_sunset_apis="${hash_code_sunset_apis}" >> "${GITHUB_OUTPUT:?}"
-            
+            echo "${sunset_apis}" > sunset_apis.json
+          
           else
             echo "No API Versions will be sunset within the next 3 weeks."
           fi
@@ -105,12 +110,15 @@ jobs:
       # Create a JIRA ticket only if the there is not already a ticket with the same title
       - name: Create JIRA Ticket
         id: create-jira-ticket
-        if: steps.retrieve-sunset-apis.outputs.sunset_apis != null
+        if: steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis != null
         env:
           JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
           JIRA_TICKET_TITLE: "[API Platform] Some APIs are approaching their sunset date. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
-          JIRA_TICKET_DESCRIPTION: "The following APIs will be sunset in the next 3 weeks. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {code:json}${{steps.retrieve-sunset-apis.outputs.sunset_apis}}{code}"
-        run: .github/scripts/create_jira_ticket.sh
+        run: |
+          sunset_apis=$(cat sunset_apis.json | sed 's/"/\\"/g')
+          JIRA_TICKET_DESCRIPTION="The following APIs will be sunset in the next 3 weeks. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {code:json}${sunset_apis}{code}"
+          export JIRA_TICKET_DESCRIPTION
+          .github/scripts/create_jira_ticket.sh
 
       # Send Slack notification only if the Jira ticket was created
       - name: Send Slack Notification
@@ -118,17 +126,10 @@ jobs:
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_APIX_2 }}
           SLACK_BEARER_TOKEN: ${{ secrets.SLACK_BEARER_TOKEN }}
-          SUNSET_APIS: ${{ steps.retrieve-sunset-apis.outputs.sunset_apis }}
           JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
         run: |
+          echo "JIRA_TICKET_ID: ${JIRA_TICKET_ID}"
           message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
           -H 'Content-type: application/json' \
-          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next 3 weeks: see :thread:. Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
+          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next 3 weeks. See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
           echo "message_id=${message_id}"]
-          
-          sleep 2 # wait for 2 seconds to avoid slack rate limit
-          
-          # Add the JSON array as a reply to message thread
-          curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
-          -H 'Content-type: application/json' \
-          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'",{"thread_ts":"'"${message_id}"'","text":"'"${SUNSET_APIS}"'","parse": "full",}' https://slack.com/api/chat.postMessage

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -74,26 +74,27 @@ jobs:
       - name: Retrieve Sunset APIs
         id: retrieve-sunset-apis
         env:
-          openapi_spec_url: "https://raw.githubusercontent.com/mongodb/openapi/dev/openapi/v2/versions.json"
+          openapi_spec_url: "https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/v2.json"
         run: |
-          three_weeks_date=""
+          three_months_date=""
+          
           # Determine if the system is macOS or Linux
           if [[ "$(uname)" == "Darwin" ]]; then
-            # macOS date command format
-            three_weeks_date=$(date -v+3w +"%Y-%m-%d")
+          # macOS date command format
+            three_months_date=$(date -v+3m +"%Y-%m-%d")
           else
-            # Linux date command format
-            three_weeks_date=$(date --date="3 weeks" +"%Y-%m-%d")
+          # Linux date command format
+            three_months_date=$(date --date="3 months" +"%Y-%m-%d")
           fi
           
-          echo "three_weeks_date: ${three_weeks_date}"
+          echo "three_months_date: ${three_months_date}"
           
           current_date=$(date +"%Y-%m-%d")
           echo "current_date: ${current_date}"
           
-          sunset_apis=$(foascli sunset ls -s "${openapi_spec_url}" --from "${current_date}" --to "${three_weeks_date}")
-          if [[ "$(sunset_apis)" != "null" ]]; then
-            echo "API Versions that will be sunsets in the next 3 weeks: ${sunset_apis}"
+          sunset_apis=$(foascli sunset ls -s "${openapi_spec_url}" --from "${current_date}" --to "${three_months_date}")
+          if [[ "${sunset_apis}" != "null" ]]; then
+            echo "API Versions that will be sunsets in the next 3 months: ${sunset_apis}"
           
             # We calculate the md5sum of the JSON object which will be included in the Jira ticket title. 
             # This approach ensures we create a new jira ticket only if the there is not already a ticket 
@@ -104,7 +105,7 @@ jobs:
             echo "${sunset_apis}" > sunset_apis.json
           
           else
-            echo "No API Versions will be sunset within the next 3 weeks."
+            echo "No API Versions will be sunset within the next 3 months."
           fi
 
       # Create a JIRA ticket only if the there is not already a ticket with the same title
@@ -113,10 +114,10 @@ jobs:
         if: steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis != null
         env:
           JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
-          JIRA_TICKET_TITLE: "[API Platform] Some APIs are approaching their sunset date. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
+          JIRA_TICKET_TITLE: "[API Platform] Some APIs are approaching their sunset date in the next 3 months. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
         run: |
           sunset_apis=$(cat sunset_apis.json | sed 's/"/\\"/g')
-          JIRA_TICKET_DESCRIPTION="The following APIs will be sunset in the next 3 weeks. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {code:json}${sunset_apis}{code}"
+          JIRA_TICKET_DESCRIPTION="The following APIs will be sunset in the next 3 months. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {code:json}${sunset_apis}{code}"
           export JIRA_TICKET_DESCRIPTION
           .github/scripts/create_jira_ticket.sh
 
@@ -131,5 +132,5 @@ jobs:
           echo "JIRA_TICKET_ID: ${JIRA_TICKET_ID}"
           message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
           -H 'Content-type: application/json' \
-          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next 3 weeks. See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
+          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next 3 months. See Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
           echo "message_id=${message_id}"]

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -1,4 +1,4 @@
-name: 'Send a Slack Notification for upcoming release of API versions'
+name: 'Send a Slack Notification for APIs important events'
 
 on:
   workflow_dispatch: # Allow manual triggering
@@ -6,7 +6,8 @@ on:
     - cron: '0 9 * * 1-5' # Run once a day at 09:00 UTC between Monday and Friday
 
 jobs:
-  send-api-version-reminder:
+  new-api-version-reminder:
+    name: New API Version Release Reminder
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (dev branch)
@@ -47,3 +48,85 @@ jobs:
           -H 'Content-type: application/json' \
           --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following API Versions are scheduled to be released in the next 3 weeks: '"${API_VERSIONS}"'. Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
           echo "message_id=${message_id}"
+
+  sunset-api-version-reminder:
+    name: Sunset APIs Reminder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          sparse-checkout:
+            .github/scripts/upcoming_api_releases.sh
+
+      - name: Install FOASCLI
+        env:
+          foascli_version: ${{ vars.FOASCLI_VERSION }}
+        run: |
+          wget https://github.com/mongodb/openapi/releases/download/v"${foascli_version}"/mongodb-foas-cli_"${foascli_version}"_linux_x86_64.tar.gz -O foascli.tar.gz
+          tar -xzvf foascli.tar.gz 
+          pushd mongodb-foas-cli_*
+          echo "$(pwd)/bin" >> "${GITHUB_PATH}"
+          popd
+
+      - name: Retrieve Sunset APIs
+        id: retrieve-sunset-apis
+        env:
+          openapi_spec_url: "https://raw.githubusercontent.com/mongodb/openapi/dev/openapi/v2/versions.json"
+        run: |
+          three_weeks_date=""
+          # Determine if the system is macOS or Linux
+          if [[ "$(uname)" == "Darwin" ]]; then
+            # macOS date command format
+            three_weeks_date=$(date -v+3w +"%Y-%m-%d")
+          else
+            # Linux date command format
+            three_weeks_date=$(date --date="3 weeks" +"%Y-%m-%d")
+          fi
+          
+          current_date=$(date +%s)
+          sunset_apis=$(foascli sunset ls -s "${openapi_spec_url}" --from "${current_date}" --to "${three_weeks_date}")
+          if [[ "$(sunset_apis)" != "null" ]]; then
+            echo "API Versions that will be sunsets in the next 3 weeks: ${sunset_apis}"
+            
+            # We calculate the md5sum of the JSON object which will be included in the Jira ticket title. 
+            # This approach ensures we create a new jira ticket only if the there is not already a ticket 
+            # with the same title
+            hash_code_sunset_apis=$(echo "$sunset_apis" | jq -cS . | md5sum | awk '{print $1}')
+            
+            echo sunset_apis="${sunset_apis}" >> "${GITHUB_OUTPUT:?}"
+            echo hash_code_sunset_apis="${hash_code_sunset_apis}" >> "${GITHUB_OUTPUT:?}"
+            
+          else
+            echo "No API Versions will be sunset within the next 3 weeks."
+          fi
+
+      # Create a JIRA ticket only if the there is not already a ticket with the same title
+      - name: Create JIRA Ticket
+        id: create-jira-ticket
+        if: steps.retrieve-sunset-apis.outputs.sunset_apis != null
+        env:
+          JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
+          JIRA_TICKET_TITLE: "[API Platform] Some APIs are approaching their sunset date. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
+          JIRA_TICKET_DESCRIPTION: "The following APIs will be sunset in the next 3 weeks. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {code:json}${{steps.retrieve-sunset-apis.outputs.sunset_apis}}{code}"
+        run: .github/scripts/create_jira_ticket.sh
+
+      # Send Slack notification only if the Jira ticket was created
+      - name: Send Slack Notification
+        if: steps.create-jira-ticket.outputs.jira-ticket-id != null
+        env:
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_APIX_2 }}
+          SLACK_BEARER_TOKEN: ${{ secrets.SLACK_BEARER_TOKEN }}
+          SUNSET_APIS: ${{ steps.retrieve-sunset-apis.outputs.sunset_apis }}
+          JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
+        run: |
+          message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
+          -H 'Content-type: application/json' \
+          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following APIs are scheduled to be sunset in the next 3 weeks: see :thread:. Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
+          echo "message_id=${message_id}"]
+          
+          sleep 2 # wait for 2 seconds to avoid slack rate limit
+          
+          curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
+          -H 'Content-type: application/json' \
+          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'",{"thread_ts":"'"${message_id}"'","text":"'"${SUNSET_APIS}"'","parse": "full",}' https://slack.com/api/chat.postMessage

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -116,8 +116,8 @@ jobs:
           JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
           JIRA_TICKET_TITLE: "[API Platform] Some APIs are approaching their sunset date in the next 3 months. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
         run: |
-          sunset_apis=$(cat sunset_apis.json | sed 's/"/\\"/g')
-          JIRA_TICKET_DESCRIPTION="The following APIs will be sunset in the next 3 months. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {code:json}${sunset_apis}{code}"
+          sunset_apis=$(sed 's/"/\\"/g' sunset_apis.json)
+          JIRA_TICKET_DESCRIPTION="The following APIs will be sunset in the next 3 months. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {noformat}${sunset_apis}{noformat}"
           export JIRA_TICKET_DESCRIPTION
           .github/scripts/create_jira_ticket.sh
 


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-292660


I tested in a fork: https://github.com/andreaangiolillo/openapi-test/actions/runs/12676885001
Jira ticket created: https://jira.mongodb.org/browse/CLOUDP-293642 


Slack message: (The last message in the chat is the correct one 😆 )
![Screenshot 2025-01-08 at 18 39 24](https://github.com/user-attachments/assets/2887cc4f-9bbe-4961-bed3-812d6191fdd1)