### PR TITLE
CLOUDP-290416: Add workflow for releasing IPA metrics

### DIFF
--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run Metric Collection Job
         if: ${{steps.get_previous_status.outputs.result == 'true' }}
         working-directory: ./tools/spectral/ipa/metrics/scripts
-        run: node ./tools/spectral/ipa/metrics/scripts/runMetricCollection.js ../../../../../openapi-foas.json
+        run: node runMetricCollection.js ../../../../../openapi-foas.json
 
       - name: Dump Metric Collection Job Data to S3
         if: ${{steps.get_previous_status.outputs.result == 'true' }}

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -1,0 +1,74 @@
+name: IPA Validation Metrics Release
+on:
+  workflow_call:
+    secrets: # all secrets are passed explicitly in this workflow
+#      aws_access_key:
+#        required: true
+#      aws_secret_key:
+#        required: true
+#      aws_s3_bucket_prefix:
+#        required: true
+      api_bot_pat:
+        required: true
+#    inputs:
+#      env:
+#        description: 'Environment for the FOAS to use for IPA metrics collection'
+#        required: true
+#        type: string
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  release-IPA-metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get Previous Run Date and Status
+        id: get_previous_status
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.api_bot_pat }}
+          script: |
+            const script = require('tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js')
+            const shouldRunRelease = await getShouldRunMetricsRelease({github, context})
+            return shouldRunRelease
+
+      - name: Skip Metric Collection Job
+        if: ${{steps.get_previous_status.outputs.result == 'false' }}
+        run: echo "Skipping IPA metrics release!"
+
+      - name: Setup Node
+        if: ${{steps.get_previous_status.outputs.result == 'true' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        if: ${{steps.get_previous_status.outputs.result == 'true' }}
+        run: npm install
+
+      - name: Download openapi-foas
+        if: ${{steps.get_previous_status.outputs.result == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: openapi-foas-dev  # TODO: Change to passed input env
+          github-token: ${{ secrets.api_bot_pat }}
+          run-id: ${{ github.run_id }}
+
+      - name: Run Metric Collection Job
+        if: ${{steps.get_previous_status.outputs.result == 'true' }}
+        working-directory: ./tools/spectral/ipa/metrics/scripts
+        run: node ./tools/spectral/ipa/metrics/scripts/runMetricCollection.js ../../../../../openapi-foas.json
+
+      - name: Dump Metric Collection Job Data to S3
+        if: ${{steps.get_previous_status.outputs.result == 'true' }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}       # TODO: Change to passed secret
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}   # TODO: Change to passed secret
+          S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}          # TODO: Change to passed secret
+        run: node ./tools/spectral/ipa/metrics/scripts/dataDump.js openapi-foas.json

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -77,4 +77,5 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}       # TODO: Change to passed secret
           AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}   # TODO: Change to passed secret
           S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}          # TODO: Change to passed secret
-        run: node ./tools/spectral/ipa/metrics/scripts/dataDump.js openapi-foas.json
+        working-directory: ./tools/spectral/ipa/metrics/scripts
+        run: node dataDump.js ../../../../../openapi-foas.json

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -10,6 +10,12 @@ on:
 #        required: true
       api_bot_pat:
         required: true
+      IPA_S3_BUCKET_DW_STAGING_USERNAME:
+        required: true
+      IPA_S3_BUCKET_DW_STAGING_PASSWORD:
+        required: true
+      IPA_S3_BUCKET_DW_STAGING_PREFIX:
+        required: true
 #    inputs:
 #      env:
 #        description: 'Environment for the FOAS to use for IPA metrics collection'
@@ -29,7 +35,7 @@ jobs:
 
       - name: Get Previous Run Date and Status
         id: get_previous_status
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.api_bot_pat }}
           script: |

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -1,0 +1,31 @@
+// Used in .github/workflows/release-IPA-metrics.yml
+export default async function getShouldRunMetricsRelease({ github, context }) {
+  const response = await github.actions.listWorkflowRuns({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    workflow_id: context.workflow,
+    per_page: 2,
+    page: 1,
+  });
+
+  if (response === undefined) {
+    return true;
+  }
+
+  const { data: runs } = response;
+
+  if (runs === undefined || runs.length === 0) {
+    return true;
+  }
+
+  const previousStatus = runs[1].status;
+
+  const lastRunDate = new Date(runs[1].created_at);
+  const today = new Date();
+  const lastRunWasToday =
+    today.getFullYear() === lastRunDate.getFullYear() &&
+    today.getMonth() === lastRunDate.getMonth() &&
+    today.getDate() === lastRunDate.getDate();
+
+  return previousStatus === 'failure' || !lastRunWasToday;
+}

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -22,10 +22,6 @@ export default async function getShouldRunMetricsRelease({ github, context }) {
 
   const lastRunDate = new Date(runs[1].created_at);
   const today = new Date();
-  const lastRunWasToday =
-    today.getFullYear() === lastRunDate.getFullYear() &&
-    today.getMonth() === lastRunDate.getMonth() &&
-    today.getDate() === lastRunDate.getDate();
 
-  return previousStatus === 'failure' || !lastRunWasToday;
+  return previousStatus === 'failure' || today.toDateString() !== lastRunDate.toDateString();
 }


### PR DESCRIPTION
## Proposed changes

Adding workflow to release IPA metrics to s3.

- Uses staging creds and s3 bucket for now
- Not included in release spec workflow, this workflow will be triggered manually to verify it works as expected

Follow up:
- Add workflow to `release-spec.yml` run when we're confident it works as expected
- Update `failure-handler.yml` to also consider ipa release run result status
- Later on: When stable update to push to production s3 instead

_Jira ticket:_ [CLOUDP-290416](https://jira.mongodb.org/browse/CLOUDP-290416)
