### PR TITLE
CLOUDP-293900: Fix failing Postman release job

### DIFF
--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          
+      - name: Install npm dependencies
+        run: npm install
+
       - name: Fetch OpenAPI Specification
         working-directory: ./tools/postman
         run: |


### PR DESCRIPTION
## Proposed changes

In a previous PR the npm install was removed from one of the Postman scripts, in favor of `actions/setup-node` with npm cache, though I forgot to add the same action step to the Postman release job causing it to fail. See: Issue #347

_Jira ticket:_ [CLOUDP-293900](https://jira.mongodb.org/browse/CLOUDP-293900)
