### PR TITLE
CLOUDP-293820: Update optional validations workflow to use cached npm

### DIFF
--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -26,6 +26,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+      - name: Install npm dependencies
+        run: npm install
       - name: Download openapi-foas
         uses: actions/download-artifact@v4
         with:

--- a/tools/postman/README.md
+++ b/tools/postman/README.md
@@ -83,7 +83,13 @@ The OpenAPI path for Postman generation and configured feature flags can also be
 
 ### Running locally
 
-Once env vars are configured, the setup scripts can be run locally using the Make following commands:
+Once env vars are configured, install the required dependencies:
+
+```
+npm install
+```
+
+Then, the setup scripts can be run locally using the Make following commands:
 - `make fetch_openapi`
 - `make convert_to_collection` - covert OpenAPI to Postman collection
 - `make transform_collection` - transform Postman collection to fix common issues

--- a/tools/postman/scripts/convert-to-collection.sh
+++ b/tools/postman/scripts/convert-to-collection.sh
@@ -18,9 +18,6 @@ TMP_FOLDER=${TMP_FOLDER:-"../tmp"}
 echo "Removing regex"
 jq 'del(.. | select(type == "object") | .pattern?)' "$OPENAPI_FOLDER"/"$OPENAPI_FILE_NAME" > "$TMP_FOLDER"/tmp.json
 
-echo "Installing openapi-to-postmanv2"
-npm install
-
 echo "Converting $OPENAPI_FOLDER/$OPENAPI_FILE_NAME from OpenAPI to PostmanV2"
 npx openapi2postmanv2 -s "$TMP_FOLDER"/tmp.json -o "$TMP_FOLDER"/"$COLLECTION_FILE_NAME" -O folderStrategy=Tags
 


### PR DESCRIPTION
## Proposed changes

We've been seeing some failures with the postman validations in the GH actions due to network error. This PR updates the workflow to use `actions/setup-node`, which supports npm cache, to reduce these issues in the future. Currently the same approach is used for the other spectral validation workflows.

_Jira ticket:_ [CLOUDP-293820](https://jira.mongodb.org/browse/CLOUDP-293820)
