### PR TITLE
chore: FindLatestContentVersionMatched never errors

### DIFF
--- a/tools/cli/Makefile
+++ b/tools/cli/Makefile
@@ -13,8 +13,6 @@ E2E_TIMEOUT?=60m
 E2E_PARALLEL?=1
 E2E_EXTRA_ARGS?=
 
-
-
 LINKER_GH_SHA_FLAG=-s -w -X github.com/mongodb/openapi/tools/cli/internal/version.GitCommit=${GIT_SHA}
 LINKER_FLAGS=${LINKER_GH_SHA_FLAG} -X github.com/mongodb/openapi/tools/cli/internal/version.Version=${VERSION}
 

--- a/tools/cli/internal/apiversion/version.go
+++ b/tools/cli/internal/apiversion/version.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package apiversion
 
 import (
@@ -128,7 +129,7 @@ func Parse(contentType string) (string, error) {
 }
 
 // FindLatestContentVersionMatched finds the latest content version that matches the requested version.
-func FindLatestContentVersionMatched(op *openapi3.Operation, requestedVersion *APIVersion) (*APIVersion, error) {
+func FindLatestContentVersionMatched(op *openapi3.Operation, requestedVersion *APIVersion) *APIVersion {
 	/*
 		  given:
 			 version: 2024-01-01
@@ -142,7 +143,7 @@ func FindLatestContentVersionMatched(op *openapi3.Operation, requestedVersion *A
 	*/
 	var latestVersionMatch *APIVersion
 	if op.Responses == nil {
-		return requestedVersion, nil
+		return requestedVersion
 	}
 
 	for _, response := range op.Responses.Map() {
@@ -153,7 +154,7 @@ func FindLatestContentVersionMatched(op *openapi3.Operation, requestedVersion *A
 		for contentType := range response.Value.Content {
 			contentVersion, err := New(WithContent(contentType))
 			if err != nil {
-				log.Printf("Ignoring invalid content type: %s", contentType)
+				log.Printf("Ignoring invalid content type: %q", contentType)
 				continue
 			}
 			if contentVersion.GreaterThan(requestedVersion) {
@@ -161,7 +162,7 @@ func FindLatestContentVersionMatched(op *openapi3.Operation, requestedVersion *A
 			}
 
 			if contentVersion.Equal(requestedVersion) {
-				return contentVersion, nil
+				return contentVersion
 			}
 
 			if latestVersionMatch == nil || contentVersion.GreaterThan(latestVersionMatch) {
@@ -171,10 +172,10 @@ func FindLatestContentVersionMatched(op *openapi3.Operation, requestedVersion *A
 	}
 
 	if latestVersionMatch == nil {
-		return requestedVersion, nil
+		return requestedVersion
 	}
 
-	return latestVersionMatch, nil
+	return latestVersionMatch
 }
 
 // Sort versions

--- a/tools/cli/internal/apiversion/version_test.go
+++ b/tools/cli/internal/apiversion/version_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseVersion(t *testing.T) {
@@ -126,6 +127,7 @@ func TestNewAPIVersionFromContentType(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			version, err := New(WithContent(tt.contentType))
+			t.Parallel()
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -158,6 +160,7 @@ func TestApiVersion_GreaterThan(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			v1, _ := New(WithVersion(tt.version1))
 			v2, _ := New(WithVersion(tt.version2))
 			assert.Equal(t, tt.expected, v1.GreaterThan(v2))
@@ -188,6 +191,7 @@ func TestApiVersion_LessThan(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			v1, _ := New(WithVersion(tt.version1))
 			v2, _ := New(WithVersion(tt.version2))
 			assert.Equal(t, tt.expected, v1.LessThan(v2))
@@ -215,6 +219,7 @@ func TestApiVersion_IsZero(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			v, _ := New(WithVersion(tt.version))
 			assert.Equal(t, tt.expected, v.IsZero())
 		})
@@ -275,6 +280,7 @@ func TestApiVersion_Equal(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			v1, _ := New(WithVersion(tt.version1))
 			v2, _ := New(WithVersion(tt.version2))
 			assert.Equal(t, tt.expected, v1.Equal(v2))
@@ -311,6 +317,7 @@ func TestNewAPIVersionFromTime(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			timeValue, _ := time.Parse("2006-01-02", tt.time)
 			match, err := New(WithDate(timeValue))
 			if tt.wantErr {
@@ -327,114 +334,71 @@ func TestNewVersionDate(t *testing.T) {
 		name          string
 		version       string
 		expectedMatch string
-		wantErr       bool
+		wantErr       require.ErrorAssertionFunc
 	}{
 		{
 			name:          "2023-01-01",
 			version:       "2023-01-01",
 			expectedMatch: "2023-01-01",
-			wantErr:       false,
+			wantErr:       require.NoError,
 		},
 		{
 			name:          "2023-01-02",
 			version:       "2023-01-02",
 			expectedMatch: "2023-01-02",
-			wantErr:       false,
+			wantErr:       require.NoError,
 		},
 		{
 			name:          "2030-02-20",
 			version:       "2030-02-20",
 			expectedMatch: "2030-02-20",
-			wantErr:       false,
+			wantErr:       require.NoError,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			match, err := DateFromVersion(tt.version)
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.Equal(t, tt.expectedMatch, match.Format(dateFormat))
-			}
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.expectedMatch, match.Format(dateFormat))
 		})
 	}
 }
 
-func TestNewAPIVersionFromDateString(t *testing.T) {
+func TestNew_WithVersion(t *testing.T) {
 	testCases := []struct {
 		name          string
 		version       string
 		expectedMatch string
-		wantErr       bool
+		wantErr       require.ErrorAssertionFunc
 	}{
 		{
 			name:          "2023-01-01",
 			version:       "2023-01-01",
 			expectedMatch: "2023-01-01",
-			wantErr:       false,
+			wantErr:       require.NoError,
 		},
 		{
 			name:          "2023-01-02",
 			version:       "2023-01-02",
 			expectedMatch: "2023-01-02",
-			wantErr:       false,
+			wantErr:       require.NoError,
 		},
 		{
 			name:          "2030-02-20",
 			version:       "2030-02-20",
 			expectedMatch: "2030-02-20",
-			wantErr:       false,
+			wantErr:       require.NoError,
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			match, err := New(WithVersion(tt.version))
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.Equal(t, tt.expectedMatch, match.String())
-			}
-		})
-	}
-}
-
-func TestNewAPIVersion(t *testing.T) {
-	testCases := []struct {
-		name          string
-		version       string
-		expectedMatch string
-		wantErr       bool
-	}{
-		{
-			name:          "2023-01-01",
-			version:       "2023-01-01",
-			expectedMatch: "2023-01-01",
-			wantErr:       false,
-		},
-		{
-			name:          "2023-01-02",
-			version:       "2023-01-02",
-			expectedMatch: "2023-01-02",
-			wantErr:       false,
-		},
-		{
-			name:          "2030-02-20",
-			version:       "2030-02-20",
-			expectedMatch: "2030-02-20",
-			wantErr:       false,
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			match, err := New(WithVersion(tt.version))
-			if tt.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.Equal(t, tt.expectedMatch, match.String())
-			}
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.expectedMatch, match.String())
 		})
 	}
 }

--- a/tools/cli/internal/apiversion/version_test.go
+++ b/tools/cli/internal/apiversion/version_test.go
@@ -15,10 +15,10 @@
 package apiversion
 
 import (
-	"github.com/getkin/kin-openapi/openapi3"
 	"testing"
 	"time"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tools/cli/internal/openapi/filter/extension.go
+++ b/tools/cli/internal/openapi/filter/extension.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package filter
 
 import (
@@ -29,9 +30,11 @@ type ExtensionFilter struct {
 	metadata *Metadata
 }
 
-const sunsetExtension = "x-sunset"
-const xGenExtension = "x-xgen-version"
-const format = "2006-01-02T15:04:05Z07:00"
+const (
+	sunsetExtension = "x-sunset"
+	xGenExtension   = "x-xgen-version"
+	format          = "2006-01-02T15:04:05Z07:00"
+)
 
 func (f *ExtensionFilter) Apply() error {
 	for _, pathItem := range f.oas.Paths.Map() {
@@ -47,11 +50,7 @@ func (f *ExtensionFilter) Apply() error {
 
 			updateExtensionToDateString(operation.Extensions)
 
-			latestVersionMatch, err := apiversion.FindLatestContentVersionMatched(operation, f.metadata.targetVersion)
-			if err != nil {
-				return err
-			}
-
+			latestVersionMatch := apiversion.FindLatestContentVersionMatched(operation, f.metadata.targetVersion)
 			for _, response := range operation.Responses.Map() {
 				if response == nil {
 					continue
@@ -89,15 +88,15 @@ func updateExtensionToDateString(extensions map[string]any) {
 		return
 	}
 
-	for key, value := range extensions {
-		if key != sunsetExtension && key != xGenExtension {
+	for k, v := range extensions {
+		if k != sunsetExtension && k != xGenExtension {
 			continue
 		}
-		date, err := time.Parse(format, value.(string))
+		date, err := time.Parse(format, v.(string))
 		if err != nil {
 			continue
 		}
-		extensions[key] = date.Format("2006-01-02")
+		extensions[k] = date.Format("2006-01-02")
 	}
 }
 

--- a/tools/cli/internal/openapi/filter/versioning.go
+++ b/tools/cli/internal/openapi/filter/versioning.go
@@ -92,9 +92,7 @@ func (f *VersioningFilter) apply(path *openapi3.PathItem) error {
 		config.parsedOperations[op.OperationID] = opConfig
 
 		var err error
-		if opConfig.latestMatchedVersion, err = apiversion.FindLatestContentVersionMatched(op, f.metadata.targetVersion); err != nil {
-			return err
-		}
+		opConfig.latestMatchedVersion = apiversion.FindLatestContentVersionMatched(op, f.metadata.targetVersion)
 
 		err = updateResponses(op, config)
 		if err != nil {

--- a/tools/cli/internal/openapi/filter/versioning.go
+++ b/tools/cli/internal/openapi/filter/versioning.go
@@ -91,11 +91,8 @@ func (f *VersioningFilter) apply(path *openapi3.PathItem) error {
 		opConfig := newOperationConfig(op)
 		config.parsedOperations[op.OperationID] = opConfig
 
-		var err error
 		opConfig.latestMatchedVersion = apiversion.FindLatestContentVersionMatched(op, f.metadata.targetVersion)
-
-		err = updateResponses(op, config)
-		if err != nil {
+		if err := updateResponses(op, config); err != nil {
 			return err
 		}
 
@@ -103,12 +100,9 @@ func (f *VersioningFilter) apply(path *openapi3.PathItem) error {
 			log.Printf("Removing operation: %s", op.OperationID)
 			path.SetOperation(opKey, nil)
 		}
-
-		err = updateRequestBody(op, opConfig)
-		if err != nil {
+		if err := updateRequestBody(op, opConfig); err != nil {
 			return err
 		}
-
 		addDeprecationMessageToOperation(op, opConfig.deprecatedVersions)
 	}
 

--- a/tools/cli/internal/openapi/filter/versioning_test.go
+++ b/tools/cli/internal/openapi/filter/versioning_test.go
@@ -23,66 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPathFilter_getLatestVersionMatch(t *testing.T) {
-	testCases := []struct {
-		name          string
-		targetVersion string
-		expectedMatch string
-	}{
-		{
-			name:          "exact match 2023-01-01",
-			targetVersion: "2023-01-01",
-			expectedMatch: "2023-01-01",
-		},
-		{
-			name:          "exact match 2023-11-15",
-			targetVersion: "2023-11-15",
-			expectedMatch: "2023-11-15",
-		},
-		{
-			name:          "exact match 2024-05-30",
-			targetVersion: "2024-05-30",
-			expectedMatch: "2024-05-30",
-		},
-		{
-			name:          "approx match 2023-01-01",
-			targetVersion: "2023-01-02",
-			expectedMatch: "2023-01-01",
-		},
-		{
-			name:          "approx match 2023-01-01",
-			targetVersion: "2023-01-31",
-			expectedMatch: "2023-01-01",
-		},
-		{
-			name:          "approx match 2023-02-01",
-			targetVersion: "2023-02-20",
-			expectedMatch: "2023-02-01",
-		},
-		{
-			name:          "future date",
-			targetVersion: "2030-02-20",
-			expectedMatch: "2024-05-30",
-		},
-		{
-			name:          "past date",
-			targetVersion: "1999-02-20",
-			expectedMatch: "1999-02-20",
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			targetVersion, err := apiversion.New(apiversion.WithVersion(tt.targetVersion))
-			require.NoError(t, err)
-			r, err := apiversion.FindLatestContentVersionMatched(oasOperationAllVersions(), targetVersion)
-			require.NoError(t, err)
-			// transform time to str with format "2006-01-02"
-			assert.Equal(t, tt.expectedMatch, r.String())
-		})
-	}
-}
-
 func TestPathFilter_processPathItem(t *testing.T) {
 	version, err := apiversion.New(apiversion.WithVersion("2023-11-15"))
 	require.NoError(t, err)


### PR DESCRIPTION
## Proposed changes

`FindLatestContentVersionMatched` never errors, removing from returned values