### PR TITLE
CLOUDP-287250: Add rule IPA-113 Singleton must not have ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@babel/preset-env": "^7.26.0",
                 "@eslint/js": "^9.16.0",
                 "@jest/globals": "^29.7.0",
+                "@stoplight/types": "^14.1.1",
                 "eslint": "^9.17.0",
                 "eslint-plugin-require-extensions": "^0.1.3",
                 "globals": "^15.14.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@babel/preset-env": "^7.26.0",
         "@eslint/js": "^9.16.0",
         "@jest/globals": "^29.7.0",
+        "@stoplight/types": "^14.1.1",
         "eslint": "^9.17.0",
         "eslint-plugin-require-extensions": "^0.1.3",
         "globals": "^15.14.0",

--- a/tools/spectral/ipa/__tests__/singletonHasNoId.test.js
+++ b/tools/spectral/ipa/__tests__/singletonHasNoId.test.js
@@ -1,0 +1,214 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-113-singleton-must-not-have-id', [
+  {
+    name: 'valid resources',
+    document: {
+      paths: {
+        '/standard': {
+          post: {},
+          get: {
+            responses: {
+              200: {
+                content: {
+                  version1: {
+                    schema: {
+                      properties: {
+                        id: {},
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/standard/{exampleId}': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  version1: {
+                    schema: {
+                      properties: {
+                        id: {},
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          patch: {},
+          delete: {},
+        },
+        '/singleton1': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  version1: {
+                    schema: {
+                      properties: {
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/singleton2': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  version1: {
+                    schema: {
+                      properties: {
+                        someId: {},
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid resources',
+    document: {
+      paths: {
+        '/singleton1': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  version1: {
+                    schema: {
+                      properties: {
+                        id: {},
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/singleton2': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  version1: {
+                    schema: {
+                      properties: {
+                        _id: {},
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/singleton3': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  version1: {
+                    schema: {
+                      properties: {
+                        someId: {},
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                  version2: {
+                    schema: {
+                      properties: {
+                        id: {},
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-113-singleton-must-not-have-id',
+        message: 'Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113',
+        path: ['paths', '/singleton1'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-113-singleton-must-not-have-id',
+        message: 'Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113',
+        path: ['paths', '/singleton2'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-113-singleton-must-not-have-id',
+        message: 'Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113',
+        path: ['paths', '/singleton3'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid resources with exceptions',
+    document: {
+      paths: {
+        '/singleton1': {
+          'x-xgen-IPA-exception': {
+            'xgen-IPA-113-singleton-must-not-have-id': 'reason',
+          },
+          get: {
+            responses: {
+              200: {
+                content: {
+                  version1: {
+                    schema: {
+                      properties: {
+                        id: {},
+                        someProperty: {},
+                      },
+                      type: 'object',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -1,6 +1,7 @@
 extends:
-  - ./rulesets/IPA-005.yaml
   - ./rulesets/IPA-102.yaml
   - ./rulesets/IPA-104.yaml
+  - ./rulesets/IPA-005.yaml
   - ./rulesets/IPA-109.yaml
+  - ./rulesets/IPA-113.yaml
   - ./rulesets/IPA-123.yaml

--- a/tools/spectral/ipa/rulesets/IPA-113.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-113.yaml
@@ -1,0 +1,14 @@
+# IPA-113: Singleton Resources
+# http://go/ipa/113
+
+functions:
+  - singletonHasNoId
+
+rules:
+  xgen-IPA-113-singleton-must-not-have-id:
+    description: 'Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113'
+    message: '{{error}} http://go/ipa/113'
+    severity: warn
+    given: '$.paths[*]'
+    then:
+      function: 'singletonHasNoId'

--- a/tools/spectral/ipa/rulesets/functions/singletonHasNoId.js
+++ b/tools/spectral/ipa/rulesets/functions/singletonHasNoId.js
@@ -1,0 +1,46 @@
+import {
+  getResourcePaths,
+  hasGetMethod,
+  isChild,
+  isCustomMethod,
+  isSingletonResource,
+} from './utils/resourceEvaluation.js';
+import { hasException } from './utils/exceptions.js';
+import { getAllSuccessfulGetResponseSchemas } from './utils/methodUtils.js';
+
+const RULE_NAME = 'xgen-IPA-113-singleton-must-not-have-id';
+const ERROR_MESSAGE = 'Singleton resources must not have a user-provided or system-generated ID.';
+
+export default (input, opts, { path, documentInventory }) => {
+  const resourcePath = path[1];
+
+  if (isCustomMethod(resourcePath) || isChild(resourcePath)) {
+    return;
+  }
+
+  if (hasException(input, RULE_NAME)) {
+    return;
+  }
+
+  const oas = documentInventory.resolved;
+  const resourcePaths = getResourcePaths(resourcePath, Object.keys(oas.paths));
+
+  if (isSingletonResource(resourcePaths) && hasGetMethod(input)) {
+    const resourceSchemas = getAllSuccessfulGetResponseSchemas(input);
+    if (resourceSchemas.some((schema) => schemaHasIdProperty(schema))) {
+      return [
+        {
+          message: ERROR_MESSAGE,
+        },
+      ];
+    }
+  }
+};
+
+function schemaHasIdProperty(schema) {
+  if (Object.keys(schema).includes('properties')) {
+    const propertyNames = Object.keys(schema['properties']);
+    return propertyNames.includes('id') || propertyNames.includes('_id');
+  }
+  return false;
+}

--- a/tools/spectral/ipa/rulesets/functions/utils/methodUtils.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/methodUtils.js
@@ -1,0 +1,19 @@
+/**
+ * Returns a list of all successful response schemas for the 'get' method of the passed resource, i.e. for any 2xx response.
+ *
+ * @param {object} pathObject the object for the path
+ * @returns {Object[]} all 2xx 'get' response schemas
+ */
+export function getAllSuccessfulGetResponseSchemas(pathObject) {
+  const responses = pathObject['get']['responses'];
+  const successfulResponseKey = Object.keys(responses).filter((k) => k.startsWith('2'))[0];
+  const responseContent = responses[successfulResponseKey]['content'];
+  const result = [];
+  Object.keys(responseContent).forEach((k) => {
+    const schema = responseContent[k]['schema'];
+    if (schema) {
+      result.push(schema);
+    }
+  });
+  return result;
+}


### PR DESCRIPTION
## Proposed changes

Adds rule for IPA 113: "Singleton resources must not have a user-provided or system-generated ID".

- For singleton resources checks the fields in the response for the GET method, if there is a field `id` or `_id` it returns a validation error
- Ignores paginated or array responses

Drive-by:
- Improvement of the test hook to only create a spectral instance with the specific rule that is tested, reduces the number of rules that spectral will try to validate in one test run

Current offenders:
```
warning  xgen-IPA-113-singleton-must-not-have-id  Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113  paths./api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation
warning  xgen-IPA-113-singleton-must-not-have-id  Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113  paths./api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment
warning  xgen-IPA-113-singleton-must-not-have-id  Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113  paths./api/atlas/v2/orgs/{orgId}/federationSettings
```

_Jira ticket:_ [CLOUDP-287250](https://jira.mongodb.org/browse/CLOUDP-287250)
