### PR TITLE
chore: lint parity with CLI

### DIFF
--- a/tools/cli/.golangci.yml
+++ b/tools/cli/.golangci.yml
@@ -18,12 +18,15 @@ linters-settings:
       - name: blank-imports
       - name: context-as-argument
       - name: context-keys-type
+      - name: defer
       - name: dot-imports
       - name: error-return
       - name: error-strings
       - name: error-naming
+      - name: early-return
       - name: errorf
       - name: exported
+      - name: import-shadowing
       - name: indent-error-flow
       - name: if-return
       - name: increment-decrement
@@ -42,6 +45,15 @@ linters-settings:
       - name: unused-parameter
       - name: unreachable-code
       - name: redefines-builtin-id
+      - name: early-return
+      - name: unused-receiver
+      - name: constant-logical-expr
+      - name: confusing-naming
+      - name: unnecessary-stmt
+      - name: use-any
+      - name: imports-blocklist
+        arguments:
+          - "github.com/pkg/errors"
   misspell:
     locale: US
   lll:
@@ -52,42 +64,49 @@ linters-settings:
   funlen:
     lines: 360
     statements: 120
+  gci:
+    sections:
+      - standard
+      - default
 linters:
   disable-all: true
   enable:
-    - dogsled
-    - errcheck
-    - funlen
-    - gocritic
-    - gofmt
-    - goimports
-    - revive
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - lll
-    - misspell
-    - nakedret
-    - nolintlint
-    - rowserrcheck
-    - copyloopvar
-    - staticcheck
-    - stylecheck
-    - typecheck
-    - unconvert
-    - unused
-    - whitespace
-    - thelper
-    - testifylint
-    - exhaustive
-    - makezero
-    - noctx
-    - tenv
-    - prealloc
-    - predeclared
-    - whitespace
+    - copyloopvar # copyloopvar is a linter detects places where loop variables are copied
+    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    - errcheck # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases
+    - errorlint # Errorlint is a linter that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    - exhaustive # check exhaustiveness of enum switch statements
+    - copyloopvar # copyloopvar is a linter detects places where loop variables are copied. Replaces exportloopref since Go1.22
+    - funlen # Tool for detection of long functions
+    - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
+    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
+    - godot # Check if comments end in a period [fast: true, auto-fix: true]
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - goimports # Check import statements are formatted according to the 'goimport' command. Reformat imports in autofix mode.
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end.
+    - gosec # Inspects source code for security problems
+    - gosimple # Linter for Go source code that specializes in simplifying code
+    - govet # Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes.
+    - ineffassign # Detects when assignments to existing variables are not used
+    - lll # Reports long lines
+    - makezero # Finds slice declarations with non-zero initial length
+    - misspell # Finds commonly misspelled English words
+    - nakedret # Checks that functions with naked returns are not longer than a maximum size (can be zero).
+    - noctx # Finds sending http request without context.Context
+    - nolintlint # Reports ill-formed or insufficient nolint directives
+    - perfsprint # Checks that fmt.Sprintf can be replaced with a faster alternative.
+    - prealloc # Finds slice declarations that could potentially be pre-allocated
+    - predeclared # find code that shadows one of Go's predeclared identifiers
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    - rowserrcheck # checks whether Rows.Err of rows is checked successfully
+    - staticcheck # It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
+    - stylecheck # Stylecheck is a replacement for golint
+    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
+    - testifylint # Checks usage of github.com/stretchr/testify.
+    - thelper # thelper detects tests helpers which is not start with t.Helper() method.
+    - unconvert # Remove unnecessary type conversions
+    - unused # Checks Go code for unused constants, variables, functions and types
+    - whitespace # Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.
 
   # don't enable:
   #   - deadcode

--- a/tools/cli/.golangci.yml
+++ b/tools/cli/.golangci.yml
@@ -45,7 +45,6 @@ linters-settings:
       - name: unused-parameter
       - name: unreachable-code
       - name: redefines-builtin-id
-      - name: early-return
       - name: unused-receiver
       - name: constant-logical-expr
       - name: confusing-naming

--- a/tools/cli/internal/apiversion/version.go
+++ b/tools/cli/internal/apiversion/version.go
@@ -178,7 +178,7 @@ func FindLatestContentVersionMatched(op *openapi3.Operation, requestedVersion *A
 	return latestVersionMatch
 }
 
-// Sort versions
+// Sort versions.
 func Sort(versions []*APIVersion) {
 	for i := 0; i < len(versions); i++ {
 		for j := i + 1; j < len(versions); j++ {

--- a/tools/cli/internal/apiversion/version_test.go
+++ b/tools/cli/internal/apiversion/version_test.go
@@ -58,6 +58,7 @@ func TestParseVersion(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			match, err := Parse(tt.contentType)
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -127,6 +128,7 @@ func TestNewAPIVersionFromContentType(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			version, err := New(WithContent(tt.contentType))
 			t.Parallel()
 			if tt.wantErr {

--- a/tools/cli/internal/apiversion/version_test.go
+++ b/tools/cli/internal/apiversion/version_test.go
@@ -130,7 +130,6 @@ func TestNewAPIVersionFromContentType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			version, err := New(WithContent(tt.contentType))
-			t.Parallel()
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -474,7 +474,7 @@ func findChangelogEntry(changelog []*Entry, date, operationID, version, changeCo
 	return nil
 }
 
-func newStringFromStruct(data interface{}) string {
+func newStringFromStruct(data any) string {
 	bytes, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return ""
@@ -489,7 +489,7 @@ func newStringFromStruct(data interface{}) string {
 // 1. Remove all entries with hideFromChangelog
 // 2. Remove all empty versions
 // 3. Remove all empty paths
-// 4. Shift changelog entry if it turns out empty
+// 4. Shift changelog entry if it turns out empty.
 func NewNotHiddenEntries(changelog []*Entry) ([]*Entry, error) {
 	if len(changelog) == 0 {
 		return changelog, nil

--- a/tools/cli/internal/changelog/manual_entry_test.go
+++ b/tools/cli/internal/changelog/manual_entry_test.go
@@ -64,7 +64,7 @@ func TestDetectManualEntriesAndMergeChangelog(t *testing.T) {
 				HTTPMethod: "POST",
 				Tag:        "Multi-Cloud Clusters",
 				Sunset:     "",
-				ManualChangelogEntries: map[string]interface{}{
+				ManualChangelogEntries: map[string]any{
 					previousRunDate:    "change info 1", // Already in the changelog
 					runDate:            "change info 2", // Should be added to the changelog
 					theDayAfterRunDate: "change info 3", // Should not be added to the changelog

--- a/tools/cli/internal/changelog/merge.go
+++ b/tools/cli/internal/changelog/merge.go
@@ -50,7 +50,7 @@ func newChangeTypeOverrides() map[string]string {
 	}
 }
 
-// NewEntriesFromSunsetAndManualEntry merges the base changelog with the new changes from manual entries and sunset endpoints
+// NewEntriesFromSunsetAndManualEntry merges the base changelog with the new changes from manual entries and sunset endpoints.
 func (m *Changelog) NewEntriesFromSunsetAndManualEntry() ([]*Entry, error) {
 	conf := outputfilter.NewOperationConfigs(nil, m.Revision)
 	if _, err := m.newEntriesFromSunsetEndpoints(conf); err != nil {
@@ -116,7 +116,7 @@ func (m *Changelog) newManualEntries(conf map[string]*outputfilter.OperationConf
 	return m.BaseChangelog, nil
 }
 
-// newEntryFromOasDiff merges the base changelog with the new changes from a Base and Revision OpenAPI specs
+// newEntryFromOasDiff merges the base changelog with the new changes from a Base and Revision OpenAPI specs.
 func (m *Changelog) newEntryFromOasDiff() ([]*Entry, error) {
 	changes, err := m.newOasDiffEntries()
 	if err != nil {
@@ -143,7 +143,7 @@ func (m *Changelog) newEntryFromOasDiff() ([]*Entry, error) {
 // Logic:
 // 1. If the entry already exists in the changelog for the Run Date, use that entry or create it (newEntryAtRunDate)
 // 2. Get the paths from the changes and add them to the entry
-// 3. Sort the changelog by date DESC, path + httpMethod ASC, version DESC
+// 3. Sort the changelog by date DESC, path + httpMethod ASC, version DESC.
 func (m *Changelog) mergeChangelog(
 	changeType string,
 	changes []*outputfilter.OasDiffEntry,
@@ -167,7 +167,7 @@ func (m *Changelog) mergeChangelog(
 // 1. Get the deprecated paths from the changes
 // 2. Get the updated paths with the deprecated changes from newPathsFromDeprecatedChanges
 // 3. Get the revision paths from the changes
-// 4. Get the updated paths with the revision changes from newPathsFromRevisionChanges
+// 4. Get the updated paths with the revision changes from newPathsFromRevisionChanges.
 func (m *Changelog) newPathsFromChanges(
 	changes []*outputfilter.OasDiffEntry,
 	changeType string, entry *Entry,
@@ -185,7 +185,7 @@ func (m *Changelog) newPathsFromChanges(
 	return paths, nil
 }
 
-// newPathsFromRevisionChanges creates new paths from revision changes
+// newPathsFromRevisionChanges creates new paths from revision changes.
 func (m *Changelog) newPathsFromRevisionChanges(
 	changes []*outputfilter.OasDiffEntry,
 	changeType string, changelogPath *[]*Path,
@@ -194,7 +194,7 @@ func (m *Changelog) newPathsFromRevisionChanges(
 	return newMergedChanges(revisionChanges, changeType, m.RevisionMetadata.ActiveVersion, changelogPath, conf)
 }
 
-// newPathsFromDeprecatedChanges creates new paths from deprecated changes
+// newPathsFromDeprecatedChanges creates new paths from deprecated changes.
 func (m *Changelog) newPathsFromDeprecatedChanges(
 	changes []*outputfilter.OasDiffEntry,
 	changelogPath *[]*Path,
@@ -219,7 +219,7 @@ func (m *Changelog) newOasDiffEntries() ([]*outputfilter.OasDiffEntry, error) {
 	return outputfilter.NewChangelogEntries(changes, diffResult.SpecInfoPair, m.ExemptionFilePath)
 }
 
-// sortChangelog sorts changelog by date DESC, path + httpMethod ASC, version DESC
+// sortChangelog sorts changelog by date DESC, path + httpMethod ASC, version DESC.
 func sortChangelog(changelog []*Entry) []*Entry {
 	sort.Slice(changelog, func(i, j int) bool {
 		return changelog[i].Date > changelog[j].Date
@@ -242,7 +242,7 @@ func sortChangelog(changelog []*Entry) []*Entry {
 	return changelog
 }
 
-// newMergedChanges merges the OasDiff changes into the changelog []paths
+// newMergedChanges merges the OasDiff changes into the changelog []paths.
 func newMergedChanges(changes []*outputfilter.OasDiffEntry,
 	changeType, version string, changelogPath *[]*Path,
 	operationConfig map[string]*outputfilter.OperationConfigs) ([]*Path, error) {
@@ -372,7 +372,7 @@ func newEntryVersion(versions *[]*Version, specVersion string) *Version {
 }
 
 // newPathEntry returns the index and the path entry if it already exists in the changelog
-// otherwise it returns -1 and a new path entry
+// otherwise it returns -1 and a new path entry.
 func newPathEntry(paths *[]*Path, path, operation string) *Path {
 	for _, p := range *paths {
 		if p.URI == path && p.HTTPMethod == operation {

--- a/tools/cli/internal/changelog/merge_test.go
+++ b/tools/cli/internal/changelog/merge_test.go
@@ -15,7 +15,6 @@
 package changelog
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/mongodb/openapi/tools/cli/internal/changelog/outputfilter"
@@ -35,14 +34,14 @@ func TestMergeChangelogOneChange(t *testing.T) {
 				HTTPMethod:             "POST",
 				Tag:                    "Multi-Cloud Clusters",
 				Sunset:                 "",
-				ManualChangelogEntries: make(map[string]interface{}),
+				ManualChangelogEntries: make(map[string]any),
 			},
 			Revision: &outputfilter.OperationConfig{
 				Path:                   "/api/atlas/v2/groups/{groupId}/clusters",
 				HTTPMethod:             "POST",
 				Tag:                    "Multi-Cloud Clusters",
 				Sunset:                 "",
-				ManualChangelogEntries: make(map[string]interface{}),
+				ManualChangelogEntries: make(map[string]any),
 			},
 		},
 	}
@@ -111,14 +110,14 @@ func TestMergeChangelogTwoVersionsNoDeprecations(t *testing.T) {
 				HTTPMethod:             "POST",
 				Tag:                    "Multi-Cloud Clusters",
 				Sunset:                 "",
-				ManualChangelogEntries: make(map[string]interface{}),
+				ManualChangelogEntries: make(map[string]any),
 			},
 			Revision: &outputfilter.OperationConfig{
 				Path:                   "/api/atlas/v2/groups/{groupId}/clusters",
 				HTTPMethod:             "POST",
 				Tag:                    "Multi-Cloud Clusters",
 				Sunset:                 "",
-				ManualChangelogEntries: make(map[string]interface{}),
+				ManualChangelogEntries: make(map[string]any),
 			},
 		},
 	}
@@ -250,7 +249,7 @@ func TestMergeChangelogAddTwoEndpoints(t *testing.T) {
 				HTTPMethod:             "GET",
 				Tag:                    "Streams",
 				Sunset:                 "",
-				ManualChangelogEntries: make(map[string]interface{}),
+				ManualChangelogEntries: make(map[string]any),
 			},
 		},
 		"getStreamInstance": {
@@ -260,7 +259,7 @@ func TestMergeChangelogAddTwoEndpoints(t *testing.T) {
 				HTTPMethod:             "GET",
 				Tag:                    "Streams",
 				Sunset:                 "",
-				ManualChangelogEntries: make(map[string]interface{}),
+				ManualChangelogEntries: make(map[string]any),
 			},
 		},
 	}
@@ -487,14 +486,14 @@ func TestMergeChangelogTwoVersionsWithDeprecations(t *testing.T) {
 				HTTPMethod:             "POST",
 				Tag:                    "Multi-Cloud Clusters",
 				Sunset:                 sunset,
-				ManualChangelogEntries: make(map[string]interface{}),
+				ManualChangelogEntries: make(map[string]any),
 			},
 			Revision: &outputfilter.OperationConfig{
 				Path:                   "/api/atlas/v2/groups/{groupId}/clusters",
 				HTTPMethod:             "POST",
 				Tag:                    "Multi-Cloud Clusters",
 				Sunset:                 "",
-				ManualChangelogEntries: make(map[string]interface{}),
+				ManualChangelogEntries: make(map[string]any),
 			},
 		},
 	}
@@ -709,7 +708,7 @@ func TestMergeChangelogWithDeprecations(t *testing.T) {
 
 	assert.Equal(t, "endpoint-deprecated", firstVersionEntry.Changes[1].Code)
 	assert.True(t, firstVersionEntry.Changes[1].BackwardCompatible)
-	assert.Contains(t, firstVersionEntry.Changes[1].Description, fmt.Sprintf("deprecated and marked for removal on %s", sunset))
+	assert.Contains(t, firstVersionEntry.Changes[1].Description, "deprecated and marked for removal on "+sunset)
 
 	secondVersionEntry := versions[0]
 	require.Len(t, secondVersionEntry.Changes, 1)

--- a/tools/cli/internal/changelog/outputfilter/enum.go
+++ b/tools/cli/internal/changelog/outputfilter/enum.go
@@ -6,7 +6,7 @@ const (
 )
 
 // squashRequestPropertyEnumValueAdded squashes oasdiff entries with id: "response-property-enum-value-added"
-// Message format: "added the new 'DUBLIN_IRL' enum value to the '/items/dataProcessRegion/region' response property"
+// Message format: "added the new 'DUBLIN_IRL' enum value to the '/items/dataProcessRegion/region' response property".
 func squashResponsePropertyEnumValueAdded(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"response-property-enum-value-added",
@@ -19,7 +19,7 @@ func squashResponsePropertyEnumValueAdded(entriesGroupedByOperationID map[string
 }
 
 // squashResponsePropertyEnumValueRemoved squashes oasdiff entries with id: "response-property-enum-value-removed"
-// Message format: "removed the 'DUBLIN_IRL' enum value from the '/items/dataProcessRegion/region' response property"
+// Message format: "removed the 'DUBLIN_IRL' enum value from the '/items/dataProcessRegion/region' response property".
 func squashResponsePropertyEnumValueRemoved(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"response-property-enum-value-removed",
@@ -32,7 +32,7 @@ func squashResponsePropertyEnumValueRemoved(entriesGroupedByOperationID map[stri
 }
 
 // squashResponseMediatypeEnumValueRemoved squashes oasdiff entries with id: "response-mediatype-enum-value-removed"
-// Message format: "response schema application/json enum value removed from 'DUBLIN_IRL'"
+// Message format: "response schema application/json enum value removed from 'DUBLIN_IRL'".
 func squashResponseMediatypeEnumValueRemoved(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"response-mediatype-enum-value-removed",
@@ -45,7 +45,7 @@ func squashResponseMediatypeEnumValueRemoved(entriesGroupedByOperationID map[str
 }
 
 // squashResponseWriteOnlyPropertyEnumValueAdded squashes oasdiff entries with id: "response-write-only-property-enum-value-added"
-// Message format: "added the new 'DUBLIN_IRL' enum value to the '/items/dataProcessRegion/region' response write-only property",
+// Message format: "added the new 'DUBLIN_IRL' enum value to the '/items/dataProcessRegion/region' response write-only property",.
 func squashResponseWriteOnlyPropertyEnumValueAdded(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"response-write-only-property-enum-value-added",
@@ -58,7 +58,7 @@ func squashResponseWriteOnlyPropertyEnumValueAdded(entriesGroupedByOperationID m
 }
 
 // squashRequestBodyEnumValueRemoved squashes oasdiff entries with id: "request-body-enum-value-removed"
-// Message format: "request body enum value removed 'DUBLIN_IRL'",
+// Message format: "request body enum value removed 'DUBLIN_IRL'",.
 func squashRequestBodyEnumValueRemoved(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"request-body-enum-value-removed",
@@ -71,7 +71,7 @@ func squashRequestBodyEnumValueRemoved(entriesGroupedByOperationID map[string][]
 }
 
 // squashRequestParameterEnumValueAdded squashes oasdiff entries with id: "request-parameter-enum-value-added"
-// Message format: "added the new enum value 'AVAILABLE' to the 'query' request parameter 'status'"
+// Message format: "added the new enum value 'AVAILABLE' to the 'query' request parameter 'status'".
 func squashRequestParameterEnumValueAdded(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"request-parameter-enum-value-added",
@@ -84,7 +84,7 @@ func squashRequestParameterEnumValueAdded(entriesGroupedByOperationID map[string
 }
 
 // squashRequestParameterEnumValueRemoved squashes oasdiff entries with id: "request-parameter-enum-value-removed"
-// Message format: "removed the enum value 'AVAILABLE' from the 'query' request parameter 'status'"
+// Message format: "removed the enum value 'AVAILABLE' from the 'query' request parameter 'status'".
 func squashRequestParameterEnumValueRemoved(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"request-parameter-enum-value-removed",
@@ -97,7 +97,7 @@ func squashRequestParameterEnumValueRemoved(entriesGroupedByOperationID map[stri
 }
 
 // squashRequestPropertyEnumValueAdded squashes oasdiff entries with id: "request-property-enum-value-added"
-// Message format: "added the new 'DUBLIN_IRL' enum value to the request property '/items/dataProcessRegion/region'"
+// Message format: "added the new 'DUBLIN_IRL' enum value to the request property '/items/dataProcessRegion/region'".
 func squashRequestPropertyEnumValueAdded(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"request-property-enum-value-added",
@@ -110,7 +110,7 @@ func squashRequestPropertyEnumValueAdded(entriesGroupedByOperationID map[string]
 }
 
 // squashRequestPropertyEnumValueRemoved squashes oasdiff entries with id: "request-property-enum-value-removed"
-// Message format: "removed the enum value 'DUBLIN_IRL' of the request property '/items/dataProcessRegion/region'"
+// Message format: "removed the enum value 'DUBLIN_IRL' of the request property '/items/dataProcessRegion/region'".
 func squashRequestPropertyEnumValueRemoved(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashEntriesByValues(
 		"request-property-enum-value-removed",

--- a/tools/cli/internal/changelog/outputfilter/field.go
+++ b/tools/cli/internal/changelog/outputfilter/field.go
@@ -1,6 +1,6 @@
 package outputfilter
 
-// squashRequestFieldAdded squashes oasdiff entries with id "new-required-request-property"
+// squashRequestFieldAdded squashes oasdiff entries with id "new-required-request-property".
 func squashRequestFieldAdded(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"new-required-request-property",
@@ -10,7 +10,7 @@ func squashRequestFieldAdded(entriesGroupedByOperationID map[string][]*OasDiffEn
 	)
 }
 
-// squashRequestFieldRemoved squashes oasdiff entries with id "request-property-removed"
+// squashRequestFieldRemoved squashes oasdiff entries with id "request-property-removed".
 func squashRequestFieldRemoved(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"request-property-removed",
@@ -20,7 +20,7 @@ func squashRequestFieldRemoved(entriesGroupedByOperationID map[string][]*OasDiff
 	)
 }
 
-// squashResponseRequiredFieldAdded squashes oasdiff entries with id "response-required-property-added"
+// squashResponseRequiredFieldAdded squashes oasdiff entries with id "response-required-property-added".
 func squashResponseRequiredFieldAdded(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"response-required-property-added",
@@ -30,7 +30,7 @@ func squashResponseRequiredFieldAdded(entriesGroupedByOperationID map[string][]*
 	)
 }
 
-// squashResponseRequiredFieldRemoved squashes oasdiff entries with id "response-required-property-removed"
+// squashResponseRequiredFieldRemoved squashes oasdiff entries with id "response-required-property-removed".
 func squashResponseRequiredFieldRemoved(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"response-required-property-removed",
@@ -40,7 +40,7 @@ func squashResponseRequiredFieldRemoved(entriesGroupedByOperationID map[string][
 	)
 }
 
-// squashResponseOptionalFieldAdded squashes oasdiff entries with id "response-optional-property-added"
+// squashResponseOptionalFieldAdded squashes oasdiff entries with id "response-optional-property-added".
 func squashResponseOptionalFieldAdded(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"response-optional-property-added",
@@ -50,7 +50,7 @@ func squashResponseOptionalFieldAdded(entriesGroupedByOperationID map[string][]*
 	)
 }
 
-// squashResponseOptionalFieldRemoved squashes oasdiff entries with id "response-optional-property-removed"
+// squashResponseOptionalFieldRemoved squashes oasdiff entries with id "response-optional-property-removed".
 func squashResponseOptionalFieldRemoved(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"response-optional-property-removed",
@@ -60,7 +60,7 @@ func squashResponseOptionalFieldRemoved(entriesGroupedByOperationID map[string][
 	)
 }
 
-// squashResponseOptionalFieldBecomeReadonly squashes oasdiff entries with id "response-optional-property-became-read-only"
+// squashResponseOptionalFieldBecomeReadonly squashes oasdiff entries with id "response-optional-property-became-read-only".
 func squashResponseOptionalFieldBecomeReadonly(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"response-optional-property-became-read-only",
@@ -70,7 +70,7 @@ func squashResponseOptionalFieldBecomeReadonly(entriesGroupedByOperationID map[s
 	)
 }
 
-// squashResponseFieldBecameRequired squashes oasdiff entries with id "response-property-became-required"
+// squashResponseFieldBecameRequired squashes oasdiff entries with id "response-property-became-required".
 func squashResponseFieldBecameRequired(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"response-property-became-required",
@@ -80,7 +80,7 @@ func squashResponseFieldBecameRequired(entriesGroupedByOperationID map[string][]
 	)
 }
 
-// squashRequestFieldBecameRequired squashes oasdiff entries with id "request-property-became-required"
+// squashRequestFieldBecameRequired squashes oasdiff entries with id "request-property-became-required".
 func squashRequestFieldBecameRequired(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"request-property-became-required",
@@ -90,7 +90,7 @@ func squashRequestFieldBecameRequired(entriesGroupedByOperationID map[string][]*
 	)
 }
 
-// squashNewOptionalRequestProperty squashes oasdiff entries with id "new-optional-request-property"
+// squashNewOptionalRequestProperty squashes oasdiff entries with id "new-optional-request-property".
 func squashNewOptionalRequestProperty(entriesGroupedByOperationID map[string][]*OasDiffEntry) ([]*OasDiffEntry, error) {
 	return squashFieldChanged(
 		"new-optional-request-property",
@@ -100,7 +100,7 @@ func squashNewOptionalRequestProperty(entriesGroupedByOperationID map[string][]*
 	)
 }
 
-// squashFieldChanged is a helper function to squash entries based on the given operation
+// squashFieldChanged is a helper function to squash entries based on the given operation.
 func squashFieldChanged(
 	operation string,
 	entriesGroupedByOperationID map[string][]*OasDiffEntry,

--- a/tools/cli/internal/changelog/outputfilter/hide.go
+++ b/tools/cli/internal/changelog/outputfilter/hide.go
@@ -21,7 +21,7 @@ var hideIDs = []string{
 	"api-sunset-date-too-small",
 }
 
-// MarkHiddenEntries sets the HideFromChangelog flag to true
+// MarkHiddenEntries sets the HideFromChangelog flag to true.
 func MarkHiddenEntries(entries []*OasDiffEntry, exemptionsFilePath string, fs afero.Fs) ([]*OasDiffEntry, error) {
 	exemptions, err := getExemptionsFromPath(exemptionsFilePath, fs)
 	if err != nil {
@@ -36,7 +36,7 @@ func MarkHiddenEntries(entries []*OasDiffEntry, exemptionsFilePath string, fs af
 	return hideByIDs(entries, hideIDs)
 }
 
-// hideByIDs removes entries with the specified IDs from the list of entries
+// hideByIDs removes entries with the specified IDs from the list of entries.
 func hideByIDs(entries []*OasDiffEntry, ids []string) ([]*OasDiffEntry, error) {
 	if len(ids) == 0 {
 		return entries, nil
@@ -53,7 +53,7 @@ func hideByIDs(entries []*OasDiffEntry, ids []string) ([]*OasDiffEntry, error) {
 	return entries, nil
 }
 
-// hideByExemptions hides entries based on the exemptions
+// hideByExemptions hides entries based on the exemptions.
 func hideByExemptions(entries []*OasDiffEntry, exemptions []breakingchanges.Exemption) ([]*OasDiffEntry, error) {
 	exemptionsMarkedHidden := breakingchanges.GetHiddenExemptions(exemptions)
 	log.Printf("Found %d exemptions marked hidden from the changelog.", len(exemptionsMarkedHidden))

--- a/tools/cli/internal/changelog/outputfilter/message.go
+++ b/tools/cli/internal/changelog/outputfilter/message.go
@@ -46,7 +46,7 @@ func removeRedundantOneOfAllOf(text string) string {
 	return text
 }
 
-// removeResponseStatusCodes removes the status codes from the response messages
+// removeResponseStatusCodes removes the status codes from the response messages.
 func removeResponseStatusCodes(text string) string {
 	// to the response with the '200' status
 	re := regexp.MustCompile(` property for the response status '\d{3}'`)

--- a/tools/cli/internal/changelog/outputfilter/operationconfig.go
+++ b/tools/cli/internal/changelog/outputfilter/operationconfig.go
@@ -10,7 +10,7 @@ type OperationConfig struct {
 	HTTPMethod             string
 	Tag                    string
 	Sunset                 string
-	ManualChangelogEntries map[string]interface{}
+	ManualChangelogEntries map[string]any
 }
 
 type OperationConfigs struct {
@@ -109,9 +109,9 @@ func newEndpointConfig(pathName, operatioName string, operation *openapi3.Operat
 		sunset = value.(string)
 	}
 
-	manualChangelogEntries := make(map[string]interface{})
+	manualChangelogEntries := make(map[string]any)
 	if value, ok := operation.Extensions["x-xgen-changelog"]; ok {
-		manualChangelogEntries = value.(map[string]interface{})
+		manualChangelogEntries = value.(map[string]any)
 	}
 
 	return &OperationConfig{

--- a/tools/cli/internal/changelog/outputfilter/operationconfig_test.go
+++ b/tools/cli/internal/changelog/outputfilter/operationconfig_test.go
@@ -21,21 +21,21 @@ func TestOpenApiSpecMethods(t *testing.T) {
 			HTTPMethod:             "POST",
 			Tag:                    "Multi-Cloud Clusters",
 			Sunset:                 "2025-06-01",
-			ManualChangelogEntries: map[string]interface{}{},
+			ManualChangelogEntries: map[string]any{},
 		},
 		"deleteCluster": {
 			Path:                   "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}",
 			HTTPMethod:             "DELETE",
 			Tag:                    "Multi-Cloud Clusters",
 			Sunset:                 "2025-06-01",
-			ManualChangelogEntries: map[string]interface{}{},
+			ManualChangelogEntries: map[string]any{},
 		},
 		"getCluster": {
 			Path:       "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}",
 			HTTPMethod: "GET",
 			Tag:        "Multi-Cloud Clusters",
 			Sunset:     "2025-06-01",
-			ManualChangelogEntries: map[string]interface{}{
+			ManualChangelogEntries: map[string]any{
 				"2023-07-07": "July 7th changelog entry",
 				"2023-08-08": "August announcement for /api/atlas/v2/clusters",
 			},
@@ -45,14 +45,14 @@ func TestOpenApiSpecMethods(t *testing.T) {
 			HTTPMethod:             "GET",
 			Tag:                    "Multi-Cloud Clusters",
 			Sunset:                 "2025-06-01",
-			ManualChangelogEntries: map[string]interface{}{},
+			ManualChangelogEntries: map[string]any{},
 		},
 		"updateCluster": {
 			Path:                   "/api/atlas/v2/groups/{groupId}/clusters/{clusterName}",
 			HTTPMethod:             "PATCH",
 			Tag:                    "Multi-Cloud Clusters",
 			Sunset:                 "2025-06-01",
-			ManualChangelogEntries: map[string]interface{}{},
+			ManualChangelogEntries: map[string]any{},
 		},
 	}
 
@@ -180,7 +180,7 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 						HTTPMethod:             "GET",
 						Tag:                    "base-tag",
 						Sunset:                 "",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 					Revision: nil,
 				},
@@ -191,7 +191,7 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 						HTTPMethod:             "GET",
 						Tag:                    "revision-tag",
 						Sunset:                 "",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 				},
 			},
@@ -205,7 +205,7 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 							Get: &openapi3.Operation{
 								OperationID: "op1",
 								Tags:        []string{"base-tag"},
-								Extensions: map[string]interface{}{
+								Extensions: map[string]any{
 									"x-sunset": "2024-08-01",
 								},
 							},
@@ -220,7 +220,7 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 							Get: &openapi3.Operation{
 								OperationID: "op1",
 								Tags:        []string{"revision-tag"},
-								Extensions: map[string]interface{}{
+								Extensions: map[string]any{
 									"x-sunset": "2024-12-01",
 								},
 							},
@@ -235,14 +235,14 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 						HTTPMethod:             "GET",
 						Tag:                    "base-tag",
 						Sunset:                 "2024-08-01",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 					Revision: &OperationConfig{
 						Path:                   "/path",
 						HTTPMethod:             "GET",
 						Tag:                    "revision-tag",
 						Sunset:                 "2024-12-01",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 				},
 			},
@@ -256,7 +256,7 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 							Get: &openapi3.Operation{
 								OperationID: "op1",
 								Tags:        []string{"base-tag"},
-								Extensions: map[string]interface{}{
+								Extensions: map[string]any{
 									"x-sunset": "2024-08-01",
 								},
 							},
@@ -283,14 +283,14 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 						HTTPMethod:             "GET",
 						Tag:                    "base-tag",
 						Sunset:                 "2024-08-01",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 					Revision: &OperationConfig{
 						Path:                   "/path",
 						HTTPMethod:             "GET",
 						Tag:                    "revision-tag",
 						Sunset:                 "", // Sunset not present in revision
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 				},
 			},
@@ -316,7 +316,7 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 							Get: &openapi3.Operation{
 								OperationID: "op1",
 								Tags:        []string{"revision-tag"},
-								Extensions: map[string]interface{}{
+								Extensions: map[string]any{
 									"x-sunset": "2024-12-01",
 								},
 							},
@@ -330,14 +330,14 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 						Path:                   "/path",
 						HTTPMethod:             "GET",
 						Tag:                    "base-tag",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 					Revision: &OperationConfig{
 						Path:                   "/path",
 						HTTPMethod:             "GET",
 						Tag:                    "revision-tag",
 						Sunset:                 "2024-12-01",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 				},
 			},
@@ -363,8 +363,8 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 							Get: &openapi3.Operation{
 								OperationID: "op1",
 								Tags:        []string{"revision-tag"},
-								Extensions: map[string]interface{}{
-									"x-xgen-changelog": map[string]interface{}{
+								Extensions: map[string]any{
+									"x-xgen-changelog": map[string]any{
 										"2024-01-01": "Revision changelog entry.",
 									},
 								},
@@ -380,14 +380,14 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 						HTTPMethod:             "GET",
 						Tag:                    "base-tag",
 						Sunset:                 "",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 					Revision: &OperationConfig{
 						Path:       "/path",
 						HTTPMethod: "GET",
 						Tag:        "revision-tag",
 						Sunset:     "",
-						ManualChangelogEntries: map[string]interface{}{
+						ManualChangelogEntries: map[string]any{
 							"2024-01-01": "Revision changelog entry.",
 						},
 					},
@@ -415,8 +415,8 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 							Get: &openapi3.Operation{
 								OperationID: "op1",
 								Tags:        []string{"revision-tag"},
-								Extensions: map[string]interface{}{
-									"x-xgen-changelog": map[string]interface{}{
+								Extensions: map[string]any{
+									"x-xgen-changelog": map[string]any{
 										"2024-01-01": "Revision changelog entry.",
 										"2024-01-02": "Revision changelog entry.",
 									},
@@ -433,14 +433,14 @@ func TestNewEndpointsConfigGivenBaseAndRevision(t *testing.T) {
 						HTTPMethod:             "GET",
 						Tag:                    "base-tag",
 						Sunset:                 "",
-						ManualChangelogEntries: map[string]interface{}{},
+						ManualChangelogEntries: map[string]any{},
 					},
 					Revision: &OperationConfig{
 						Path:       "/path",
 						HTTPMethod: "GET",
 						Tag:        "revision-tag",
 						Sunset:     "",
-						ManualChangelogEntries: map[string]interface{}{
+						ManualChangelogEntries: map[string]any{
 							"2024-01-01": "Revision changelog entry.",
 							"2024-01-02": "Revision changelog entry.",
 						},

--- a/tools/cli/internal/changelog/outputfilter/squash.go
+++ b/tools/cli/internal/changelog/outputfilter/squash.go
@@ -2,10 +2,9 @@ package outputfilter
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
-
-	"regexp"
 )
 
 var (
@@ -214,7 +213,7 @@ type squashedEntries struct {
 	valuesToSquash    map[string]struct{}
 }
 
-// squashEntriesByValues squashes entries based on the given parameters
+// squashEntriesByValues squashes entries based on the given parameters.
 func squashEntriesByValues(
 	operation string,
 	entriesGroupedByOperationID map[string][]*OasDiffEntry,
@@ -356,7 +355,7 @@ func extractExactValuesOrFail(operation string, entry *OasDiffEntry, expectedNum
 		operation, expectedNumberOfValues, text)
 }
 
-// pluralizeToIfNeeded checks if pluralization is needed
+// pluralizeToIfNeeded checks if pluralization is needed.
 func pluralizeToIfNeeded(from, to string, count int) string {
 	if count > 1 {
 		return to

--- a/tools/cli/internal/changelog/sunset_test.go
+++ b/tools/cli/internal/changelog/sunset_test.go
@@ -83,7 +83,7 @@ func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
 				HTTPMethod:             "POST",
 				Tag:                    "Multi-Cloud Clusters",
 				Sunset:                 previousRunDate,
-				ManualChangelogEntries: map[string]interface{}{},
+				ManualChangelogEntries: map[string]any{},
 			},
 		},
 		"getCluster": {
@@ -93,7 +93,7 @@ func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
 				HTTPMethod:             "GET",
 				Tag:                    "Multi-Cloud Clusters",
 				Sunset:                 "",
-				ManualChangelogEntries: map[string]interface{}{},
+				ManualChangelogEntries: map[string]any{},
 			},
 		},
 		"listStreamInstances": {
@@ -103,7 +103,7 @@ func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
 				HTTPMethod:             "GET",
 				Tag:                    "Streams",
 				Sunset:                 runDate,
-				ManualChangelogEntries: map[string]interface{}{},
+				ManualChangelogEntries: map[string]any{},
 			},
 		},
 		"getStreamInstance": {
@@ -113,7 +113,7 @@ func TestNewOasDiffEntriesFromSunsetEndpoints(t *testing.T) {
 				HTTPMethod:             "GET",
 				Tag:                    "Streams",
 				Sunset:                 "2023-07-13",
-				ManualChangelogEntries: map[string]interface{}{},
+				ManualChangelogEntries: map[string]any{},
 			},
 		},
 	}

--- a/tools/cli/internal/cli/breakingchanges/exemptions/parse.go
+++ b/tools/cli/internal/cli/breakingchanges/exemptions/parse.go
@@ -15,7 +15,7 @@
 package exemptions
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/mongodb/openapi/tools/cli/internal/breakingchanges"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
@@ -42,7 +42,7 @@ func (o *Opts) Run() error {
 
 func (o *Opts) PreRunE(_ []string) error {
 	if o.exemptionsPaths == "" {
-		return fmt.Errorf("valid exemptions file path is required")
+		return errors.New("valid exemptions file path is required")
 	}
 	_, err := o.fs.Stat(o.exemptionsPaths)
 	if err != nil {
@@ -52,7 +52,7 @@ func (o *Opts) PreRunE(_ []string) error {
 }
 
 // ParseBuilder builds the merge command with the following signature:
-// breaking-changes exemptions parse -e file_path
+// breaking-changes exemptions parse -e file_path.
 func ParseBuilder() *cobra.Command {
 	opts := &Opts{
 		fs: afero.NewOsFs(),

--- a/tools/cli/internal/cli/changelog/convert/slack.go
+++ b/tools/cli/internal/cli/changelog/convert/slack.go
@@ -178,7 +178,7 @@ func newColorFromBackwardCompatible(backwardCompatible, hideFromChangelog bool) 
 }
 
 // SlackBuilder constructs the command for converting the changelog entries into a format that can be used with Slack APIs.
-// changelog convert slack -p path_to_changelog -m message_id 1503435956.000247 -c channel_id C061EG9SL
+// changelog convert slack -p path_to_changelog -m message_id 1503435956.000247 -c channel_id C061EG9SL.
 func SlackBuilder() *cobra.Command {
 	opts := &SlackOpts{}
 

--- a/tools/cli/internal/cli/changelog/create.go
+++ b/tools/cli/internal/cli/changelog/create.go
@@ -117,7 +117,7 @@ func (o *Opts) newOutputFilePath(fileName string) string {
 }
 
 // CreateBuilder builds the merge command with the following signature:
-// changelog create -b path_folder -r path_folder --dry-run
+// changelog create -b path_folder -r path_folder --dry-run.
 func CreateBuilder() *cobra.Command {
 	opts := &Opts{
 		fs: afero.NewOsFs(),

--- a/tools/cli/internal/cli/changelog/metadata/create.go
+++ b/tools/cli/internal/cli/changelog/metadata/create.go
@@ -79,7 +79,7 @@ func (o *Opts) PreRun() error {
 	return nil
 }
 
-// changelog metadata create [--run-date=2024-09-22] --sha=e624d716e86f6910757b60cefdf3aa3181582d38 versions=2023-01-01,2023-02-01
+// changelog metadata create [--run-date=2024-09-22] --sha=e624d716e86f6910757b60cefdf3aa3181582d38 versions=2023-01-01,2023-02-01.
 func CreateBuilder() *cobra.Command {
 	opts := &Opts{
 		fs: afero.NewOsFs(),

--- a/tools/cli/internal/cli/merge/merge.go
+++ b/tools/cli/internal/cli/merge/merge.go
@@ -44,7 +44,7 @@ func (o *Opts) Run() error {
 	}
 
 	if o.gitSha != "" {
-		federated.Info.Extensions = map[string]interface{}{
+		federated.Info.Extensions = map[string]any{
 			"x-xgen-sha": o.gitSha,
 		}
 	}
@@ -85,7 +85,7 @@ func (o *Opts) PreRunE(_ []string) error {
 }
 
 // Builder builds the merge command with the following signature:
-// merge -b base-oas -e external-oas-1 -e external-oas-2
+// merge -b base-oas -e external-oas-1 -e external-oas-2.
 func Builder() *cobra.Command {
 	opts := &Opts{
 		fs: afero.NewOsFs(),

--- a/tools/cli/internal/cli/split/split.go
+++ b/tools/cli/internal/cli/split/split.go
@@ -83,7 +83,7 @@ func (o *Opts) saveVersionedOas(oas *openapi3.T, version string) error {
 		path = o.outputPath
 	}
 
-	path = strings.Replace(path, fmt.Sprintf(".%s", o.format), fmt.Sprintf("-%s.%s", version, o.format), 1)
+	path = strings.Replace(path, "."+o.format, fmt.Sprintf("-%s.%s", version, o.format), 1)
 	return openapi.Save(path, oas, o.format, o.fs)
 }
 
@@ -108,7 +108,7 @@ func (o *Opts) PreRunE(_ []string) error {
 }
 
 // Builder builds the split command with the following signature:
-// split -b base-oas -o output-oas.json
+// split -b base-oas -o output-oas.json.
 func Builder() *cobra.Command {
 	opts := &Opts{
 		fs: afero.NewOsFs(),

--- a/tools/cli/internal/cli/sunset/list.go
+++ b/tools/cli/internal/cli/sunset/list.go
@@ -20,10 +20,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mongodb/openapi/tools/cli/internal/openapi"
-
 	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/usage"
+	"github.com/mongodb/openapi/tools/cli/internal/openapi"
 	"github.com/mongodb/openapi/tools/cli/internal/openapi/sunset"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -145,7 +144,7 @@ func (o *ListOpts) validate() error {
 }
 
 // ListBuilder builds the merge command with the following signature:
-// sunset ls -s spec.json -f 2024-01-01 -t 2024-09-22
+// sunset ls -s spec.json -f 2024-01-01 -t 2024-09-22.
 func ListBuilder() *cobra.Command {
 	opts := &ListOpts{
 		fs: afero.NewOsFs(),

--- a/tools/cli/internal/cli/versions/versions.go
+++ b/tools/cli/internal/cli/versions/versions.go
@@ -16,6 +16,7 @@ package versions
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -54,7 +55,7 @@ func (o *Opts) Run() error {
 	}
 
 	if versions == nil {
-		return fmt.Errorf("no versions found in the OpenAPI specification")
+		return errors.New("no versions found in the OpenAPI specification")
 	}
 
 	bytes, err := o.getVersionBytes(versions)
@@ -80,7 +81,7 @@ func (o *Opts) getVersionBytes(versions []string) ([]byte, error) {
 		return data, nil
 	}
 
-	var jsonData interface{}
+	var jsonData any
 	if mErr := json.Unmarshal(data, &jsonData); mErr != nil {
 		return nil, mErr
 	}
@@ -110,7 +111,7 @@ func (o *Opts) PreRunE(_ []string) error {
 }
 
 // Builder builds the versions command with the following signature:
-// versions -s oas
+// versions -s oas.
 func Builder() *cobra.Command {
 	opts := &Opts{
 		fs: afero.NewOsFs(),

--- a/tools/cli/internal/openapi/file.go
+++ b/tools/cli/internal/openapi/file.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package openapi
 
 import (
@@ -104,7 +105,7 @@ func SerializeToJSON[T any](data T) ([]byte, error) {
 }
 
 func SerializeToYAML(data []byte) ([]byte, error) {
-	var jsonData interface{}
+	var jsonData any
 	if err := json.Unmarshal(data, &jsonData); err != nil {
 		return nil, err
 	}

--- a/tools/cli/internal/openapi/filter/extension.go
+++ b/tools/cli/internal/openapi/filter/extension.go
@@ -24,7 +24,7 @@ import (
 
 // Filter: ExtensionFilter is a filter that updates the x-sunset and x-xgen-version extensions to a date string
 // and deletes the x-sunset extension if the latest matched version is deprecated by hidden versions
-// for the target environment
+// for the target environment.
 type ExtensionFilter struct {
 	oas      *openapi3.T
 	metadata *Metadata
@@ -69,14 +69,14 @@ func (f *ExtensionFilter) Apply() error {
 				}
 
 				f.deleteSunsetIfDeprecatedByHiddenVersions(latestVersionMatch, response.Value.Content)
-				f.updateToDateString(response.Value.Content)
+				updateToDateString(response.Value.Content)
 			}
 
 			request := operation.RequestBody
 			if request == nil || request.Value == nil || request.Value.Content == nil {
 				continue
 			}
-			f.updateToDateString(request.Value.Content)
+			updateToDateString(request.Value.Content)
 			f.deleteSunsetIfDeprecatedByHiddenVersions(latestVersionMatch, request.Value.Content)
 		}
 	}
@@ -100,7 +100,7 @@ func updateExtensionToDateString(extensions map[string]any) {
 	}
 }
 
-func (f *ExtensionFilter) updateToDateString(content openapi3.Content) {
+func updateToDateString(content openapi3.Content) {
 	for _, mediaType := range content {
 		if mediaType.Extensions == nil {
 			continue
@@ -110,7 +110,7 @@ func (f *ExtensionFilter) updateToDateString(content openapi3.Content) {
 	}
 }
 
-// deleteSunsetIfDeprecatedByHiddenVersions deletes the sunset extension if the latest matched version is deprecated by hidden versions
+// deleteSunsetIfDeprecatedByHiddenVersions deletes the sunset extension if the latest matched version is deprecated by hidden versions.
 func (f *ExtensionFilter) deleteSunsetIfDeprecatedByHiddenVersions(latestMatchedVersion *apiversion.APIVersion, content openapi3.Content) {
 	versions, versionToContentType := getVersionsInContentType(content)
 

--- a/tools/cli/internal/openapi/filter/extension_test.go
+++ b/tools/cli/internal/openapi/filter/extension_test.go
@@ -94,7 +94,7 @@ func getOasSunset() *openapi3.T {
 							Description: "description",
 						},
 					},
-					Extensions: map[string]interface{}{
+					Extensions: map[string]any{
 						"x-sunset":    "2024-05-30T00:00:00Z",
 						xGenExtension: "2023-01-01T00:00:00Z",
 					},
@@ -105,7 +105,7 @@ func getOasSunset() *openapi3.T {
 							Description: "description",
 						},
 					},
-					Extensions: map[string]interface{}{
+					Extensions: map[string]any{
 						"x-sunset":    "2024-04-10",
 						xGenExtension: "2024-02-30T00:00:00Z",
 					},
@@ -115,13 +115,13 @@ func getOasSunset() *openapi3.T {
 						Value: &openapi3.Schema{
 							Description: "description",
 						},
-						Extensions: map[string]interface{}{
+						Extensions: map[string]any{
 							"x-sunset":    "2025-01-01T00:00:00Z",
 							xGenExtension: "2025-01-01",
 						},
 					},
-					Extensions: map[string]interface{}{
-						hiddenEnvsExtension: map[string]interface{}{
+					Extensions: map[string]any{
+						hiddenEnvsExtension: map[string]any{
 							"envs": "dev,qa,prod,stage",
 						},
 					},
@@ -132,7 +132,7 @@ func getOasSunset() *openapi3.T {
 							Description: "description",
 						},
 					},
-					Extensions: map[string]interface{}{
+					Extensions: map[string]any{
 						"x-sunset":    "2025-01-01T00:00:00Z",
 						xGenExtension: "2024-05-30",
 					},

--- a/tools/cli/internal/openapi/filter/hidden_envs.go
+++ b/tools/cli/internal/openapi/filter/hidden_envs.go
@@ -26,7 +26,7 @@ const (
 )
 
 // Filter: HiddenEnvsFilter is a filter that removes paths, operations,
-// request/response bodies and content types that are hidden for the target environment
+// request/response bodies and content types that are hidden for the target environment.
 type HiddenEnvsFilter struct {
 	oas      *openapi3.T
 	metadata *Metadata
@@ -199,8 +199,8 @@ func (f *HiddenEnvsFilter) isPathHiddenForEnv(pathItem *openapi3.PathItem) bool 
 	return false
 }
 
-func isHiddenExtensionEqualToTargetEnv(extension interface{}, target string) bool {
-	if envs, ok := extension.(map[string]interface{}); ok {
+func isHiddenExtensionEqualToTargetEnv(extension any, target string) bool {
+	if envs, ok := extension.(map[string]any); ok {
 		if v, ok := envs[hiddenEnvsExtKey].(string); ok {
 			log.Printf("Found x-hidden-envs: V: %q", v)
 			return strings.Contains(v, target)

--- a/tools/cli/internal/openapi/filter/hidden_envs_test.go
+++ b/tools/cli/internal/openapi/filter/hidden_envs_test.go
@@ -34,8 +34,8 @@ func TestIsOperationHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment matches target environment",
 			operation: &openapi3.Operation{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "prod",
 					},
 				},
@@ -48,8 +48,8 @@ func TestIsOperationHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment matches target environment, multiple environments",
 			operation: &openapi3.Operation{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "prod,dev,staging,prod",
 					},
 				},
@@ -62,8 +62,8 @@ func TestIsOperationHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment does not match target environment",
 			operation: &openapi3.Operation{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "staging",
 					},
 				},
@@ -76,8 +76,8 @@ func TestIsOperationHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment does not match target environment, empty envs",
 			operation: &openapi3.Operation{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "",
 					},
 				},
@@ -90,8 +90,8 @@ func TestIsOperationHiddenForEnv(t *testing.T) {
 		{
 			name: "No hidden environment extension",
 			operation: &openapi3.Operation{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "no",
 					},
 				},
@@ -126,8 +126,8 @@ func TestIsPathHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment matches target environment",
 			pathItem: &openapi3.PathItem{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "prod",
 					},
 				},
@@ -140,8 +140,8 @@ func TestIsPathHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment matches target environment, multiple environments",
 			pathItem: &openapi3.PathItem{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "prod,dev,staging,prod",
 					},
 				},
@@ -154,8 +154,8 @@ func TestIsPathHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment does not match target environment",
 			pathItem: &openapi3.PathItem{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "staging",
 					},
 				},
@@ -168,8 +168,8 @@ func TestIsPathHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment does not match target environment, empty envs",
 			pathItem: &openapi3.PathItem{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "",
 					},
 				},
@@ -182,7 +182,7 @@ func TestIsPathHiddenForEnv(t *testing.T) {
 		{
 			name: "No hidden environment extension",
 			pathItem: &openapi3.PathItem{
-				Extensions: map[string]interface{}{},
+				Extensions: map[string]any{},
 			},
 			metadata: &Metadata{
 				targetEnv: "prod",
@@ -213,8 +213,8 @@ func TestIsRequestBodyHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment matches target environment",
 			requestBody: &openapi3.RequestBodyRef{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "prod",
 					},
 				},
@@ -227,8 +227,8 @@ func TestIsRequestBodyHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment matches target environment, multiple environments",
 			requestBody: &openapi3.RequestBodyRef{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "prod,dev,staging,prod",
 					},
 				},
@@ -241,8 +241,8 @@ func TestIsRequestBodyHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment does not match target environment",
 			requestBody: &openapi3.RequestBodyRef{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "staging",
 					},
 				},
@@ -255,8 +255,8 @@ func TestIsRequestBodyHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment does not match target environment, empty envs",
 			requestBody: &openapi3.RequestBodyRef{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "",
 					},
 				},
@@ -269,8 +269,8 @@ func TestIsRequestBodyHiddenForEnv(t *testing.T) {
 		{
 			name: "No hidden environment extension",
 			requestBody: &openapi3.RequestBodyRef{
-				Extensions: map[string]interface{}{
-					"other-extension": map[string]interface{}{
+				Extensions: map[string]any{
+					"other-extension": map[string]any{
 						"envs": "no",
 					},
 				},
@@ -305,8 +305,8 @@ func TestIsResponseHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment matches target environment",
 			response: &openapi3.ResponseRef{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "prod",
 					},
 				},
@@ -319,8 +319,8 @@ func TestIsResponseHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment matches target environment, multiple environments",
 			response: &openapi3.ResponseRef{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "prod,dev,staging,prod",
 					},
 				},
@@ -333,8 +333,8 @@ func TestIsResponseHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment does not match target environment",
 			response: &openapi3.ResponseRef{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "staging",
 					},
 				},
@@ -347,8 +347,8 @@ func TestIsResponseHiddenForEnv(t *testing.T) {
 		{
 			name: "Hidden environment does not match target environment, empty envs",
 			response: &openapi3.ResponseRef{
-				Extensions: map[string]interface{}{
-					hiddenEnvsExtension: map[string]interface{}{
+				Extensions: map[string]any{
+					hiddenEnvsExtension: map[string]any{
 						"envs": "",
 					},
 				},
@@ -361,8 +361,8 @@ func TestIsResponseHiddenForEnv(t *testing.T) {
 		{
 			name: "No hidden environment extension",
 			response: &openapi3.ResponseRef{
-				Extensions: map[string]interface{}{
-					"other-extension": map[string]interface{}{
+				Extensions: map[string]any{
+					"other-extension": map[string]any{
 						"envs": "no",
 					},
 				},
@@ -398,8 +398,8 @@ func TestApplyOnPath(t *testing.T) {
 			name: "Operation Hidden extension matches target environment",
 			input: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						hiddenEnvsExtension: map[string]interface{}{
+					Extensions: map[string]any{
+						hiddenEnvsExtension: map[string]any{
 							"envs": "prod",
 						},
 					},
@@ -417,8 +417,8 @@ func TestApplyOnPath(t *testing.T) {
 			name: "Operation Hidden extension does not matches target environment",
 			input: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						hiddenEnvsExtension: map[string]interface{}{
+					Extensions: map[string]any{
+						hiddenEnvsExtension: map[string]any{
 							"envs": "dev",
 						},
 					},
@@ -429,7 +429,7 @@ func TestApplyOnPath(t *testing.T) {
 			},
 			expected: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{},
+					Extensions: map[string]any{},
 				},
 			},
 		},
@@ -441,8 +441,8 @@ func TestApplyOnPath(t *testing.T) {
 					Responses: openapi3.NewResponses(
 						openapi3.WithName("200",
 							&openapi3.Response{
-								Extensions: map[string]interface{}{
-									hiddenEnvsExtension: map[string]interface{}{
+								Extensions: map[string]any{
+									hiddenEnvsExtension: map[string]any{
 										"envs": "prod",
 									},
 								},
@@ -471,8 +471,8 @@ func TestApplyOnPath(t *testing.T) {
 					Responses: openapi3.NewResponses(
 						openapi3.WithName("200",
 							&openapi3.Response{
-								Extensions: map[string]interface{}{
-									hiddenEnvsExtension: map[string]interface{}{
+								Extensions: map[string]any{
+									hiddenEnvsExtension: map[string]any{
 										"envs": "prod",
 									},
 								},
@@ -490,8 +490,8 @@ func TestApplyOnPath(t *testing.T) {
 					Responses: openapi3.NewResponses(
 						openapi3.WithName("200",
 							&openapi3.Response{
-								Extensions: map[string]interface{}{
-									hiddenEnvsExtension: map[string]interface{}{
+								Extensions: map[string]any{
+									hiddenEnvsExtension: map[string]any{
 										"envs": "prod",
 									},
 								},
@@ -510,8 +510,8 @@ func TestApplyOnPath(t *testing.T) {
 						openapi3.WithName("400", &openapi3.Response{}),
 					),
 					RequestBody: &openapi3.RequestBodyRef{
-						Extensions: map[string]interface{}{
-							hiddenEnvsExtension: map[string]interface{}{
+						Extensions: map[string]any{
+							hiddenEnvsExtension: map[string]any{
 								"envs": "prod",
 							},
 						},
@@ -541,8 +541,8 @@ func TestApplyOnPath(t *testing.T) {
 						openapi3.WithName("400", &openapi3.Response{}),
 					),
 					RequestBody: &openapi3.RequestBodyRef{
-						Extensions: map[string]interface{}{
-							hiddenEnvsExtension: map[string]interface{}{
+						Extensions: map[string]any{
+							hiddenEnvsExtension: map[string]any{
 								"envs": "prod",
 							},
 						},
@@ -559,7 +559,7 @@ func TestApplyOnPath(t *testing.T) {
 						openapi3.WithName("400", &openapi3.Response{}),
 					),
 					RequestBody: &openapi3.RequestBodyRef{
-						Extensions: map[string]interface{}{},
+						Extensions: map[string]any{},
 					},
 				},
 			},
@@ -596,8 +596,8 @@ func TestRemoveResponseIfHiddenForEnv(t *testing.T) {
 					&openapi3.ResponseRef{
 						Value: &openapi3.Response{
 							Description: pointer.Get("A sample response"),
-							Extensions: map[string]interface{}{
-								hiddenEnvsExtension: map[string]interface{}{
+							Extensions: map[string]any{
+								hiddenEnvsExtension: map[string]any{
 									"envs": "prod",
 								},
 							},
@@ -628,16 +628,16 @@ func TestRemoveResponseIfHiddenForEnv(t *testing.T) {
 							Content: map[string]*openapi3.MediaType{
 								"application/json": {
 									Schema: &openapi3.SchemaRef{},
-									Extensions: map[string]interface{}{
-										hiddenEnvsExtension: map[string]interface{}{
+									Extensions: map[string]any{
+										hiddenEnvsExtension: map[string]any{
 											"envs": "prod",
 										},
 									},
 								},
 								"application/2-json": {
 									Schema: &openapi3.SchemaRef{},
-									Extensions: map[string]interface{}{
-										hiddenEnvsExtension: map[string]interface{}{
+									Extensions: map[string]any{
+										hiddenEnvsExtension: map[string]any{
 											"envs": "dev",
 										},
 									},
@@ -655,7 +655,7 @@ func TestRemoveResponseIfHiddenForEnv(t *testing.T) {
 							Content: map[string]*openapi3.MediaType{
 								"application/2-json": {
 									Schema:     &openapi3.SchemaRef{},
-									Extensions: map[string]interface{}{},
+									Extensions: map[string]any{},
 								},
 							},
 						},
@@ -674,16 +674,16 @@ func TestRemoveResponseIfHiddenForEnv(t *testing.T) {
 							Content: map[string]*openapi3.MediaType{
 								"application/json": {
 									Schema: &openapi3.SchemaRef{},
-									Extensions: map[string]interface{}{
-										hiddenEnvsExtension: map[string]interface{}{
+									Extensions: map[string]any{
+										hiddenEnvsExtension: map[string]any{
 											"envs": "dev",
 										},
 									},
 								},
 								"application/2-json": {
 									Schema: &openapi3.SchemaRef{},
-									Extensions: map[string]interface{}{
-										hiddenEnvsExtension: map[string]interface{}{
+									Extensions: map[string]any{
+										hiddenEnvsExtension: map[string]any{
 											"envs": "dev",
 										},
 									},
@@ -701,11 +701,11 @@ func TestRemoveResponseIfHiddenForEnv(t *testing.T) {
 							Content: map[string]*openapi3.MediaType{
 								"application/json": {
 									Schema:     &openapi3.SchemaRef{},
-									Extensions: map[string]interface{}{},
+									Extensions: map[string]any{},
 								},
 								"application/2-json": {
 									Schema:     &openapi3.SchemaRef{},
-									Extensions: map[string]interface{}{},
+									Extensions: map[string]any{},
 								},
 							},
 						},
@@ -749,8 +749,8 @@ func getApplyOas() *openapi3.T {
 	oas := &openapi3.T{}
 	oas.Paths = &openapi3.Paths{}
 	hiddenFromProd := &openapi3.PathItem{
-		Extensions: map[string]interface{}{
-			hiddenEnvsExtension: map[string]interface{}{
+		Extensions: map[string]any{
+			hiddenEnvsExtension: map[string]any{
 				"envs": "prod",
 			},
 		},
@@ -760,8 +760,8 @@ func getApplyOas() *openapi3.T {
 	}
 
 	hiddenFromDev := &openapi3.PathItem{
-		Extensions: map[string]interface{}{
-			hiddenEnvsExtension: map[string]interface{}{
+		Extensions: map[string]any{
+			hiddenEnvsExtension: map[string]any{
 				"envs": "dev",
 			},
 		},

--- a/tools/cli/internal/openapi/filter/operations.go
+++ b/tools/cli/internal/openapi/filter/operations.go
@@ -56,7 +56,7 @@ func moveSunsetExtensionToOperation(operation *openapi3.Operation) {
 
 			if sunset, ok := mediaType.Extensions["x-sunset"]; ok {
 				if operation.Extensions == nil {
-					operation.Extensions = make(map[string]interface{})
+					operation.Extensions = make(map[string]any)
 				}
 				operation.Extensions[sunsetExtension] = sunset
 				delete(mediaType.Extensions, sunsetExtension)

--- a/tools/cli/internal/openapi/filter/operations_test.go
+++ b/tools/cli/internal/openapi/filter/operations_test.go
@@ -22,7 +22,7 @@ import (
 
 func Test_FilterOperations_owners(t *testing.T) {
 	operation := &openapi3.Operation{
-		Extensions: map[string]interface{}{
+		Extensions: map[string]any{
 			"x-xgen-owner-team": "team1",
 		},
 		Summary:     "summary",
@@ -48,7 +48,7 @@ func Test_FilterOperations_moveSunsetToOperationAndMarkDeprecated(t *testing.T) 
 		Value: &openapi3.Response{
 			Content: openapi3.Content{
 				"application/json": &openapi3.MediaType{
-					Extensions: map[string]interface{}{
+					Extensions: map[string]any{
 						"x-sunset": "2024-01-01"},
 				},
 			},

--- a/tools/cli/internal/openapi/filter/versioning.go
+++ b/tools/cli/internal/openapi/filter/versioning.go
@@ -66,7 +66,7 @@ func (f *VersioningFilter) Apply() error {
 			continue
 		}
 
-		if err := f.apply(pathItem); err != nil {
+		if err := f.applyInternal(pathItem); err != nil {
 			return err
 		}
 
@@ -80,7 +80,7 @@ func (f *VersioningFilter) Apply() error {
 	return nil
 }
 
-func (f *VersioningFilter) apply(path *openapi3.PathItem) error {
+func (f *VersioningFilter) applyInternal(path *openapi3.PathItem) error {
 	config := &VersionConfig{
 		requestedVersion:      f.metadata.targetVersion,
 		operationsToBeRemoved: make(map[string]*openapi3.Operation),
@@ -109,7 +109,7 @@ func (f *VersioningFilter) apply(path *openapi3.PathItem) error {
 	return nil
 }
 
-// updateResponses filters the response and removes the deprecated responses from the operation and add the  to the operation config
+// updateResponses filters the response and removes the deprecated responses from the operation and add the  to the operation config.
 func updateResponses(op *openapi3.Operation, config *VersionConfig) error {
 	for responseCode, response := range op.Responses.Map() {
 		if response.Value == nil {
@@ -169,7 +169,7 @@ func filterResponse(response *openapi3.ResponseRef, op *openapi3.Operation, rCon
 }
 
 // addDeprecationMessageToOperation adds a deprecation message to the operation description if there are deprecated versions
-// Example: "Read Only role. Deprecated versions: v2-{2023-01-01}"
+// Example: "Read Only role. Deprecated versions: v2-{2023-01-01}".
 func addDeprecationMessageToOperation(op *openapi3.Operation, deprecatedVersions []*apiversion.APIVersion) {
 	if len(deprecatedVersions) == 0 {
 		return
@@ -226,7 +226,7 @@ func filterLatestVersionedContent(content map[string]*openapi3.MediaType, latest
 	return latestContent, nil
 }
 
-// filterContentExactMatch filters the content based on the exact match of the version
+// filterContentExactMatch filters the content based on the exact match of the version.
 func filterContentExactMatch(content map[string]*openapi3.MediaType, version *apiversion.APIVersion) (map[string]*openapi3.MediaType, error) {
 	if content == nil {
 		return nil, nil
@@ -253,14 +253,14 @@ func filterContentExactMatch(content map[string]*openapi3.MediaType, version *ap
 	return filteredContent, nil
 }
 
-// updateSingleMediaTypeExtension updates the media type extension with the version in string format
+// updateSingleMediaTypeExtension updates the media type extension with the version in string format.
 func updateSingleMediaTypeExtension(m *openapi3.MediaType, version *apiversion.APIVersion) {
 	if _, ok := m.Extensions[versionExtension]; ok {
 		m.Extensions[versionExtension] = version.String()
 	}
 }
 
-// getDeprecatedVersionsPerContent returns the deprecated versions for a given content type
+// getDeprecatedVersionsPerContent returns the deprecated versions for a given content type.
 func getDeprecatedVersionsPerContent(content map[string]*openapi3.MediaType, version *apiversion.APIVersion) []*apiversion.APIVersion {
 	versionsInContentType := make(map[string]*apiversion.APIVersion)
 	for contentType := range content {

--- a/tools/cli/internal/openapi/filter/versioning_test.go
+++ b/tools/cli/internal/openapi/filter/versioning_test.go
@@ -32,7 +32,7 @@ func TestPathFilter_processPathItem(t *testing.T) {
 	}
 
 	path := oasPathAllVersions()
-	require.NoError(t, filter.apply(path))
+	require.NoError(t, filter.applyInternal(path))
 
 	assert.NotNil(t, path.Get)
 	assert.Equal(t, 1, path.Get.Responses.Len())
@@ -53,7 +53,7 @@ func TestPathFilter_moreThanOneResponse(t *testing.T) {
 	}
 
 	path := oasPathAllVersions()
-	err = filter.apply(path)
+	err = filter.applyInternal(path)
 
 	require.NoError(t, err)
 	assert.NotNil(t, path.Get)
@@ -89,7 +89,7 @@ func TestPathFilter_filterRequestBody(t *testing.T) {
 	}
 
 	path := oasPathAllVersions()
-	require.NoError(t, filter.apply(path))
+	require.NoError(t, filter.applyInternal(path))
 
 	assert.NotNil(t, path.Get)
 	assert.NotNil(t, path.Get.RequestBody)

--- a/tools/cli/internal/openapi/filter/versioning_test.go
+++ b/tools/cli/internal/openapi/filter/versioning_test.go
@@ -179,7 +179,7 @@ func TestPathFilter_removeResponses(t *testing.T) {
 func getOasWithPaths() *openapi3.T {
 	oas := &openapi3.T{}
 	oas.Paths = &openapi3.Paths{
-		Extensions: map[string]interface{}{
+		Extensions: map[string]any{
 			"x-sunset": "2025-01-10",
 		},
 	}

--- a/tools/cli/internal/openapi/oasdiff_result.go
+++ b/tools/cli/internal/openapi/oasdiff_result.go
@@ -50,7 +50,7 @@ type OasDiffResult struct {
 }
 
 // GetSimpleDiff returns the diff between two OpenAPI specs.
-func (o OasDiff) GetSimpleDiff(base, revision *load.SpecInfo) (*OasDiffResult, error) {
+func (o *OasDiff) GetSimpleDiff(base, revision *load.SpecInfo) (*OasDiffResult, error) {
 	diffReport, err := o.diffGetter.Get(o.config, base.Spec, revision.Spec)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (o OasDiff) GetSimpleDiff(base, revision *load.SpecInfo) (*OasDiffResult, e
 }
 
 // GetFlattenedDiff returns the diff between two OpenAPI specs after flattening them.
-func (o OasDiff) GetFlattenedDiff(base, revision *load.SpecInfo) (*OasDiffResult, error) {
+func (o *OasDiff) GetFlattenedDiff(base, revision *load.SpecInfo) (*OasDiffResult, error) {
 	flattenBaseSpec, err := allof.MergeSpec(base.Spec)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func (o OasDiff) GetFlattenedDiff(base, revision *load.SpecInfo) (*OasDiffResult
 }
 
 // GetDiffWithConfig returns the diff between two OpenAPI specs with a custom config.
-func (o OasDiff) GetDiffWithConfig(base, revision *load.SpecInfo, config *diff.Config) (*OasDiffResult, error) {
+func (o *OasDiff) GetDiffWithConfig(base, revision *load.SpecInfo, config *diff.Config) (*OasDiffResult, error) {
 	diffReport, err := o.diffGetter.Get(config, base.Spec, revision.Spec)
 	if err != nil {
 		return nil, err

--- a/tools/cli/internal/openapi/oasdiff_test.go
+++ b/tools/cli/internal/openapi/oasdiff_test.go
@@ -1162,8 +1162,8 @@ func TestHandlePathConflict(t *testing.T) {
 			name: "No Conflict - Identical Paths",
 			externalPath: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "false",
 						},
 					},
@@ -1181,8 +1181,8 @@ func TestHandlePathConflict(t *testing.T) {
 			name: "Conflict with AllowDocsDiff",
 			externalPath: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "true",
 						},
 					},
@@ -1214,8 +1214,8 @@ func TestHandlePathConflict(t *testing.T) {
 			name: "Conflict with Different Operations",
 			externalPath: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "false",
 						},
 					},
@@ -1242,8 +1242,8 @@ func TestHandlePathConflict(t *testing.T) {
 			name: "Conflict with Different Path Operation",
 			externalPath: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "false",
 						},
 					},
@@ -1292,8 +1292,8 @@ func TestHandlePathConflict(t *testing.T) {
 			name: "Identical Paths with Extensions",
 			externalPath: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "false",
 						},
 					},

--- a/tools/cli/internal/openapi/paths.go
+++ b/tools/cli/internal/openapi/paths.go
@@ -65,56 +65,13 @@ func allOperationsHaveExtension(pathData *openapi3.PathItem, path, extensionName
 	return true
 }
 
-func getOperationExtensionWithName(operation *openapi3.Operation, extensionName string) interface{} {
+func getOperationExtensionWithName(operation *openapi3.Operation, extensionName string) any {
 	if operation.Extensions == nil || operation.Extensions[extensionName] == nil {
 		log.Printf("Operation %s does not have extension %q", operation.OperationID, extensionName)
 		return nil
 	}
 
 	return operation.Extensions[extensionName]
-}
-
-func allOperationsAllowDocsDiff(pathData *openapi3.PathItem) bool {
-	if pathData.Operations() == nil || len(pathData.Operations()) == 0 {
-		return false
-	}
-
-	if pathData.Get != nil {
-		prop := getOperationExtensionProperty(pathData.Get, xgenSoaMigration, allowDocsDiff)
-		if prop != "true" {
-			return false
-		}
-	}
-
-	if pathData.Put != nil {
-		prop := getOperationExtensionProperty(pathData.Put, xgenSoaMigration, allowDocsDiff)
-		if prop != "true" {
-			return false
-		}
-	}
-
-	if pathData.Post != nil {
-		prop := getOperationExtensionProperty(pathData.Post, xgenSoaMigration, allowDocsDiff)
-		if prop != "true" {
-			return false
-		}
-	}
-
-	if pathData.Patch != nil {
-		prop := getOperationExtensionProperty(pathData.Patch, xgenSoaMigration, allowDocsDiff)
-		if prop != "true" {
-			return false
-		}
-	}
-
-	if pathData.Delete != nil {
-		prop := getOperationExtensionProperty(pathData.Delete, xgenSoaMigration, allowDocsDiff)
-		if prop != "true" {
-			return false
-		}
-	}
-
-	return true
 }
 
 func getOperationExtensionProperty(operation *openapi3.Operation, extensionName, extensionProperty string) string {
@@ -127,7 +84,7 @@ func getOperationExtensionProperty(operation *openapi3.Operation, extensionName,
 		return ""
 	}
 
-	value, ok := extension.(map[string]interface{})[extensionProperty].(string)
+	value, ok := extension.(map[string]any)[extensionProperty].(string)
 	if ok {
 		return value
 	}

--- a/tools/cli/internal/openapi/paths_test.go
+++ b/tools/cli/internal/openapi/paths_test.go
@@ -29,36 +29,36 @@ func TestAllOperationsHaveExtension(t *testing.T) {
 			name: "All operations have extension",
 			input: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"test": "true",
 						},
 					},
 				},
 				Put: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"test": "true",
 						},
 					},
 				},
 				Post: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"test": "true",
 						},
 					},
 				},
 				Patch: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"test": "true",
 						},
 					},
 				},
 				Delete: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"test": "true",
 						},
 					},
@@ -70,14 +70,14 @@ func TestAllOperationsHaveExtension(t *testing.T) {
 			name: "Not all operations have extension",
 			input: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"test": "true",
 						},
 					},
 				},
 				Put: &openapi3.Operation{
-					Extensions: map[string]interface{}{
+					Extensions: map[string]any{
 						"x-xgen-sunset": "true",
 					},
 				},
@@ -111,36 +111,36 @@ func TestAllOperationsAllowDocsDiff(t *testing.T) {
 			name: "All operations allow docs diff",
 			input: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "true",
 						},
 					},
 				},
 				Put: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "true",
 						},
 					},
 				},
 				Post: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "true",
 						},
 					},
 				},
 				Patch: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "true",
 						},
 					},
 				},
 				Delete: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "true",
 						},
 					},
@@ -152,15 +152,15 @@ func TestAllOperationsAllowDocsDiff(t *testing.T) {
 			name: "Not all operations allow docs diff",
 			input: &openapi3.PathItem{
 				Get: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "true",
 						},
 					},
 				},
 				Put: &openapi3.Operation{
-					Extensions: map[string]interface{}{
-						"x-xgen-soa-migration": map[string]interface{}{
+					Extensions: map[string]any{
+						"x-xgen-soa-migration": map[string]any{
 							"allowDocsDiff": "false",
 						},
 					},

--- a/tools/cli/internal/openapi/versions_test.go
+++ b/tools/cli/internal/openapi/versions_test.go
@@ -31,7 +31,7 @@ func NewVersionedResponses(t *testing.T) *openapi3.T {
 	t.Helper()
 	inputPath := &openapi3.Paths{}
 
-	extension := map[string]interface{}{
+	extension := map[string]any{
 		"x-xgen-version": "2023-01-01",
 	}
 	response := &openapi3.ResponseRef{
@@ -57,7 +57,7 @@ func NewVersionedResponses(t *testing.T) *openapi3.T {
 		},
 	})
 
-	extensionTwo := map[string]interface{}{
+	extensionTwo := map[string]any{
 		"x-xgen-version": "2023-02-01",
 	}
 

--- a/tools/cli/internal/version/version.go
+++ b/tools/cli/internal/version/version.go
@@ -14,7 +14,7 @@
 
 package version
 
-// These variables are set at compilation time in the Makefile
+// These variables are set at compilation time in the Makefile.
 var (
 	Version   = "next" // Version for CLI.
 	GitCommit = "next" // GitCommit git sha of the build.


### PR DESCRIPTION
## Proposed changes

Noticed some important lints missing on a previous PR so bringling some parity from the CLI lints, mainly 
- gci import ordering consistency
- godot, comments should be correct phrases that end in full stops
- preference for `any` since right now we have a mix
- perfsprint to detect string operations that can be optimized 