### PR TITLE
CLOUDP-295191: Fix optional spec validation - IPA validation

### DIFF
--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -68,7 +68,7 @@ jobs:
           npm run test
       - name: Run IPA
         run: |
-          spectral lint ./openapi/v2.yaml --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
+          npx spectral lint ./openapi/v2.yaml --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           sparse-checkout: |
             .github
+            openapi
             tools/spectral/ipa
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -65,6 +66,9 @@ jobs:
       - name: Run Jest tests
         run: |
           npm run test
+      - name: Run IPA
+        run: |
+          spectral lint ./openapi/v2.yaml --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           sparse-checkout: |
             .github
-            openapi
             tools/spectral/ipa
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -66,9 +65,6 @@ jobs:
       - name: Run Jest tests
         run: |
           npm run test
-      - name: Run IPA
-        run: |
-          npx spectral lint ./openapi/v2.yaml --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run IPA validation
         id: ipa-spectral-validation
         run: |
-          spectral lint openapi-foas.json --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
+          npx spectral lint openapi-foas.json --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
       - name: Validate the FOAS can be used to generate Postman collection
         id: spectral-validation
         env:


### PR DESCRIPTION
## Proposed changes

Fixes IPA validation failure on the optional spec validation run, due to spectral command not found.

_Jira ticket:_ [CLOUDP-295191](https://jira.mongodb.org/browse/CLOUDP-295191)
