### PR TITLE
CLOUDP-295790: Export IPA product metrics as parquet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@stoplight/spectral-functions": "^1.9.3",
                 "@stoplight/spectral-ref-resolver": "^1.0.5",
                 "@stoplight/spectral-ruleset-bundler": "^1.6.1",
+                "apache-arrow": "^19.0.0",
                 "dotenv": "^16.4.7",
                 "eslint-plugin-jest": "^28.10.0",
                 "openapi-to-postmanv2": "4.24.0"
@@ -254,34 +255,32 @@
             }
         },
         "node_modules/@aws-sdk/client-s3": {
-            "version": "3.729.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.729.0.tgz",
-            "integrity": "sha512-hpagpazcfOYtxE4nDlR/6JcaIdZ3T2BUt2Ev11Zyz2B5G8eC1dWJgvFsW7ws35252Nb6HTLkJajtnM3v9KtXGw==",
+            "version": "3.731.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.731.1.tgz",
+            "integrity": "sha512-Ab2PA/8Th6JkurCkxnQJZHPE/JnnSsX/XHQzirkQb+JpKOyWMRC/YZUBfAaiwhxqX65RHgklrwil+UbFl4TtAQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha1-browser": "5.2.0",
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sso-oidc": "3.726.0",
-                "@aws-sdk/client-sts": "3.726.1",
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/credential-provider-node": "3.726.0",
-                "@aws-sdk/middleware-bucket-endpoint": "3.726.0",
-                "@aws-sdk/middleware-expect-continue": "3.723.0",
-                "@aws-sdk/middleware-flexible-checksums": "3.729.0",
-                "@aws-sdk/middleware-host-header": "3.723.0",
-                "@aws-sdk/middleware-location-constraint": "3.723.0",
-                "@aws-sdk/middleware-logger": "3.723.0",
-                "@aws-sdk/middleware-recursion-detection": "3.723.0",
-                "@aws-sdk/middleware-sdk-s3": "3.723.0",
-                "@aws-sdk/middleware-ssec": "3.723.0",
-                "@aws-sdk/middleware-user-agent": "3.726.0",
-                "@aws-sdk/region-config-resolver": "3.723.0",
-                "@aws-sdk/signature-v4-multi-region": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
-                "@aws-sdk/util-endpoints": "3.726.0",
-                "@aws-sdk/util-user-agent-browser": "3.723.0",
-                "@aws-sdk/util-user-agent-node": "3.726.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/credential-provider-node": "3.731.1",
+                "@aws-sdk/middleware-bucket-endpoint": "3.731.0",
+                "@aws-sdk/middleware-expect-continue": "3.731.0",
+                "@aws-sdk/middleware-flexible-checksums": "3.731.0",
+                "@aws-sdk/middleware-host-header": "3.731.0",
+                "@aws-sdk/middleware-location-constraint": "3.731.0",
+                "@aws-sdk/middleware-logger": "3.731.0",
+                "@aws-sdk/middleware-recursion-detection": "3.731.0",
+                "@aws-sdk/middleware-sdk-s3": "3.731.0",
+                "@aws-sdk/middleware-ssec": "3.731.0",
+                "@aws-sdk/middleware-user-agent": "3.731.0",
+                "@aws-sdk/region-config-resolver": "3.731.0",
+                "@aws-sdk/signature-v4-multi-region": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
+                "@aws-sdk/util-endpoints": "3.731.0",
+                "@aws-sdk/util-user-agent-browser": "3.731.0",
+                "@aws-sdk/util-user-agent-node": "3.731.0",
                 "@aws-sdk/xml-builder": "3.723.0",
                 "@smithy/config-resolver": "^4.0.0",
                 "@smithy/core": "^3.0.0",
@@ -323,127 +322,23 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.726.0.tgz",
-            "integrity": "sha512-NM5pjv2qglEc4XN3nnDqtqGsSGv1k5YTmzDo3W3pObItHmpS8grSeNfX9zSH+aVl0Q8hE4ZIgvTPNZ+GzwVlqg==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.731.0.tgz",
+            "integrity": "sha512-O4C/UYGgqMsBg21MMApFdgyh8BX568hQhbdoNFmRVTBoSnCZ3w+H4a1wBPX4Gyl0NX+ab6Xxo9rId8HiyPXJ0A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/middleware-host-header": "3.723.0",
-                "@aws-sdk/middleware-logger": "3.723.0",
-                "@aws-sdk/middleware-recursion-detection": "3.723.0",
-                "@aws-sdk/middleware-user-agent": "3.726.0",
-                "@aws-sdk/region-config-resolver": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
-                "@aws-sdk/util-endpoints": "3.726.0",
-                "@aws-sdk/util-user-agent-browser": "3.723.0",
-                "@aws-sdk/util-user-agent-node": "3.726.0",
-                "@smithy/config-resolver": "^4.0.0",
-                "@smithy/core": "^3.0.0",
-                "@smithy/fetch-http-handler": "^5.0.0",
-                "@smithy/hash-node": "^4.0.0",
-                "@smithy/invalid-dependency": "^4.0.0",
-                "@smithy/middleware-content-length": "^4.0.0",
-                "@smithy/middleware-endpoint": "^4.0.0",
-                "@smithy/middleware-retry": "^4.0.0",
-                "@smithy/middleware-serde": "^4.0.0",
-                "@smithy/middleware-stack": "^4.0.0",
-                "@smithy/node-config-provider": "^4.0.0",
-                "@smithy/node-http-handler": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/smithy-client": "^4.0.0",
-                "@smithy/types": "^4.0.0",
-                "@smithy/url-parser": "^4.0.0",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.0",
-                "@smithy/util-defaults-mode-node": "^4.0.0",
-                "@smithy/util-endpoints": "^3.0.0",
-                "@smithy/util-middleware": "^4.0.0",
-                "@smithy/util-retry": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.726.0.tgz",
-            "integrity": "sha512-5JzTX9jwev7+y2Jkzjz0pd1wobB5JQfPOQF3N2DrJ5Pao0/k6uRYwE4NqB0p0HlGrMTDm7xNq7OSPPIPG575Jw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/credential-provider-node": "3.726.0",
-                "@aws-sdk/middleware-host-header": "3.723.0",
-                "@aws-sdk/middleware-logger": "3.723.0",
-                "@aws-sdk/middleware-recursion-detection": "3.723.0",
-                "@aws-sdk/middleware-user-agent": "3.726.0",
-                "@aws-sdk/region-config-resolver": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
-                "@aws-sdk/util-endpoints": "3.726.0",
-                "@aws-sdk/util-user-agent-browser": "3.723.0",
-                "@aws-sdk/util-user-agent-node": "3.726.0",
-                "@smithy/config-resolver": "^4.0.0",
-                "@smithy/core": "^3.0.0",
-                "@smithy/fetch-http-handler": "^5.0.0",
-                "@smithy/hash-node": "^4.0.0",
-                "@smithy/invalid-dependency": "^4.0.0",
-                "@smithy/middleware-content-length": "^4.0.0",
-                "@smithy/middleware-endpoint": "^4.0.0",
-                "@smithy/middleware-retry": "^4.0.0",
-                "@smithy/middleware-serde": "^4.0.0",
-                "@smithy/middleware-stack": "^4.0.0",
-                "@smithy/node-config-provider": "^4.0.0",
-                "@smithy/node-http-handler": "^4.0.0",
-                "@smithy/protocol-http": "^5.0.0",
-                "@smithy/smithy-client": "^4.0.0",
-                "@smithy/types": "^4.0.0",
-                "@smithy/url-parser": "^4.0.0",
-                "@smithy/util-base64": "^4.0.0",
-                "@smithy/util-body-length-browser": "^4.0.0",
-                "@smithy/util-body-length-node": "^4.0.0",
-                "@smithy/util-defaults-mode-browser": "^4.0.0",
-                "@smithy/util-defaults-mode-node": "^4.0.0",
-                "@smithy/util-endpoints": "^3.0.0",
-                "@smithy/util-middleware": "^4.0.0",
-                "@smithy/util-retry": "^4.0.0",
-                "@smithy/util-utf8": "^4.0.0",
-                "tslib": "^2.6.2"
-            },
-            "engines": {
-                "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.726.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts": {
-            "version": "3.726.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.726.1.tgz",
-            "integrity": "sha512-qh9Q9Vu1hrM/wMBOBIaskwnE4GTFaZu26Q6WHwyWNfj7J8a40vBxpW16c2vYXHLBtwRKM1be8uRLkmDwghpiNw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "5.2.0",
-                "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/client-sso-oidc": "3.726.0",
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/credential-provider-node": "3.726.0",
-                "@aws-sdk/middleware-host-header": "3.723.0",
-                "@aws-sdk/middleware-logger": "3.723.0",
-                "@aws-sdk/middleware-recursion-detection": "3.723.0",
-                "@aws-sdk/middleware-user-agent": "3.726.0",
-                "@aws-sdk/region-config-resolver": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
-                "@aws-sdk/util-endpoints": "3.726.0",
-                "@aws-sdk/util-user-agent-browser": "3.723.0",
-                "@aws-sdk/util-user-agent-node": "3.726.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/middleware-host-header": "3.731.0",
+                "@aws-sdk/middleware-logger": "3.731.0",
+                "@aws-sdk/middleware-recursion-detection": "3.731.0",
+                "@aws-sdk/middleware-user-agent": "3.731.0",
+                "@aws-sdk/region-config-resolver": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
+                "@aws-sdk/util-endpoints": "3.731.0",
+                "@aws-sdk/util-user-agent-browser": "3.731.0",
+                "@aws-sdk/util-user-agent-node": "3.731.0",
                 "@smithy/config-resolver": "^4.0.0",
                 "@smithy/core": "^3.0.0",
                 "@smithy/fetch-http-handler": "^5.0.0",
@@ -476,12 +371,12 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
-            "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.731.0.tgz",
+            "integrity": "sha512-ithBN1VWASkvAIlozJmenqDvNnFddr/SZXAs58+jCnBHgy3tXLHABZGVNCjetZkHRqNdXEO1kirnoxaFeXMeDA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/core": "^3.0.0",
                 "@smithy/node-config-provider": "^4.0.0",
                 "@smithy/property-provider": "^4.0.0",
@@ -498,13 +393,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.723.0.tgz",
-            "integrity": "sha512-OuH2yULYUHTVDUotBoP/9AEUIJPn81GQ/YBtZLoo2QyezRJ2QiO/1epVtbJlhNZRwXrToLEDmQGA2QfC8c7pbA==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.731.0.tgz",
+            "integrity": "sha512-h0WWZg4QMLgFVyIvQrC43zpVqsUWg1mPM1clpogP43B8+wEhDEQ4qWRzvFs3dQ4cqx/FLyDUZZF4cqgd94z7kw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/property-provider": "^4.0.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -514,13 +409,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.723.0.tgz",
-            "integrity": "sha512-DTsKC6xo/kz/ZSs1IcdbQMTgiYbpGTGEd83kngFc1bzmw7AmK92DBZKNZpumf8R/UfSpTcj9zzUUmrWz1kD0eQ==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.731.0.tgz",
+            "integrity": "sha512-iRtrjtcYaWgbvtu2cvDhIsPWXZGvhy1Hgks4682MEBNTc9AUwlfvDrYz2EEnTtJJyrbOdEHVrYrzqD8qPyVLCg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/fetch-http-handler": "^5.0.0",
                 "@smithy/node-http-handler": "^4.0.0",
                 "@smithy/property-provider": "^4.0.0",
@@ -535,18 +430,19 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.726.0.tgz",
-            "integrity": "sha512-seTtcKL2+gZX6yK1QRPr5mDJIBOatrpoyrO8D5b8plYtV/PDbDW3mtDJSWFHet29G61ZmlNElyXRqQCXn9WX+A==",
+            "version": "3.731.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.731.1.tgz",
+            "integrity": "sha512-0M0ejuqW8iHNcTH2ZXSY9m+I7Y06qVkj6k3vfQU9XaB//mTUCxxfGfqWAtgfr7Yi73egABTcPc0jyPdcvSW4Kw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/credential-provider-env": "3.723.0",
-                "@aws-sdk/credential-provider-http": "3.723.0",
-                "@aws-sdk/credential-provider-process": "3.723.0",
-                "@aws-sdk/credential-provider-sso": "3.726.0",
-                "@aws-sdk/credential-provider-web-identity": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/credential-provider-env": "3.731.0",
+                "@aws-sdk/credential-provider-http": "3.731.0",
+                "@aws-sdk/credential-provider-process": "3.731.0",
+                "@aws-sdk/credential-provider-sso": "3.731.1",
+                "@aws-sdk/credential-provider-web-identity": "3.731.1",
+                "@aws-sdk/nested-clients": "3.731.1",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/credential-provider-imds": "^4.0.0",
                 "@smithy/property-provider": "^4.0.0",
                 "@smithy/shared-ini-file-loader": "^4.0.0",
@@ -555,24 +451,21 @@
             },
             "engines": {
                 "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.726.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.726.0.tgz",
-            "integrity": "sha512-jjsewBcw/uLi24x8JbnuDjJad4VA9ROCE94uVRbEnGmUEsds75FWOKp3fWZLQlmjLtzsIbJOZLALkZP86liPaw==",
+            "version": "3.731.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.731.1.tgz",
+            "integrity": "sha512-5c0ZiagMTPmWilXNffeXJCLoCEz97jilHr3QJWwf2GaTay4tzN+Ld71rpdfEenzUR7fuxEWFfVlwQbFOzFNYHg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.723.0",
-                "@aws-sdk/credential-provider-http": "3.723.0",
-                "@aws-sdk/credential-provider-ini": "3.726.0",
-                "@aws-sdk/credential-provider-process": "3.723.0",
-                "@aws-sdk/credential-provider-sso": "3.726.0",
-                "@aws-sdk/credential-provider-web-identity": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/credential-provider-env": "3.731.0",
+                "@aws-sdk/credential-provider-http": "3.731.0",
+                "@aws-sdk/credential-provider-ini": "3.731.1",
+                "@aws-sdk/credential-provider-process": "3.731.0",
+                "@aws-sdk/credential-provider-sso": "3.731.1",
+                "@aws-sdk/credential-provider-web-identity": "3.731.1",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/credential-provider-imds": "^4.0.0",
                 "@smithy/property-provider": "^4.0.0",
                 "@smithy/shared-ini-file-loader": "^4.0.0",
@@ -584,13 +477,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.723.0.tgz",
-            "integrity": "sha512-fgupvUjz1+jeoCBA7GMv0L6xEk92IN6VdF4YcFhsgRHlHvNgm7ayaoKQg7pz2JAAhG/3jPX6fp0ASNy+xOhmPA==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.731.0.tgz",
+            "integrity": "sha512-6yNMY6q3xHLbs2f2+C6GhvMrjTgtFBiPJJqKaPLsTIhlTRvh4sK8pGm3ITcma0jOxtPDIuoPfBAV8N8XVMBlZg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/property-provider": "^4.0.0",
                 "@smithy/shared-ini-file-loader": "^4.0.0",
                 "@smithy/types": "^4.0.0",
@@ -601,15 +494,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.726.0.tgz",
-            "integrity": "sha512-WxkN76WeB08j2yw7jUH9yCMPxmT9eBFd9ZA/aACG7yzOIlsz7gvG3P2FQ0tVg25GHM0E4PdU3p/ByTOawzcOAg==",
+            "version": "3.731.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.731.1.tgz",
+            "integrity": "sha512-p1tp+rMUf5YNQLr8rVRmDgNtKGYLL0KCdq3K2hwwvFnx9MjReF1sA4lfm3xWsxBQM+j3QN9AvMQqBzDJ+NOSdw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.726.0",
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/token-providers": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/client-sso": "3.731.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/token-providers": "3.731.1",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/property-provider": "^4.0.0",
                 "@smithy/shared-ini-file-loader": "^4.0.0",
                 "@smithy/types": "^4.0.0",
@@ -620,31 +513,29 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.723.0.tgz",
-            "integrity": "sha512-tl7pojbFbr3qLcOE6xWaNCf1zEfZrIdSJtOPeSXfV/thFMMAvIjgf3YN6Zo1a6cxGee8zrV/C8PgOH33n+Ev/A==",
+            "version": "3.731.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.731.1.tgz",
+            "integrity": "sha512-+ynAvEGWDR5ZJFxgpwwzhvlQ3WQ7BleWXU6JwpIw3yFrD4eZEn85b8DZC1aEz7C9kb1HSV6B3gpqHqlyS6wj8g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/nested-clients": "3.731.1",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/property-provider": "^4.0.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sts": "^3.723.0"
             }
         },
         "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.726.0.tgz",
-            "integrity": "sha512-vpaP80rZqwu0C3ELayIcRIW84/nd1tadeoqllT+N9TDshuEvq4UJ+w47OBHB7RkHFJoc79lXXNYle0fdQdaE/A==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.731.0.tgz",
+            "integrity": "sha512-G9vuGW5GWCbzGOwlGFJcOkfxhw1cB6vzcv75QTT0CmciLXK+Cio8O2pqMSTTF2kg9Y6iHVC2BlOtLRkJAVOxVQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@aws-sdk/util-arn-parser": "3.723.0",
                 "@smithy/node-config-provider": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.0",
@@ -657,12 +548,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-expect-continue": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.723.0.tgz",
-            "integrity": "sha512-w/O0EkIzkiqvGu7U8Ke7tue0V0HYM5dZQrz6nVU+R8T2LddWJ+njEIHU4Wh8aHPLQXdZA5NQumv0xLPdEutykw==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.731.0.tgz",
+            "integrity": "sha512-oY4nsY/mb5O5eZCzIuWpyvzO45Bi6UBtE48IaJsoyVctagA1l8hB66aczH9M1NHNjvbS4Beu1agwh3Nyb1eJug==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/protocol-http": "^5.0.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -672,16 +563,16 @@
             }
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.729.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.729.0.tgz",
-            "integrity": "sha512-GY92MQ7Pr8hK2rwKmOYSGMmfPQRCWRJ3s1aAIyJBpOHUejWdaNAi78vxeUzVkmGdVjUfF6hRTRAxqV7MnHwe/g==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.731.0.tgz",
+            "integrity": "sha512-LMs/rndovYjYSntSYyPE/PIl4iHNiquaU0lpDqpQc9iTgQcNbjdriSUWpibgu1jXlGBpBYCqttNkxmEThbbWxA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/crc32": "5.2.0",
                 "@aws-crypto/crc32c": "5.2.0",
                 "@aws-crypto/util": "5.2.0",
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/is-array-buffer": "^4.0.0",
                 "@smithy/node-config-provider": "^4.0.0",
                 "@smithy/protocol-http": "^5.0.0",
@@ -696,12 +587,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
-            "integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.731.0.tgz",
+            "integrity": "sha512-ndAJsm5uWPPJRZowLKpB1zuL17qWlWVtCJP4I/ynBkq1PU1DijDXBul2UZaG6Mpvsgms1NXo/h9noHuK7T3v8w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/protocol-http": "^5.0.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -711,12 +602,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-location-constraint": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.723.0.tgz",
-            "integrity": "sha512-inp9tyrdRWjGOMu1rzli8i2gTo0P4X6L7nNRXNTKfyPNZcBimZ4H0H1B671JofSI5isaklVy5r4pvv2VjjLSHw==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.731.0.tgz",
+            "integrity": "sha512-1I2EjAFxrQksrzqdN7YYuY/q2YsjqeX4l7f9VOkdBjiZeDvVIEdM99IT5sISJB/r6CjNrYX5MhqGhE8i1VFchA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -725,12 +616,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
-            "integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.731.0.tgz",
+            "integrity": "sha512-IIZrOdjbY2vKzPJPrwE7FoFQCIPEL6UqURi8LEaiVyCag4p2fvaTN5pgKuQtGC2+iYd/HHcGT4qn2bAqF5Jmmw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -739,12 +630,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
-            "integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.731.0.tgz",
+            "integrity": "sha512-y6FLASB1iKWuR5tUipMyo77bt0lEl3OnCrrd2xw/H24avq1HhJjjPR0HHhJE6QKJzF/FYXeV88tcyPSMe32VDw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/protocol-http": "^5.0.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -754,13 +645,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.723.0.tgz",
-            "integrity": "sha512-wfjOvNJVp8LDWhq4wO5jtSMb8Vgf4tNlR7QTEQfoYc6AGU3WlK5xyUQcpfcpwytEhQTN9u0cJLQpSyXDO+qSCw==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.731.0.tgz",
+            "integrity": "sha512-J9aKyQaVoec5eWTSDfO4h2sKHNP0wTzN15LFcHnkD+e/d0rdmOi7BTkkbJrIaynma9WShIasmrtM3HNi9GiiTA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
                 "@aws-sdk/util-arn-parser": "3.723.0",
                 "@smithy/core": "^3.0.0",
                 "@smithy/node-config-provider": "^4.0.0",
@@ -779,12 +670,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-ssec": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.723.0.tgz",
-            "integrity": "sha512-Bs+8RAeSMik6ZYCGSDJzJieGsDDh2fRbh1HQG94T8kpwBXVxMYihm6e9Xp2cyl+w9fyyCnh0IdCKChP/DvrdhA==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.731.0.tgz",
+            "integrity": "sha512-1HP4lxGcQx4awXgxfL8t9faBK7TqEL7zkAZrm/YBbLrT9oQomxZOHKIOHvo5VVh4qmsNBdqnH2XUlSMY71gsww==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
             },
@@ -793,14 +684,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.726.0.tgz",
-            "integrity": "sha512-hZvzuE5S0JmFie1r68K2wQvJbzyxJFdzltj9skgnnwdvLe8F/tz7MqLkm28uV0m4jeHk0LpiBo6eZaPkQiwsZQ==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.731.0.tgz",
+            "integrity": "sha512-Ngr2Gz0aec/uduoKaO3srN52SYkEHndYtFzkK/gDUyQwQzi4ha2eIisxPiuHEX6RvXT31V9ouqn/YtVkt0R76A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
-                "@aws-sdk/util-endpoints": "3.726.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
+                "@aws-sdk/util-endpoints": "3.731.0",
                 "@smithy/core": "^3.0.0",
                 "@smithy/protocol-http": "^5.0.0",
                 "@smithy/types": "^4.0.0",
@@ -810,13 +701,62 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
-            "integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.731.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.731.1.tgz",
+            "integrity": "sha512-/L8iVrulnXZl+kgmTn+oxRxNnhcSIbf+r12C06vGUq60w0YMidLvxJZN7vt8H9SnCAGCHqud2MS7ExCEvhc0gA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.731.0",
+                "@aws-sdk/middleware-host-header": "3.731.0",
+                "@aws-sdk/middleware-logger": "3.731.0",
+                "@aws-sdk/middleware-recursion-detection": "3.731.0",
+                "@aws-sdk/middleware-user-agent": "3.731.0",
+                "@aws-sdk/region-config-resolver": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
+                "@aws-sdk/util-endpoints": "3.731.0",
+                "@aws-sdk/util-user-agent-browser": "3.731.0",
+                "@aws-sdk/util-user-agent-node": "3.731.0",
+                "@smithy/config-resolver": "^4.0.0",
+                "@smithy/core": "^3.0.0",
+                "@smithy/fetch-http-handler": "^5.0.0",
+                "@smithy/hash-node": "^4.0.0",
+                "@smithy/invalid-dependency": "^4.0.0",
+                "@smithy/middleware-content-length": "^4.0.0",
+                "@smithy/middleware-endpoint": "^4.0.0",
+                "@smithy/middleware-retry": "^4.0.0",
+                "@smithy/middleware-serde": "^4.0.0",
+                "@smithy/middleware-stack": "^4.0.0",
+                "@smithy/node-config-provider": "^4.0.0",
+                "@smithy/node-http-handler": "^4.0.0",
+                "@smithy/protocol-http": "^5.0.0",
+                "@smithy/smithy-client": "^4.0.0",
+                "@smithy/types": "^4.0.0",
+                "@smithy/url-parser": "^4.0.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.0",
+                "@smithy/util-defaults-mode-node": "^4.0.0",
+                "@smithy/util-endpoints": "^3.0.0",
+                "@smithy/util-middleware": "^4.0.0",
+                "@smithy/util-retry": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.731.0.tgz",
+            "integrity": "sha512-XlDpRNkDVHF59f07JmkuAidEv//m3hT6/JL85h0l3+zrpaRWhf8n8lVUyAPNq35ZujK8AcorYM+93u7hdWsliQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/node-config-provider": "^4.0.0",
                 "@smithy/types": "^4.0.0",
                 "@smithy/util-config-provider": "^4.0.0",
@@ -828,13 +768,13 @@
             }
         },
         "node_modules/@aws-sdk/signature-v4-multi-region": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.723.0.tgz",
-            "integrity": "sha512-lJlVAa5Sl589qO8lwMLVUtnlF1Q7I+6k1Iomv2goY9d1bRl4q2N5Pit2qJVr2AMW0sceQXeh23i2a/CKOqVAdg==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.731.0.tgz",
+            "integrity": "sha512-1r/b4Os15dR+BCVRRLVQJMF7Krq6xX6IKHxN43kuvODYWz8Nv3XDlaSpeRpAzyJuzW/fTp4JgE+z0+gmJfdEeA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-sdk-s3": "3.723.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/middleware-sdk-s3": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/protocol-http": "^5.0.0",
                 "@smithy/signature-v4": "^5.0.0",
                 "@smithy/types": "^4.0.0",
@@ -845,12 +785,13 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.723.0.tgz",
-            "integrity": "sha512-hniWi1x4JHVwKElANh9afKIMUhAutHVBRD8zo6usr0PAoj+Waf220+1ULS74GXtLXAPCiNXl5Og+PHA7xT8ElQ==",
+            "version": "3.731.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.731.1.tgz",
+            "integrity": "sha512-t34GOPwBZsX7zGHjiTXmMHGY3kHM7fLiQ60Jqk0On9P0ASHTDE5U75RgCXboE3u+qEv9wyKyaqMNyMWj9qQlFg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/nested-clients": "3.731.1",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/property-provider": "^4.0.0",
                 "@smithy/shared-ini-file-loader": "^4.0.0",
                 "@smithy/types": "^4.0.0",
@@ -858,15 +799,12 @@
             },
             "engines": {
                 "node": ">=18.0.0"
-            },
-            "peerDependencies": {
-                "@aws-sdk/client-sso-oidc": "^3.723.0"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-            "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.731.0.tgz",
+            "integrity": "sha512-NrdkJg6oOUbXR2r9WvHP408CLyvST8cJfp1/jP9pemtjvjPoh6NukbCtiSFdOOb1eryP02CnqQWItfJC1p2Y/Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.0.0",
@@ -889,12 +827,12 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.726.0.tgz",
-            "integrity": "sha512-sLd30ASsPMoPn3XBK50oe/bkpJ4N8Bpb7SbhoxcY3Lk+fSASaWxbbXE81nbvCnkxrZCvkPOiDHzJCp1E2im71A==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.731.0.tgz",
+            "integrity": "sha512-riztxTAfncFS9yQWcBJffGgOgLoKSa63ph+rxWJxKl6BHAmWEvHICj1qDcVmnWfIcvJ5cClclY75l9qKaUH7rQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/types": "^4.0.0",
                 "@smithy/util-endpoints": "^3.0.0",
                 "tslib": "^2.6.2"
@@ -916,25 +854,25 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.723.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
-            "integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.731.0.tgz",
+            "integrity": "sha512-EnYXxTkCNCjTTBjW/pelRPv4Thsi9jepoB6qQjPMA9/ixrZ71BhhQecz9kgqzZLR9BPCwb6hgJ/Yd702jqJ4aQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/types": "^4.0.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.726.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.726.0.tgz",
-            "integrity": "sha512-iEj6KX9o6IQf23oziorveRqyzyclWai95oZHDJtYav3fvLJKStwSjygO4xSF7ycHcTYeCHSLO1FFOHgGVs4Viw==",
+            "version": "3.731.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.731.0.tgz",
+            "integrity": "sha512-Rze78Ym5Bx7aWMvmZE2iL3JPo2INNCC5N9rLVx98Gg1G0ZaxclVRUvJrh1AojNlOFxU+otkxAe7FA3Foy2iLLQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.726.0",
-                "@aws-sdk/types": "3.723.0",
+                "@aws-sdk/middleware-user-agent": "3.731.0",
+                "@aws-sdk/types": "3.731.0",
                 "@smithy/node-config-provider": "^4.0.0",
                 "@smithy/types": "^4.0.0",
                 "tslib": "^2.6.2"
@@ -980,9 +918,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.3",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-            "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+            "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -1020,25 +958,15 @@
                 "url": "https://opencollective.com/babel"
             }
         },
-        "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "devOptional": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@babel/generator": {
-            "version": "7.26.3",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-            "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.5.tgz",
+            "integrity": "sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.26.3",
-                "@babel/types": "^7.26.3",
+                "@babel/parser": "^7.26.5",
+                "@babel/types": "^7.26.5",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^3.0.2"
@@ -1061,13 +989,13 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-            "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+            "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.25.9",
+                "@babel/compat-data": "^7.26.5",
                 "@babel/helper-validator-option": "^7.25.9",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
@@ -1075,16 +1003,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "devOptional": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
@@ -1109,16 +1027,6 @@
                 "@babel/core": "^7.0.0"
             }
         },
-        "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
             "version": "7.26.3",
             "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
@@ -1135,16 +1043,6 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0"
-            }
-        },
-        "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
@@ -1224,9 +1122,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-            "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -1252,15 +1150,15 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-            "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+            "integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-member-expression-to-functions": "^7.25.9",
                 "@babel/helper-optimise-call-expression": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/traverse": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1343,13 +1241,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-            "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
+            "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.3"
+                "@babel/types": "^7.26.5"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1780,13 +1678,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
-            "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+            "integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2210,13 +2108,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
-            "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
+            "version": "7.26.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+            "integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.26.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2658,16 +2556,6 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@babel/preset-env/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@babel/preset-modules": {
             "version": "0.1.6-no-external-plugins",
             "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
@@ -2712,17 +2600,17 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.26.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-            "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.5.tgz",
+            "integrity": "sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.26.3",
-                "@babel/parser": "^7.26.3",
+                "@babel/generator": "^7.26.5",
+                "@babel/parser": "^7.26.5",
                 "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.3",
+                "@babel/types": "^7.26.5",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -2741,9 +2629,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.3",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-            "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+            "version": "7.26.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
+            "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -2801,12 +2689,12 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
-            "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
+            "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.4",
+                "@eslint/object-schema": "^2.1.5",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
@@ -2818,6 +2706,7 @@
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
             "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
@@ -2886,14 +2775,15 @@
             "version": "9.18.0",
             "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.18.0.tgz",
             "integrity": "sha512-fK6L7rxcq6/z+AaQMtiFTkvbHkBLNlwyRxHpKawP0x3u9+NC6MQTnFW+AdpwC6gfHTW0051cokQgtTN2FqlxQA==",
+            "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
-            "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
+            "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
             "license": "Apache-2.0",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2903,6 +2793,7 @@
             "version": "0.2.5",
             "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
             "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@eslint/core": "^0.10.0",
                 "levn": "^0.4.1"
@@ -3395,9 +3286,9 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+            "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -3555,12 +3446,6 @@
             "peerDependencies": {
                 "rollup": "^1.20.0||^2.0.0"
             }
-        },
-        "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
-            "version": "0.0.39",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-            "license": "MIT"
         },
         "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
             "version": "1.0.1",
@@ -3904,19 +3789,6 @@
             },
             "engines": {
                 "node": ">=18.0.0"
-            }
-        },
-        "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@smithy/middleware-serde": {
@@ -4841,6 +4713,15 @@
             "integrity": "sha512-Pb6M8TDO9DtSVla9yXSTAxmo9GVEouq5P40DWXdOie69bXogZTkgvopCq+yEvTMA0F6PEvdJmbtTV3ccIp11VQ==",
             "license": "Apache-2.0"
         },
+        "node_modules/@swc/helpers": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+            "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.8.0"
+            }
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4886,6 +4767,18 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/command-line-args": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+            "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/command-line-usage": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+            "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+            "license": "MIT"
+        },
         "node_modules/@types/es-aggregate-error": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/es-aggregate-error/-/es-aggregate-error-1.0.6.tgz",
@@ -4896,9 +4789,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "version": "0.0.39",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
             "license": "MIT"
         },
         "node_modules/@types/graceful-fs": {
@@ -4951,9 +4844,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.10.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-            "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+            "version": "22.10.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.7.tgz",
+            "integrity": "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.20.0"
@@ -4996,13 +4889,13 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.17.0.tgz",
-            "integrity": "sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.21.0.tgz",
+            "integrity": "sha512-G3IBKz0/0IPfdeGRMbp+4rbjfSSdnGkXsM/pFZA8zM9t9klXDnB/YnKOBQ0GoPmoROa4bCq2NeHgJa5ydsQ4mA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.17.0",
-                "@typescript-eslint/visitor-keys": "8.17.0"
+                "@typescript-eslint/types": "8.21.0",
+                "@typescript-eslint/visitor-keys": "8.21.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5013,9 +4906,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.17.0.tgz",
-            "integrity": "sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.21.0.tgz",
+            "integrity": "sha512-PAL6LUuQwotLW2a8VsySDBwYMm129vFm4tMVlylzdoTybTHaAi0oBp7Ac6LhSrHHOdLM3efH+nAR6hAWoMF89A==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5026,19 +4919,19 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.17.0.tgz",
-            "integrity": "sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==",
-            "license": "BSD-2-Clause",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.21.0.tgz",
+            "integrity": "sha512-x+aeKh/AjAArSauz0GiQZsjT8ciadNMHdkUSwBB9Z6PrKc/4knM4g3UfHml6oDJmKC88a6//cdxnO/+P2LkMcg==",
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.17.0",
-                "@typescript-eslint/visitor-keys": "8.17.0",
+                "@typescript-eslint/types": "8.21.0",
+                "@typescript-eslint/visitor-keys": "8.21.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
                 "minimatch": "^9.0.4",
                 "semver": "^7.6.0",
-                "ts-api-utils": "^1.3.0"
+                "ts-api-utils": "^2.0.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5047,10 +4940,8 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.8.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -5063,16 +4954,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
-                "micromatch": "^4.0.4"
+                "micromatch": "^4.0.8"
             },
             "engines": {
                 "node": ">=8.6.0"
@@ -5105,16 +4996,28 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.17.0.tgz",
-            "integrity": "sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.21.0.tgz",
+            "integrity": "sha512-xcXBfcq0Kaxgj7dwejMbFyq7IOHgpNMtVuDveK7w3ZGwG9owKzhALVwKpTF2yrZmEwl9SWdetf3fxNzJQaVuxw==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.17.0",
-                "@typescript-eslint/types": "8.17.0",
-                "@typescript-eslint/typescript-estree": "8.17.0"
+                "@typescript-eslint/scope-manager": "8.21.0",
+                "@typescript-eslint/types": "8.21.0",
+                "@typescript-eslint/typescript-estree": "8.21.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5124,21 +5027,17 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.8.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.17.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.17.0.tgz",
-            "integrity": "sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.21.0.tgz",
+            "integrity": "sha512-BkLMNpdV6prozk8LlyK/SOoWLmUFi+ZD+pcqti9ILCbVvHGk1ui1g4jJOc2WDLaeExz2qWwojxlPce5PljcT3w==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.17.0",
+                "@typescript-eslint/types": "8.21.0",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -5292,20 +5191,64 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/apache-arrow": {
+            "version": "19.0.0",
+            "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-19.0.0.tgz",
+            "integrity": "sha512-xifuq9x7tYriK64p7xwtpe9JFBxiQxs0OXBnKv36OwQmkjpNhZN7aKXFa0mV5vaOxf0uKHmjlnxUNw/2fl5FRw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/helpers": "^0.5.11",
+                "@types/command-line-args": "^5.2.3",
+                "@types/command-line-usage": "^5.0.4",
+                "@types/node": "^20.13.0",
+                "command-line-args": "^6.0.1",
+                "command-line-usage": "^7.0.1",
+                "flatbuffers": "^24.3.25",
+                "json-bignum": "^0.0.3",
+                "tslib": "^2.6.2"
+            },
+            "bin": {
+                "arrow2csv": "bin/arrow2csv.js"
+            }
+        },
+        "node_modules/apache-arrow/node_modules/@types/node": {
+            "version": "20.17.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.14.tgz",
+            "integrity": "sha512-w6qdYetNL5KRBiSClK/KWai+2IMEJuAj+EujKCumalFOwXtvOXaEan9AuwcRID2IcOIAWSIfR495hBtgKlx2zg==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.19.2"
+            }
+        },
+        "node_modules/apache-arrow/node_modules/undici-types": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "license": "MIT"
+        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "license": "Python-2.0"
         },
+        "node_modules/array-back": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+            "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.17"
+            }
+        },
         "node_modules/array-buffer-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
-            "integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.5",
-                "is-array-buffer": "^3.0.4"
+                "call-bound": "^1.0.3",
+                "is-array-buffer": "^3.0.5"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5315,19 +5258,18 @@
             }
         },
         "node_modules/arraybuffer.prototype.slice": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
-            "integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+            "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
             "license": "MIT",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
-                "call-bind": "^1.0.5",
+                "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.22.3",
-                "es-errors": "^1.2.1",
-                "get-intrinsic": "^1.2.3",
-                "is-array-buffer": "^3.0.4",
-                "is-shared-array-buffer": "^1.0.2"
+                "es-abstract": "^1.23.5",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "is-array-buffer": "^3.0.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5443,16 +5385,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/babel-plugin-istanbul/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "devOptional": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/babel-plugin-jest-hoist": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
@@ -5482,16 +5414,6 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-            }
-        },
-        "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
@@ -5600,9 +5522,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-            "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "devOptional": true,
             "funding": [
                 {
@@ -5620,9 +5542,9 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001669",
-                "electron-to-chromium": "^1.5.41",
-                "node-releases": "^2.0.18",
+                "caniuse-lite": "^1.0.30001688",
+                "electron-to-chromium": "^1.5.73",
+                "node-releases": "^2.0.19",
                 "update-browserslist-db": "^1.1.1"
             },
             "bin": {
@@ -5674,9 +5596,9 @@
             }
         },
         "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.0.tgz",
-            "integrity": "sha512-CCKAP2tkPau7D3GE8+V8R6sQubA9R5foIzGp+85EXCVSCivuxBNAWqcpn72PKYiIcqoViv/kcUDpaEIMBVi1lQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+            "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -5684,6 +5606,22 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/call-me-maybe": {
@@ -5712,9 +5650,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001687",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-            "integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+            "version": "1.0.30001695",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+            "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
             "devOptional": true,
             "funding": [
                 {
@@ -5746,6 +5684,21 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk-template": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+            "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk-template?sponsor=1"
             }
         },
         "node_modules/char-regex": {
@@ -5837,6 +5790,44 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "license": "MIT"
         },
+        "node_modules/command-line-args": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+            "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
+            "license": "MIT",
+            "dependencies": {
+                "array-back": "^6.2.2",
+                "find-replace": "^5.0.2",
+                "lodash.camelcase": "^4.3.0",
+                "typical": "^7.2.0"
+            },
+            "engines": {
+                "node": ">=12.20"
+            },
+            "peerDependencies": {
+                "@75lb/nature": "latest"
+            },
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/command-line-usage": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
+            "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
+            "license": "MIT",
+            "dependencies": {
+                "array-back": "^6.2.2",
+                "chalk-template": "^0.4.0",
+                "table-layout": "^4.1.0",
+                "typical": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
         "node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -5884,13 +5875,13 @@
             "license": "MIT"
         },
         "node_modules/core-js-compat": {
-            "version": "3.39.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
-            "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
+            "version": "3.40.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
+            "integrity": "sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "browserslist": "^4.24.2"
+                "browserslist": "^4.24.3"
             },
             "funding": {
                 "type": "opencollective",
@@ -5940,14 +5931,14 @@
             "license": "MIT"
         },
         "node_modules/data-view-buffer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
-            "integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+            "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.6",
+                "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
+                "is-data-view": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5957,29 +5948,29 @@
             }
         },
         "node_modules/data-view-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
-            "integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+            "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
-                "is-data-view": "^1.0.1"
+                "is-data-view": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
             },
             "funding": {
-                "url": "https://github.com/sponsors/ljharb"
+                "url": "https://github.com/sponsors/inspect-js"
             }
         },
         "node_modules/data-view-byte-offset": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
-            "integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+            "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.6",
+                "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
                 "is-data-view": "^1.0.1"
             },
@@ -5991,9 +5982,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -6113,10 +6104,24 @@
                 "url": "https://dotenvx.com"
             }
         },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.71",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.71.tgz",
-            "integrity": "sha512-dB68l59BI75W1BUGVTAEJy45CEVuEGy9qPVVQ8pnHyHMn36PLPPoE1mjLH+lo9rKulO3HC2OhbACI/8tCqJBcA==",
+            "version": "1.5.83",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
+            "integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
             "devOptional": true,
             "license": "ISC"
         },
@@ -6150,57 +6155,62 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.23.5",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.5.tgz",
-            "integrity": "sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==",
+            "version": "1.23.9",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+            "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
             "license": "MIT",
             "dependencies": {
-                "array-buffer-byte-length": "^1.0.1",
-                "arraybuffer.prototype.slice": "^1.0.3",
+                "array-buffer-byte-length": "^1.0.2",
+                "arraybuffer.prototype.slice": "^1.0.4",
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
-                "data-view-buffer": "^1.0.1",
-                "data-view-byte-length": "^1.0.1",
-                "data-view-byte-offset": "^1.0.0",
-                "es-define-property": "^1.0.0",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "data-view-buffer": "^1.0.2",
+                "data-view-byte-length": "^1.0.2",
+                "data-view-byte-offset": "^1.0.1",
+                "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
                 "es-object-atoms": "^1.0.0",
-                "es-set-tostringtag": "^2.0.3",
-                "es-to-primitive": "^1.2.1",
-                "function.prototype.name": "^1.1.6",
-                "get-intrinsic": "^1.2.4",
-                "get-symbol-description": "^1.0.2",
+                "es-set-tostringtag": "^2.1.0",
+                "es-to-primitive": "^1.3.0",
+                "function.prototype.name": "^1.1.8",
+                "get-intrinsic": "^1.2.7",
+                "get-proto": "^1.0.0",
+                "get-symbol-description": "^1.1.0",
                 "globalthis": "^1.0.4",
-                "gopd": "^1.0.1",
+                "gopd": "^1.2.0",
                 "has-property-descriptors": "^1.0.2",
-                "has-proto": "^1.0.3",
-                "has-symbols": "^1.0.3",
+                "has-proto": "^1.2.0",
+                "has-symbols": "^1.1.0",
                 "hasown": "^2.0.2",
-                "internal-slot": "^1.0.7",
-                "is-array-buffer": "^3.0.4",
+                "internal-slot": "^1.1.0",
+                "is-array-buffer": "^3.0.5",
                 "is-callable": "^1.2.7",
-                "is-data-view": "^1.0.1",
-                "is-negative-zero": "^2.0.3",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.3",
-                "is-string": "^1.0.7",
-                "is-typed-array": "^1.1.13",
-                "is-weakref": "^1.0.2",
+                "is-data-view": "^1.0.2",
+                "is-regex": "^1.2.1",
+                "is-shared-array-buffer": "^1.0.4",
+                "is-string": "^1.1.1",
+                "is-typed-array": "^1.1.15",
+                "is-weakref": "^1.1.0",
+                "math-intrinsics": "^1.1.0",
                 "object-inspect": "^1.13.3",
                 "object-keys": "^1.1.1",
-                "object.assign": "^4.1.5",
+                "object.assign": "^4.1.7",
+                "own-keys": "^1.0.1",
                 "regexp.prototype.flags": "^1.5.3",
-                "safe-array-concat": "^1.1.2",
-                "safe-regex-test": "^1.0.3",
-                "string.prototype.trim": "^1.2.9",
-                "string.prototype.trimend": "^1.0.8",
+                "safe-array-concat": "^1.1.3",
+                "safe-push-apply": "^1.0.0",
+                "safe-regex-test": "^1.1.0",
+                "set-proto": "^1.0.0",
+                "string.prototype.trim": "^1.2.10",
+                "string.prototype.trimend": "^1.0.9",
                 "string.prototype.trimstart": "^1.0.8",
-                "typed-array-buffer": "^1.0.2",
-                "typed-array-byte-length": "^1.0.1",
-                "typed-array-byte-offset": "^1.0.2",
-                "typed-array-length": "^1.0.6",
-                "unbox-primitive": "^1.0.2",
-                "which-typed-array": "^1.1.15"
+                "typed-array-buffer": "^1.0.3",
+                "typed-array-byte-length": "^1.0.3",
+                "typed-array-byte-offset": "^1.0.4",
+                "typed-array-length": "^1.0.7",
+                "unbox-primitive": "^1.1.0",
+                "which-typed-array": "^1.1.18"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6232,13 +6242,10 @@
             }
         },
         "node_modules/es-define-property": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "license": "MIT",
-            "dependencies": {
-                "get-intrinsic": "^1.2.4"
-            },
             "engines": {
                 "node": ">= 0.4"
             }
@@ -6253,9 +6260,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-            "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -6265,14 +6272,15 @@
             }
         },
         "node_modules/es-set-tostringtag": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
-            "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "license": "MIT",
             "dependencies": {
-                "get-intrinsic": "^1.2.4",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
                 "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.1"
+                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6326,6 +6334,7 @@
             "version": "9.18.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.18.0.tgz",
             "integrity": "sha512-+waTfRWQlSbpt3KWE+CjrPPYnbq9kfZIYUqapc0uBXyjTp8aYXZDsUH16m39Ryq3NjAVP4tjuF7KaukeqoCoaA==",
+            "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -6381,9 +6390,10 @@
             }
         },
         "node_modules/eslint-plugin-jest": {
-            "version": "28.10.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.10.0.tgz",
-            "integrity": "sha512-hyMWUxkBH99HpXT3p8hc7REbEZK3D+nk8vHXGgpB+XXsi0gO4PxMSP+pjfUzb67GnV9yawV9a53eUmcde1CCZA==",
+            "version": "28.11.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
+            "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
+            "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
             },
@@ -6444,6 +6454,12 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/eslint/node_modules/@types/estree": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "license": "MIT"
         },
         "node_modules/eslint/node_modules/ajv": {
             "version": "6.12.6",
@@ -6664,9 +6680,19 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-            "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
+            "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
             "license": "BSD-3-Clause"
         },
         "node_modules/fast-xml-parser": {
@@ -6692,9 +6718,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.17.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
+            "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -6743,6 +6769,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/find-replace": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+            "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "@75lb/nature": "latest"
+            },
+            "peerDependenciesMeta": {
+                "@75lb/nature": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -6771,6 +6814,12 @@
             "engines": {
                 "node": ">=16"
             }
+        },
+        "node_modules/flatbuffers": {
+            "version": "24.12.23",
+            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+            "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+            "license": "Apache-2.0"
         },
         "node_modules/flatted": {
             "version": "3.3.2",
@@ -6837,15 +6886,17 @@
             }
         },
         "node_modules/function.prototype.name": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-            "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.2.0",
-                "es-abstract": "^1.22.1",
-                "functions-have-names": "^1.2.3"
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "functions-have-names": "^1.2.3",
+                "hasown": "^2.0.2",
+                "is-callable": "^1.2.7"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6883,16 +6934,21 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+            "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
             "license": "MIT",
             "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
                 "function-bind": "^1.1.2",
-                "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3",
-                "hasown": "^2.0.0"
+                "get-proto": "^1.0.0",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6909,6 +6965,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/get-source": {
@@ -6935,14 +7004,14 @@
             }
         },
         "node_modules/get-symbol-description": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
-            "integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+            "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.5",
+                "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4"
+                "get-intrinsic": "^1.2.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6989,6 +7058,7 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-15.14.0.tgz",
             "integrity": "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -7040,10 +7110,13 @@
             }
         },
         "node_modules/has-bigints": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-            "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
             "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -7070,12 +7143,12 @@
             }
         },
         "node_modules/has-proto": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.1.0.tgz",
-            "integrity": "sha512-QLdzI9IIO1Jg7f9GT1gXpPpXArAn6cS31R1eEZqz08Gc+uQ8/XiqHWt17Fiw+2p6oTTIq5GXEpQkAlA88YRl/Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+            "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7"
+                "dunder-proto": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7255,27 +7328,28 @@
             "license": "ISC"
         },
         "node_modules/internal-slot": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
-            "integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "hasown": "^2.0.0",
-                "side-channel": "^1.0.4"
+                "hasown": "^2.0.2",
+                "side-channel": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/is-array-buffer": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
-            "integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.2.1"
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7292,12 +7366,15 @@
             "license": "MIT"
         },
         "node_modules/is-async-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-            "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
+            "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
             "license": "MIT",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.3",
+                "get-proto": "^1.0.1",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7322,12 +7399,12 @@
             }
         },
         "node_modules/is-boolean-object": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.0.tgz",
-            "integrity": "sha512-kR5g0+dXf/+kXnqI+lu0URKYPKgICtHGGNCDSB10AaUFj3o/HkB3u7WfpRBJGFopxxY0oH3ux7ZsDjLtK7xqvw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+            "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bound": "^1.0.2",
                 "has-tostringtag": "^1.0.2"
             },
             "engines": {
@@ -7350,9 +7427,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.15.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-            "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
             "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
@@ -7365,11 +7442,13 @@
             }
         },
         "node_modules/is-data-view": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
-            "integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+            "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
             "license": "MIT",
             "dependencies": {
+                "call-bound": "^1.0.2",
+                "get-intrinsic": "^1.2.6",
                 "is-typed-array": "^1.1.13"
             },
             "engines": {
@@ -7380,12 +7459,13 @@
             }
         },
         "node_modules/is-date-object": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
             "license": "MIT",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7404,12 +7484,12 @@
             }
         },
         "node_modules/is-finalizationregistry": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.0.tgz",
-            "integrity": "sha512-qfMdqbAQEwBw78ZyReKnlA8ezmPdb9BemzIIip/JkjaZUhitfXDkkr+3QTboW0JrSXT1QWyYShpvnNHGZ4c4yA==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+            "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7"
+                "call-bound": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7438,12 +7518,15 @@
             }
         },
         "node_modules/is-generator-function": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+            "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
             "license": "MIT",
             "dependencies": {
-                "has-tostringtag": "^1.0.0"
+                "call-bound": "^1.0.3",
+                "get-proto": "^1.0.0",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7476,18 +7559,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-negative-zero": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -7498,12 +7569,12 @@
             }
         },
         "node_modules/is-number-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.0.tgz",
-            "integrity": "sha512-KVSZV0Dunv9DTPkhXwcZ3Q+tUc9TsaE1ZwX5J2WMvsSGS6Md8TFPun5uwh0yRdrNerI6vf/tbJxqSx4c1ZI1Lw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bound": "^1.0.3",
                 "has-tostringtag": "^1.0.2"
             },
             "engines": {
@@ -7523,13 +7594,13 @@
             }
         },
         "node_modules/is-regex": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.0.tgz",
-            "integrity": "sha512-B6ohK4ZmoftlUe+uvenXSbPJFo6U37BH7oO1B3nQH8f/7h27N56s85MhUtbFJAziz5dcmuR3i8ovUl35zp8pFA==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "gopd": "^1.1.0",
+                "call-bound": "^1.0.2",
+                "gopd": "^1.2.0",
                 "has-tostringtag": "^1.0.2",
                 "hasown": "^2.0.2"
             },
@@ -7553,12 +7624,12 @@
             }
         },
         "node_modules/is-shared-array-buffer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
-            "integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7"
+                "call-bound": "^1.0.3"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7581,12 +7652,12 @@
             }
         },
         "node_modules/is-string": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.0.tgz",
-            "integrity": "sha512-PlfzajuF9vSo5wErv3MJAKD/nqf9ngAs1NFQYm16nUYFO2IzxJ2hcm+IOCg+EEopdykNNUhVq5cz35cAUxU8+g==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bound": "^1.0.3",
                 "has-tostringtag": "^1.0.2"
             },
             "engines": {
@@ -7597,14 +7668,14 @@
             }
         },
         "node_modules/is-symbol": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.0.tgz",
-            "integrity": "sha512-qS8KkNNXUZ/I+nX6QT8ZS1/Yx0A444yhzdTKxCzKkNjQ9sHErBxJnJAgh+f5YhusYECEcjo4XcyH87hn6+ks0A==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "has-symbols": "^1.0.3",
-                "safe-regex-test": "^1.0.3"
+                "call-bound": "^1.0.2",
+                "has-symbols": "^1.1.0",
+                "safe-regex-test": "^1.1.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7614,12 +7685,12 @@
             }
         },
         "node_modules/is-typed-array": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-            "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "license": "MIT",
             "dependencies": {
-                "which-typed-array": "^1.1.14"
+                "which-typed-array": "^1.1.16"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7641,25 +7712,28 @@
             }
         },
         "node_modules/is-weakref": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+            "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2"
+                "call-bound": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-weakset": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.3.tgz",
-            "integrity": "sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "get-intrinsic": "^1.2.4"
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7702,6 +7776,19 @@
                 "@istanbuljs/schema": "^0.1.3",
                 "istanbul-lib-coverage": "^3.2.0",
                 "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-instrument/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "devOptional": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             },
             "engines": {
                 "node": ">=10"
@@ -8233,6 +8320,19 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-snapshot/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "devOptional": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/jest-util": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -8363,9 +8463,9 @@
             }
         },
         "node_modules/jsesc": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "devOptional": true,
             "license": "MIT",
             "bin": {
@@ -8373,6 +8473,14 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/json-bignum": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+            "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/json-buffer": {
@@ -8568,6 +8676,12 @@
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "license": "MIT"
         },
+        "node_modules/lodash.camelcase": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+            "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+            "license": "MIT"
+        },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -8622,6 +8736,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/make-dir/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "devOptional": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/makeerror": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -8637,6 +8764,15 @@
             "resolved": "https://registry.npmjs.org/markdown-escape/-/markdown-escape-2.0.0.tgz",
             "integrity": "sha512-Trz4v0+XWlwy68LJIyw3bLbsJiC8XAbRCKF9DbEtZjyndKOGVx6n+wNB0VfoRmY2LKboQLeniap3xrb6LGSJ8A==",
             "license": "MIT"
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -8808,9 +8944,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -8971,14 +9107,16 @@
             }
         },
         "node_modules/object.assign": {
-            "version": "4.1.5",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-            "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.5",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
                 "define-properties": "^1.2.1",
-                "has-symbols": "^1.0.3",
+                "es-object-atoms": "^1.0.0",
+                "has-symbols": "^1.1.0",
                 "object-keys": "^1.1.1"
             },
             "engines": {
@@ -9075,6 +9213,23 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/own-keys": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.2.6",
+                "object-keys": "^1.1.1",
+                "safe-push-apply": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/p-limit": {
@@ -9325,6 +9480,27 @@
                 "node": ">=10"
             }
         },
+        "node_modules/postman-collection/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/postman-collection/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/postman-url-encoder": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-3.0.5.tgz",
@@ -9464,18 +9640,19 @@
             "license": "MIT"
         },
         "node_modules/reflect.getprototypeof": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.7.tgz",
-            "integrity": "sha512-bMvFGIUKlc/eSfXNX+aZ+EL95/EgZzuwA0OBPTbZZDEJw/0AkentjMuM1oiRfwHrshqk4RzdgiTg5CcDalXN5g==",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+            "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.5",
+                "es-abstract": "^1.23.9",
                 "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "which-builtin-type": "^1.1.4"
+                "es-object-atoms": "^1.0.0",
+                "get-intrinsic": "^1.2.7",
+                "get-proto": "^1.0.1",
+                "which-builtin-type": "^1.2.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9531,14 +9708,16 @@
             }
         },
         "node_modules/regexp.prototype.flags": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
-            "integrity": "sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
                 "define-properties": "^1.2.1",
                 "es-errors": "^1.3.0",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
                 "set-function-name": "^2.0.2"
             },
             "engines": {
@@ -9586,6 +9765,19 @@
                 "regjsparser": "bin/parser"
             }
         },
+        "node_modules/regjsparser/node_modules/jsesc": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "jsesc": "bin/jsesc"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9613,17 +9805,20 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.8",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+            "version": "1.22.10",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.13.0",
+                "is-core-module": "^2.16.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
             "bin": {
                 "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9720,14 +9915,15 @@
             }
         },
         "node_modules/safe-array-concat": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
-            "integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+            "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
-                "get-intrinsic": "^1.2.4",
-                "has-symbols": "^1.0.3",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
+                "get-intrinsic": "^1.2.6",
+                "has-symbols": "^1.1.0",
                 "isarray": "^2.0.5"
             },
             "engines": {
@@ -9737,15 +9933,31 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/safe-regex-test": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
-            "integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+        "node_modules/safe-push-apply": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+            "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.6",
                 "es-errors": "^1.3.0",
-                "is-regex": "^1.1.4"
+                "isarray": "^2.0.5"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-regex": "^1.2.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9767,15 +9979,13 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "devOptional": true,
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/set-function-length": {
@@ -9805,6 +10015,20 @@
                 "es-errors": "^1.3.0",
                 "functions-have-names": "^1.2.3",
                 "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/set-proto": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+            "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9886,15 +10110,69 @@
             "license": "MIT"
         },
         "node_modules/side-channel": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
                 "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.4",
-                "object-inspect": "^1.13.1"
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10035,15 +10313,18 @@
             }
         },
         "node_modules/string.prototype.trim": {
-            "version": "1.2.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
-            "integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+            "version": "1.2.10",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+            "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
+                "define-data-property": "^1.1.4",
                 "define-properties": "^1.2.1",
-                "es-abstract": "^1.23.0",
-                "es-object-atoms": "^1.0.0"
+                "es-abstract": "^1.23.5",
+                "es-object-atoms": "^1.0.0",
+                "has-property-descriptors": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10053,14 +10334,18 @@
             }
         },
         "node_modules/string.prototype.trimend": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
-            "integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+            "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
                 "define-properties": "^1.2.1",
                 "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -10184,6 +10469,19 @@
                 "url": "https://github.com/Mermade/oas-kit?sponsor=1"
             }
         },
+        "node_modules/table-layout": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+            "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+            "license": "MIT",
+            "dependencies": {
+                "array-back": "^6.2.2",
+                "wordwrapjs": "^5.1.0"
+            },
+            "engines": {
+                "node": ">=12.17"
+            }
+        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -10231,15 +10529,15 @@
             "license": "MIT"
         },
         "node_modules/ts-api-utils": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.0.tgz",
+            "integrity": "sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==",
             "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=18.12"
             },
             "peerDependencies": {
-                "typescript": ">=4.2.0"
+                "typescript": ">=4.8.4"
             }
         },
         "node_modules/tslib": {
@@ -10284,30 +10582,30 @@
             }
         },
         "node_modules/typed-array-buffer": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-            "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bound": "^1.0.3",
                 "es-errors": "^1.3.0",
-                "is-typed-array": "^1.1.13"
+                "is-typed-array": "^1.1.14"
             },
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/typed-array-byte-length": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
-            "integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+            "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
                 "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13"
+                "gopd": "^1.2.0",
+                "has-proto": "^1.2.0",
+                "is-typed-array": "^1.1.14"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10317,18 +10615,18 @@
             }
         },
         "node_modules/typed-array-byte-offset": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.3.tgz",
-            "integrity": "sha512-GsvTyUHTriq6o/bHcTd0vM7OQ9JEdlvluu9YISaA7+KzDzPaIzEeDFNkTfhdE3MYcNhNi0vq/LlegYgIs5yPAw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+            "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
                 "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
-                "has-proto": "^1.0.3",
-                "is-typed-array": "^1.1.13",
-                "reflect.getprototypeof": "^1.0.6"
+                "gopd": "^1.2.0",
+                "has-proto": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "reflect.getprototypeof": "^1.0.9"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10358,9 +10656,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
@@ -10371,16 +10669,28 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/typical": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+            "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.17"
+            }
+        },
         "node_modules/unbox-primitive": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-            "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+            "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.2",
+                "call-bound": "^1.0.3",
                 "has-bigints": "^1.0.2",
-                "has-symbols": "^1.0.3",
-                "which-boxed-primitive": "^1.0.2"
+                "has-symbols": "^1.1.0",
+                "which-boxed-primitive": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -10446,9 +10756,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-            "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+            "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
             "devOptional": true,
             "funding": [
                 {
@@ -10467,7 +10777,7 @@
             "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
-                "picocolors": "^1.1.0"
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -10501,9 +10811,13 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
                 "uuid": "dist/bin/uuid"
@@ -10608,16 +10922,16 @@
             }
         },
         "node_modules/which-boxed-primitive": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.0.tgz",
-            "integrity": "sha512-Ei7Miu/AXe2JJ4iNF5j/UphAgRoma4trE6PtisM09bPygb3egMH3YLW/befsWb1A1AxvNSFidOFTB18XtnIIng==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
             "license": "MIT",
             "dependencies": {
                 "is-bigint": "^1.1.0",
-                "is-boolean-object": "^1.2.0",
-                "is-number-object": "^1.1.0",
-                "is-string": "^1.1.0",
-                "is-symbol": "^1.1.0"
+                "is-boolean-object": "^1.2.1",
+                "is-number-object": "^1.1.1",
+                "is-string": "^1.1.1",
+                "is-symbol": "^1.1.1"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10627,24 +10941,24 @@
             }
         },
         "node_modules/which-builtin-type": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.0.tgz",
-            "integrity": "sha512-I+qLGQ/vucCby4tf5HsLmGueEla4ZhwTBSqaooS+Y0BuxN4Cp+okmGuV+8mXZ84KDI9BA+oklo+RzKg0ONdSUA==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+            "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
             "license": "MIT",
             "dependencies": {
-                "call-bind": "^1.0.7",
+                "call-bound": "^1.0.2",
                 "function.prototype.name": "^1.1.6",
                 "has-tostringtag": "^1.0.2",
                 "is-async-function": "^2.0.0",
-                "is-date-object": "^1.0.5",
+                "is-date-object": "^1.1.0",
                 "is-finalizationregistry": "^1.1.0",
                 "is-generator-function": "^1.0.10",
-                "is-regex": "^1.1.4",
+                "is-regex": "^1.2.1",
                 "is-weakref": "^1.0.2",
                 "isarray": "^2.0.5",
-                "which-boxed-primitive": "^1.0.2",
+                "which-boxed-primitive": "^1.1.0",
                 "which-collection": "^1.0.2",
-                "which-typed-array": "^1.1.15"
+                "which-typed-array": "^1.1.16"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -10672,15 +10986,16 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.16.tgz",
-            "integrity": "sha512-g+N+GAWiRj66DngFwHvISJd+ITsyphZvD1vChfVg6cEdnzy53GzB3oy0fUNlvhz7H7+MiqhYr26qxQShCpKTTQ==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+            "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
                 "for-each": "^0.3.3",
-                "gopd": "^1.0.1",
+                "gopd": "^1.2.0",
                 "has-tostringtag": "^1.0.2"
             },
             "engines": {
@@ -10697,6 +11012,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/wordwrapjs": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+            "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.17"
             }
         },
         "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@stoplight/spectral-functions": "^1.9.3",
         "@stoplight/spectral-ref-resolver": "^1.0.5",
         "@stoplight/spectral-ruleset-bundler": "^1.6.1",
+        "apache-arrow": "^19.0.0",
         "dotenv": "^16.4.7",
         "eslint-plugin-jest": "^28.10.0",
         "openapi-to-postmanv2": "4.24.0"


### PR DESCRIPTION
## Proposed changes

Updating `dataDump.js` to use parquet instead of json for the exported data (ends up being about 1/3 of the file size 🎉)

Testing:

- Pushed to staging S3 from running locally

_Jira ticket:_ [CLOUDP-295790](https://jira.mongodb.org/browse/CLOUDP-295790)