### PR TITLE
CLOUDP-294461: [Product Metrics/Observability] Implement Metric Collection workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 *.out
 **/*ipa-collector-results-combined.log
 **/*metric-collection-results.json
+**/*spectral-output.txt
+**/*spectral-report.xml

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 
 *.out
 **/*ipa-collector-results-combined.log
+**/*metric-collection-results.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "mongodb-openapi",
     "description": "MongoDB repository with OpenAPI specification",
+    "type": "module",
     "scripts": {
         "format": "npx prettier . --write",
         "format-check": "npx prettier . --check",

--- a/tools/spectral/ipa/metrics/config.js
+++ b/tools/spectral/ipa/metrics/config.js
@@ -2,13 +2,16 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
+const outputDir = path.join(dirname, 'outputs');
 const rootDir = path.resolve(dirname, '../../../../');
 
 const config = {
   defaultOasFilePath: path.join(rootDir, 'openapi', 'v2.json'),
-  defaultCollectorResultsFilePath: path.join(dirname, 'ipa-collector-results-combined.log'),
   defaultRulesetFilePath: path.join(dirname, '..', 'ipa-spectral.yaml'),
-  defaultMetricCollectionResultsFilePath: path.join(dirname, 'metric-collection-results.json'),
+  defaultCollectorResultsFilePath: path.join(dirname, 'ipa-collector-results-combined.log'),
+  defaultMetricCollectionResultsFilePath: path.join(outputDir, 'metric-collection-results.json'),
+  defaultSpectralReportFile: path.join(outputDir, 'spectral-report.xml'),
+  defaultSpectralOutputFile: path.join(outputDir, 'spectral-output.txt'),
 };
 
 export default config;

--- a/tools/spectral/ipa/metrics/config.js
+++ b/tools/spectral/ipa/metrics/config.js
@@ -2,16 +2,17 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
-const outputDir = path.join(dirname, 'outputs');
 const rootDir = path.resolve(dirname, '../../../../');
 
 const config = {
   defaultOasFilePath: path.join(rootDir, 'openapi', 'v2.json'),
   defaultRulesetFilePath: path.join(dirname, '..', 'ipa-spectral.yaml'),
   defaultCollectorResultsFilePath: path.join(dirname, 'ipa-collector-results-combined.log'),
-  defaultMetricCollectionResultsFilePath: path.join(outputDir, 'metric-collection-results.json'),
-  defaultSpectralReportFile: path.join(outputDir, 'spectral-report.xml'),
-  defaultSpectralOutputFile: path.join(outputDir, 'spectral-output.txt'),
+  defaultOutputsDir: path.join(dirname, 'outputs'),
 };
+
+config.defaultMetricCollectionResultsFilePath = path.join(config.defaultOutputsDir, 'metric-collection-results.json');
+config.defaultSpectralReportFile = path.join(config.defaultOutputsDir, 'spectral-report.xml');
+config.defaultSpectralOutputFile = path.join(config.defaultOutputsDir, 'spectral-output.txt');
 
 export default config;

--- a/tools/spectral/ipa/metrics/config.js
+++ b/tools/spectral/ipa/metrics/config.js
@@ -1,0 +1,14 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(dirname, '../../../../');
+
+const config = {
+  defaultOasFilePath: path.join(rootDir, 'openapi', 'v2.json'),
+  defaultCollectorResultsFilePath: path.join(dirname, '..', 'ipa-collector-results-combined.log'),
+  defaultRulesetFilePath: path.join(dirname, '..', 'ipa-spectral.yaml'),
+  defaultMetricCollectionResultsFilePath: path.join(dirname, 'metric-collection-results.json'),
+};
+
+export default config;

--- a/tools/spectral/ipa/metrics/config.js
+++ b/tools/spectral/ipa/metrics/config.js
@@ -6,7 +6,7 @@ const rootDir = path.resolve(dirname, '../../../../');
 
 const config = {
   defaultOasFilePath: path.join(rootDir, 'openapi', 'v2.json'),
-  defaultCollectorResultsFilePath: path.join(dirname, '..', 'ipa-collector-results-combined.log'),
+  defaultCollectorResultsFilePath: path.join(dirname, 'ipa-collector-results-combined.log'),
   defaultRulesetFilePath: path.join(dirname, '..', 'ipa-spectral.yaml'),
   defaultMetricCollectionResultsFilePath: path.join(dirname, 'metric-collection-results.json'),
 };

--- a/tools/spectral/ipa/metrics/metricCollection.js
+++ b/tools/spectral/ipa/metrics/metricCollection.js
@@ -42,7 +42,7 @@ async function runMetricCollectionJob(oasFilePath = config.defaultOasFilePath) {
 const args = process.argv.slice(2);
 const customOasFile = args[0];
 
-if(!fs.existsSync(config.defaultOutputsDir)){
+if (!fs.existsSync(config.defaultOutputsDir)) {
   fs.mkdirSync('outputs');
   console.log(`Output directory created successfully`);
 }

--- a/tools/spectral/ipa/metrics/metricCollection.js
+++ b/tools/spectral/ipa/metrics/metricCollection.js
@@ -2,14 +2,20 @@ import spectral from '@stoplight/spectral-core';
 import { fileURLToPath } from 'node:url';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { loadOpenAPIFile, extractTeamOwnership, loadRuleset, loadCollectorResults, getSeverityPerRule, merge } from './utils.js';
+import {
+  loadOpenAPIFile,
+  extractTeamOwnership,
+  loadRuleset,
+  loadCollectorResults,
+  getSeverityPerRule,
+  merge,
+} from './utils.js';
 const { Spectral } = spectral;
 
 //TBD
 const oasFile = '../../../../openapi/v2.json';
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const collectorResultsFile = path.join(dirname, '../ipa-collector-results-combined.log');
-
 
 async function runMetricCollectionJob() {
   try {
@@ -43,7 +49,6 @@ async function runMetricCollectionJob() {
     throw error;
   }
 }
-
 
 runMetricCollectionJob()
   .then((results) => fs.writeFileSync('results.log', JSON.stringify(results)))

--- a/tools/spectral/ipa/metrics/metricCollection.js
+++ b/tools/spectral/ipa/metrics/metricCollection.js
@@ -42,6 +42,11 @@ async function runMetricCollectionJob(oasFilePath = config.defaultOasFilePath) {
 const args = process.argv.slice(2);
 const customOasFile = args[0];
 
+if(!fs.existsSync(config.defaultOutputsDir)){
+  fs.mkdirSync('outputs');
+  console.log(`Output directory created successfully`);
+}
+
 const result = spawnSync(
   'spectral',
   [

--- a/tools/spectral/ipa/metrics/metricCollection.js
+++ b/tools/spectral/ipa/metrics/metricCollection.js
@@ -1,0 +1,50 @@
+import spectral from '@stoplight/spectral-core';
+import { fileURLToPath } from 'node:url';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { loadOpenAPIFile, extractTeamOwnership, loadRuleset, loadCollectorResults, getSeverityPerRule, merge } from './utils.js';
+const { Spectral } = spectral;
+
+//TBD
+const oasFile = '../../../../openapi/v2.json';
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const collectorResultsFile = path.join(dirname, '../ipa-collector-results-combined.log');
+
+
+async function runMetricCollectionJob() {
+  try {
+    console.log('Loading OpenAPI file...');
+    const oasContent = loadOpenAPIFile(oasFile);
+
+    console.log('Extracting team ownership data...');
+    const ownershipData = extractTeamOwnership(oasContent);
+
+    console.log('Initializing Spectral...');
+    const spectral = new Spectral();
+    const rulesetPath = path.join(dirname, '../ipa-spectral.yaml');
+    const ruleset = await loadRuleset(rulesetPath, spectral);
+
+    console.log('Getting rule severities...');
+    const ruleSeverityMap = getSeverityPerRule(ruleset);
+
+    console.log('Running Spectral analysis...');
+    const spectralResults = await spectral.run(oasContent);
+
+    console.log('Loading collector results...');
+    const collectorResults = loadCollectorResults(collectorResultsFile);
+
+    console.log('Merging results...');
+    const mergedResults = merge(spectralResults, ownershipData, collectorResults, ruleSeverityMap);
+
+    console.log('Metric collection job complete.');
+    return mergedResults;
+  } catch (error) {
+    console.error('Error during metric collection:', error.message);
+    throw error;
+  }
+}
+
+
+runMetricCollectionJob()
+  .then((results) => fs.writeFileSync('results.log', JSON.stringify(results)))
+  .catch((error) => console.error(error.message));

--- a/tools/spectral/ipa/metrics/metricCollection.js
+++ b/tools/spectral/ipa/metrics/metricCollection.js
@@ -1,7 +1,5 @@
 import spectral from '@stoplight/spectral-core';
-import { fileURLToPath } from 'node:url';
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import {
   loadOpenAPIFile,
   extractTeamOwnership,

--- a/tools/spectral/ipa/metrics/metricCollection.js
+++ b/tools/spectral/ipa/metrics/metricCollection.js
@@ -9,6 +9,7 @@ import {
   merge,
 } from './utils.js';
 import config from './config.js';
+import collector from './collector.js';
 const { Spectral } = spectral;
 
 async function runMetricCollectionJob(oasFilePath = config.defaultOasFilePath) {
@@ -28,6 +29,7 @@ async function runMetricCollectionJob(oasFilePath = config.defaultOasFilePath) {
 
     console.log('Running Spectral analysis...');
     const spectralResults = await spectral.run(oasContent);
+    collector.flushToFile();
 
     console.log('Loading collector results...');
     const collectorResults = loadCollectorResults(config.defaultCollectorResultsFilePath);

--- a/tools/spectral/ipa/metrics/utils.js
+++ b/tools/spectral/ipa/metrics/utils.js
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
-import {
-  bundleAndLoadRuleset
-} from '@stoplight/spectral-ruleset-bundler/with-loader';
+import { bundleAndLoadRuleset } from '@stoplight/spectral-ruleset-bundler/with-loader';
 import { EntryType } from './collector.js';
 
 export function loadOpenAPIFile(filePath) {
@@ -80,8 +78,8 @@ export function merge(spectralResults, ownershipData, collectorResults, ruleSeve
 
   function addEntry(entryType, adoptionStatus) {
     for (const entry of collectorResults[entryType]) {
-      const existing = results.find((result) =>
-        result.component_id === entry.componentId && result.ipa_rule === entry.ruleName
+      const existing = results.find(
+        (result) => result.component_id === entry.componentId && result.ipa_rule === entry.ruleName
       );
 
       if (existing) {

--- a/tools/spectral/ipa/metrics/utils.js
+++ b/tools/spectral/ipa/metrics/utils.js
@@ -73,7 +73,7 @@ function getIPAFromIPARule(ipaRule) {
   }
 }
 
-export function merge(spectralResults, ownershipData, collectorResults, ruleSeverityMap) {
+export function merge(ownershipData, collectorResults, ruleSeverityMap) {
   const results = [];
 
   function addEntry(entryType, adoptionStatus) {

--- a/tools/spectral/ipa/metrics/utils.js
+++ b/tools/spectral/ipa/metrics/utils.js
@@ -1,0 +1,110 @@
+import fs from 'node:fs';
+import {
+  bundleAndLoadRuleset
+} from '@stoplight/spectral-ruleset-bundler/with-loader';
+import { EntryType } from './collector.js';
+
+export function loadOpenAPIFile(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to load OpenAPI file: ${error.message}`);
+  }
+}
+
+export function getSeverityPerRule(ruleset) {
+  const rules = ruleset.rules || {};
+  const map = {};
+  for (const [name, ruleObject] of Object.entries(rules)) {
+    map[name] = ruleObject.definition.severity;
+  }
+  return map;
+}
+
+export async function loadRuleset(rulesetPath, spectral) {
+  try {
+    const ruleset = await bundleAndLoadRuleset(rulesetPath, { fs, fetch });
+    await spectral.setRuleset(ruleset);
+    return ruleset;
+  } catch (error) {
+    throw new Error(`Failed to load ruleset: ${error.message}`);
+  }
+}
+
+export function extractTeamOwnership(oasContent) {
+  const ownerTeams = {};
+  const paths = oasContent.paths || {};
+
+  for (const [path, pathItem] of Object.entries(paths)) {
+    for (const [, operation] of Object.entries(pathItem)) {
+      const ownerTeam = operation['x-xgen-owner-team'];
+
+      if (ownerTeam) {
+        if (!ownerTeams[path]) {
+          ownerTeams[path] = ownerTeam;
+        } else if (ownerTeams[path] !== ownerTeam) {
+          console.warn(`Conflict on path ${path}: ${ownerTeams[path]} vs ${ownerTeam}`);
+        }
+      }
+    }
+  }
+
+  return ownerTeams;
+}
+
+export function loadCollectorResults(collectorResultsFilePath) {
+  try {
+    const content = fs.readFileSync(collectorResultsFilePath, 'utf8');
+    const contentParsed = JSON.parse(content);
+    return {
+      [EntryType.VIOLATION]: contentParsed[EntryType.VIOLATION],
+      [EntryType.ADOPTION]: contentParsed[EntryType.ADOPTION],
+      [EntryType.EXCEPTION]: contentParsed[EntryType.EXCEPTION],
+    };
+  } catch (error) {
+    throw new Error(`Failed to load Collector Results file: ${error.message}`);
+  }
+}
+
+function getIPAFromIPARule(ipaRule) {
+  const pattern = /IPA-\d{3}/;
+  const match = ipaRule.match(pattern);
+  if (match) {
+    return match[0];
+  }
+}
+
+export function merge(spectralResults, ownershipData, collectorResults, ruleSeverityMap) {
+  const results = [];
+
+  function addEntry(entryType, adoptionStatus) {
+    for (const entry of collectorResults[entryType]) {
+      const existing = results.find((result) =>
+        result.component_id === entry.componentId && result.ipa_rule === entry.ruleName
+      );
+
+      if (existing) {
+        console.warn('Duplicate entries found', existing);
+        continue;
+      }
+
+      results.push({
+        component_id: entry.componentId,
+        ipa_rule: entry.ruleName,
+        ipa: getIPAFromIPARule(entry.ruleName),
+        severity_level: ruleSeverityMap[entry.ruleName],
+        adoption_status: adoptionStatus,
+        exception_reason: entryType === EntryType.EXCEPTION ? entry.exceptionReason : null,
+        owner_team: entry.ownerTeam || null,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
+  addEntry(EntryType.VIOLATION, 'violated');
+  addEntry(EntryType.ADOPTION, 'adopted');
+  addEntry(EntryType.EXCEPTION, 'exempted');
+
+  return results;
+}

--- a/tools/spectral/ipa/metrics/utils.js
+++ b/tools/spectral/ipa/metrics/utils.js
@@ -87,6 +87,15 @@ export function merge(ownershipData, collectorResults, ruleSeverityMap) {
         continue;
       }
 
+      let ownerTeam = null;
+      if (entry.componentId.startsWith('paths')) {
+        const pathParts = entry.componentId.split('.');
+        if (pathParts.length === 2) {
+          const path = pathParts[1];
+          ownerTeam = ownershipData[path];
+        }
+      }
+
       results.push({
         component_id: entry.componentId,
         ipa_rule: entry.ruleName,
@@ -94,7 +103,7 @@ export function merge(ownershipData, collectorResults, ruleSeverityMap) {
         severity_level: ruleSeverityMap[entry.ruleName],
         adoption_status: adoptionStatus,
         exception_reason: entryType === EntryType.EXCEPTION ? entry.exceptionReason : null,
-        owner_team: entry.ownerTeam || null,
+        owner_team: ownerTeam,
         timestamp: new Date().toISOString(),
       });
     }


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-294461](https://jira.mongodb.org/browse/CLOUDP-294461)

`metricCollectionJob` implements the workflow for metric collection:
1. Run the Spectral command with IPA ruleset
2. Load OpenAPI file
3. Extract team ownership
4. Get rule severities
5. Load Collector results
6. Merge all the results into the `metric-collection-results.json`

`metricCollectionJob` allows custom OAS files, but the default is the `v2.json`
Example:` node metricCollection.js <path-to-OAS-file>`

`metricCollectionJob` produces a couple of output files:
- ` /outputs/metric-collection-results.json` : The data collected for metrics
- `/outputs/spectral-output.txt`: Output of spectral command
- `/outputs/spectral-report.xml`: Report for the errors
- ` ipa-collector-results-combined.log`: This file is intended to store the collector results. However, it does not appear to be populated when `metricCollection.js` is executed, even though `metric-collection-results.json`, which is constructed using this file, is populated correctly.

## Testing

Example output file: 
[metric-collection-results.json](https://github.com/user-attachments/files/18428594/metric-collection-results.json)



## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

<!--## Further comments-->

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
