### PR TITLE
CLOUDP-290416: Fix and refactor IPA metrics release workflow

### DIFF
--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -72,8 +72,7 @@ jobs:
 #          run-id: ${{ github.run_id }}
 
       - name: Run Metric Collection Job
-        working-directory: ./tools/spectral/ipa/metrics/scripts
-        run: node runMetricCollection.js ../../../../../openapi/v2.json # TODO: Change to foas in release run
+        run: node ./tools/spectral/ipa/metrics/scripts/runMetricCollection.js ${{ github.workspace }}/openapi/v2.json # TODO: Change to foas in release run
 
       - name: Dump Metric Collection Job Data to S3
         env:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           github-token: ${{ secrets.api_bot_pat }}
           script: |
-            const script = require('tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js')
+            const { default: getShouldRunMetricsRelease } = await import('${{ github.workspace }}/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js')
             const shouldRunRelease = await getShouldRunMetricsRelease({github, context})
             return shouldRunRelease
 

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -72,7 +72,8 @@ jobs:
 #          run-id: ${{ github.run_id }}
 
       - name: Run Metric Collection Job
-        run: node ./tools/spectral/ipa/metrics/scripts/runMetricCollection.js ${{ github.workspace }}/openapi/v2.json # TODO: Change to foas in release run
+        working-directory: ./tools/spectral/ipa/metrics/scripts
+        run: node runMetricCollection.js ../../../../../openapi/v2.json # TODO: Change to foas in release run
 
       - name: Dump Metric Collection Job Data to S3
         env:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -64,16 +64,16 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
-      - name: Download openapi-foas
-        uses: actions/download-artifact@v4
-        with:
-          name: openapi-foas-dev  # TODO: Change to passed input env
-          github-token: ${{ secrets.api_bot_pat }}
-          run-id: ${{ github.run_id }}
+#      - name: Download openapi-foas
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: openapi-foas-dev  # TODO: Change to passed input env
+#          github-token: ${{ secrets.api_bot_pat }}
+#          run-id: ${{ github.run_id }}
 
       - name: Run Metric Collection Job
         working-directory: ./tools/spectral/ipa/metrics/scripts
-        run: node runMetricCollection.js ../../../../../openapi-foas.json
+        run: node runMetricCollection.js ../../../../../openapi/v2.json # TODO: Change to foas in release run
 
       - name: Dump Metric Collection Job Data to S3
         env:
@@ -81,4 +81,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}   # TODO: Change to passed secret
           S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}          # TODO: Change to passed secret
         working-directory: ./tools/spectral/ipa/metrics/scripts
-        run: node dataDump.js ../../../../../openapi-foas.json
+        run: node dataDump.js ../../../../../openapi/v2.json # TODO: Change to foas in release run

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -27,8 +27,11 @@ permissions:
   issues: write
 
 jobs:
-  release-IPA-metrics:
+  pre-IPA-metrics-release-checks:
+    name: IPA Metrics Release Pre-Checks
     runs-on: ubuntu-latest
+    outputs:
+      should_run_release: ${{ steps.get_previous_status.outputs.result }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,23 +46,25 @@ jobs:
             const shouldRunRelease = await getShouldRunMetricsRelease({github, context})
             return shouldRunRelease
 
-      - name: Skip Metric Collection Job
-        if: ${{steps.get_previous_status.outputs.result == 'false' }}
-        run: echo "Skipping IPA metrics release!"
+  release-IPA-metrics:
+    name: Release IPA Validation Metrics
+    needs: [pre-IPA-metrics-release-checks]
+    if: ${{ needs.pre-IPA-metrics-release-checks.outputs.should_run_release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        if: ${{steps.get_previous_status.outputs.result == 'true' }}
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: 'npm'
 
       - name: Install npm dependencies
-        if: ${{steps.get_previous_status.outputs.result == 'true' }}
         run: npm install
 
       - name: Download openapi-foas
-        if: ${{steps.get_previous_status.outputs.result == 'true' }}
         uses: actions/download-artifact@v4
         with:
           name: openapi-foas-dev  # TODO: Change to passed input env
@@ -67,12 +72,10 @@ jobs:
           run-id: ${{ github.run_id }}
 
       - name: Run Metric Collection Job
-        if: ${{steps.get_previous_status.outputs.result == 'true' }}
         working-directory: ./tools/spectral/ipa/metrics/scripts
         run: node runMetricCollection.js ../../../../../openapi-foas.json
 
       - name: Dump Metric Collection Job Data to S3
-        if: ${{steps.get_previous_status.outputs.result == 'true' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}       # TODO: Change to passed secret
           AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}   # TODO: Change to passed secret

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -81,4 +81,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}   # TODO: Change to passed secret
           S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}          # TODO: Change to passed secret
         working-directory: ./tools/spectral/ipa/metrics/scripts
-        run: node dataDump.js ../../../../../openapi/v2.json # TODO: Change to foas in release run
+        run: node dataDump.js

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run Metric Collection Job
         working-directory: ./tools/spectral/ipa/metrics/scripts
-        run: node runMetricCollection.js ../../../../../openapi/v2.json # TODO: Change to foas in release run
+        run: node runMetricCollection.js ../../../../../openapi/v2.json # TODO: Change to foas from above
 
       - name: Dump Metric Collection Job Data to S3
         env:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -43,7 +43,10 @@ jobs:
           github-token: ${{ secrets.api_bot_pat }}
           script: |
             const { default: getShouldRunMetricsRelease } = await import('${{ github.workspace }}/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js')
-            const shouldRunRelease = await getShouldRunMetricsRelease({github, context})
+            const shouldRunRelease = await getShouldRunMetricsRelease({github, context}).catch((error) => {
+              console.error(error.message);
+              process.exit(1)
+            })
             return shouldRunRelease
 
   release-IPA-metrics:

--- a/tools/spectral/ipa/metrics/metricS3Upload.js
+++ b/tools/spectral/ipa/metrics/metricS3Upload.js
@@ -16,9 +16,6 @@ export async function uploadMetricCollectionDataToS3(filePath = config.defaultMe
     throw new Error('Loaded metrics collection data is empty');
   }
 
-  // Remove
-  console.log(metricsCollectionData);
-
   const table = tableFromJSON(metricsCollectionData);
   if (table === undefined) {
     throw new Error('Unable to transform metrics collection data to table');

--- a/tools/spectral/ipa/metrics/metricS3Upload.js
+++ b/tools/spectral/ipa/metrics/metricS3Upload.js
@@ -10,23 +10,23 @@ import { getS3Client, getS3FilePath } from './utils/dataDumpUtils.js';
  * @param filePath file path to the metrics collection results, uses config.js by default
  */
 export async function uploadMetricCollectionDataToS3(filePath = config.defaultMetricCollectionResultsFilePath) {
-  console.log('Creating S3 Client...');
-  const client = getS3Client();
-  const formattedDate = new Date().toISOString().split('T')[0];
-
-  console.log('Loading metrics collection data from', filePath);
-  const metricsCollectionData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  const table = tableFromJSON(metricsCollectionData);
-
-  console.log('Getting S3 file path...');
-  const s3fileProps = getS3FilePath();
-  const command = new PutObjectCommand({
-    Bucket: s3fileProps.bucketName,
-    Key: path.join(s3fileProps.key, formattedDate, 'metric-collection-results.parquet'),
-    Body: tableToIPC(table, 'stream'),
-  });
-
   try {
+    console.log('Creating S3 Client...');
+    const client = getS3Client();
+    const formattedDate = new Date().toISOString().split('T')[0];
+
+    console.log('Loading metrics collection data from', filePath);
+    const metricsCollectionData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    const table = tableFromJSON(metricsCollectionData);
+
+    console.log('Getting S3 file path...');
+    const s3fileProps = getS3FilePath();
+    const command = new PutObjectCommand({
+      Bucket: s3fileProps.bucketName,
+      Key: path.join(s3fileProps.key, formattedDate, 'metric-collection-results.parquet'),
+      Body: tableToIPC(table, 'stream'),
+    });
+
     console.log('Dumping data to S3...');
     const response = await client.send(command);
     console.log(response);

--- a/tools/spectral/ipa/metrics/metricS3Upload.js
+++ b/tools/spectral/ipa/metrics/metricS3Upload.js
@@ -16,6 +16,11 @@ export async function uploadMetricCollectionDataToS3(filePath = config.defaultMe
     throw new Error('Loaded metrics collection data is empty');
   }
 
+  const table = tableFromJSON(metricsCollectionData);
+  if (table === undefined) {
+    throw new Error('Unable to transform metrics collection data to table');
+  }
+
   try {
     console.log('Creating S3 Client...');
     const client = getS3Client();
@@ -24,7 +29,6 @@ export async function uploadMetricCollectionDataToS3(filePath = config.defaultMe
     console.log('Getting S3 file path...');
     const s3fileProps = getS3FilePath();
 
-    const table = tableFromJSON(metricsCollectionData);
     const command = new PutObjectCommand({
       Bucket: s3fileProps.bucketName,
       Key: path.join(s3fileProps.key, formattedDate, 'metric-collection-results.parquet'),

--- a/tools/spectral/ipa/metrics/metricS3Upload.js
+++ b/tools/spectral/ipa/metrics/metricS3Upload.js
@@ -24,10 +24,10 @@ export async function uploadMetricCollectionDataToS3(filePath = config.defaultMe
   try {
     console.log('Creating S3 Client...');
     const client = getS3Client();
-    const formattedDate = new Date().toISOString().split('T')[0];
 
     console.log('Getting S3 file path...');
     const s3fileProps = getS3FilePath();
+    const formattedDate = new Date().toISOString().split('T')[0];
 
     const command = new PutObjectCommand({
       Bucket: s3fileProps.bucketName,

--- a/tools/spectral/ipa/metrics/metricS3Upload.js
+++ b/tools/spectral/ipa/metrics/metricS3Upload.js
@@ -10,11 +10,15 @@ import { getS3Client, getS3FilePath } from './utils/dataDumpUtils.js';
  * @param filePath file path to the metrics collection results, uses config.js by default
  */
 export async function uploadMetricCollectionDataToS3(filePath = config.defaultMetricCollectionResultsFilePath) {
+  console.log('Creating S3 Client...');
   const client = getS3Client();
   const formattedDate = new Date().toISOString().split('T')[0];
+
+  console.log('Loading metrics collection data from', filePath);
   const metricsCollectionData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
   const table = tableFromJSON(metricsCollectionData);
 
+  console.log('Getting S3 file path...');
   const s3fileProps = getS3FilePath();
   const command = new PutObjectCommand({
     Bucket: s3fileProps.bucketName,
@@ -23,6 +27,7 @@ export async function uploadMetricCollectionDataToS3(filePath = config.defaultMe
   });
 
   try {
+    console.log('Dumping data to S3...');
     const response = await client.send(command);
     console.log(response);
   } catch (caught) {

--- a/tools/spectral/ipa/metrics/metricS3Upload.js
+++ b/tools/spectral/ipa/metrics/metricS3Upload.js
@@ -16,6 +16,9 @@ export async function uploadMetricCollectionDataToS3(filePath = config.defaultMe
     throw new Error('Loaded metrics collection data is empty');
   }
 
+  // Remove
+  console.log(metricsCollectionData);
+
   const table = tableFromJSON(metricsCollectionData);
   if (table === undefined) {
     throw new Error('Unable to transform metrics collection data to table');

--- a/tools/spectral/ipa/metrics/metricS3Upload.js
+++ b/tools/spectral/ipa/metrics/metricS3Upload.js
@@ -36,9 +36,7 @@ export async function uploadMetricCollectionDataToS3(filePath = config.defaultMe
     });
 
     console.log('Dumping data to S3...');
-    const response = await client.send(command);
-    console.log(response);
-    return response;
+    return await client.send(command);
   } catch (caught) {
     if (caught instanceof S3ServiceException && caught.name === 'EntityTooLarge') {
       console.error(

--- a/tools/spectral/ipa/metrics/scripts/dataDump.js
+++ b/tools/spectral/ipa/metrics/scripts/dataDump.js
@@ -3,6 +3,14 @@ import { uploadMetricCollectionDataToS3 } from '../metricS3Upload.js';
 const args = process.argv.slice(2);
 const filePath = args[0];
 
-uploadMetricCollectionDataToS3(filePath)
-  .then(() => console.log('Data dump to S3 completed successfully.'))
-  .catch((error) => console.error(error.message));
+const response = await uploadMetricCollectionDataToS3(filePath).catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});
+
+if (!response) {
+  console.error('PutObject response is undefined');
+  process.exit(1);
+}
+
+console.log('Data dump to S3 completed successfully.');

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -8,13 +8,11 @@ export default async function getShouldRunMetricsRelease({ github, context }) {
     page: 1,
   });
 
-  console.log('Response:', response);
-
-  if (response === undefined) {
+  if (response === undefined || response.data === undefined) {
     return true;
   }
 
-  const { data: runs } = response;
+  const { workflow_runs: runs } = response.data;
 
   console.log('Runs:', runs);
 

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -22,10 +22,10 @@ export default async function getShouldRunMetricsRelease({ github, context }) {
 
   console.log('Last run:', runs[1]);
 
-  const previousStatus = runs[1].status;
+  const previousResult = runs[1].conclusion;
 
   const lastRunDate = new Date(runs[1].created_at);
   const today = new Date();
 
-  return previousStatus === 'failure' || today.toDateString() !== lastRunDate.toDateString();
+  return previousResult === 'failure' || today.toDateString() !== lastRunDate.toDateString();
 }

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -8,19 +8,15 @@ export default async function getShouldRunMetricsRelease({ github, context }) {
     page: 1,
   });
 
-  if (response === undefined || response.data === undefined) {
-    return true;
+  if (!response || !response.data) {
+    throw Error('listWorkFlowRuns response is empty');
   }
 
   const { workflow_runs: runs } = response.data;
 
-  console.log('Runs:', runs);
-
   if (runs === undefined || runs.length === 0) {
-    return true;
+    throw Error('response.data.workflow_runs is empty');
   }
-
-  console.log('Last run:', runs[1]);
 
   const previousResult = runs[1].conclusion;
 

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -1,6 +1,6 @@
 // Used in .github/workflows/release-IPA-metrics.yml
 export default async function getShouldRunMetricsRelease({ github, context }) {
-  const response = await github.actions.listWorkflowRuns({
+  const response = await github.rest.actions.listWorkflowRuns({
     owner: context.repo.owner,
     repo: context.repo.repo,
     workflow_id: context.workflow,

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -18,6 +18,8 @@ export default async function getShouldRunMetricsRelease({ github, context }) {
     return true;
   }
 
+  console.log(runs[1]);
+
   const previousStatus = runs[1].status;
 
   const lastRunDate = new Date(runs[1].created_at);

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -3,7 +3,7 @@ export default async function getShouldRunMetricsRelease({ github, context }) {
   const response = await github.rest.actions.listWorkflowRuns({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    workflow_id: context.workflow,
+    workflow_id: 'release-IPA-metrics.yml',
     per_page: 2,
     page: 1,
   });

--- a/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
+++ b/tools/spectral/ipa/metrics/scripts/getShouldRunMetricsRelease.js
@@ -8,17 +8,21 @@ export default async function getShouldRunMetricsRelease({ github, context }) {
     page: 1,
   });
 
+  console.log('Response:', response);
+
   if (response === undefined) {
     return true;
   }
 
   const { data: runs } = response;
 
+  console.log('Runs:', runs);
+
   if (runs === undefined || runs.length === 0) {
     return true;
   }
 
-  console.log(runs[1]);
+  console.log('Last run:', runs[1]);
 
   const previousStatus = runs[1].status;
 

--- a/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
+++ b/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
@@ -28,7 +28,8 @@ if (oasFilePath && !fs.existsSync(oasFilePath)) {
   process.exit(1);
 }
 
-const result = spawnSync('spectral', [
+const result = spawnSync('npx', [
+  'spectral',
   'lint',
   oasFilePath ? oasFilePath : config.defaultOasFilePath,
   '--ruleset',

--- a/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
+++ b/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
@@ -28,7 +28,7 @@ if (oasFilePath && !fs.existsSync(oasFilePath)) {
   process.exit(1);
 }
 
-const result = spawnSync('npx spectral', [
+const result = spawnSync('spectral', [
   'lint',
   oasFilePath ? oasFilePath : config.defaultOasFilePath,
   '--ruleset',

--- a/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
+++ b/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
@@ -13,7 +13,12 @@ if (!fs.existsSync(config.defaultOutputsDir)) {
   console.log(`Output directory created successfully`);
 }
 
-const result = spawnSync('spectral', ['lint', config.defaultOasFilePath, '--ruleset', config.defaultRulesetFilePath]);
+const result = spawnSync('spectral', [
+  'lint',
+  oasFilePath ? oasFilePath : config.defaultOasFilePath,
+  '--ruleset',
+  config.defaultRulesetFilePath,
+]);
 
 if (result.error) {
   console.error('Error running Spectral lint:', result.error);

--- a/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
+++ b/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
@@ -23,6 +23,11 @@ if (!oasFilePath && !fs.existsSync(config.defaultOasFilePath)) {
   process.exit(1);
 }
 
+if (oasFilePath && !fs.existsSync(oasFilePath)) {
+  console.error('Could not find OAS file path', oasFilePath);
+  process.exit(1);
+}
+
 const result = spawnSync('spectral', [
   'lint',
   oasFilePath ? oasFilePath : config.defaultOasFilePath,

--- a/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
+++ b/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
@@ -13,6 +13,16 @@ if (!fs.existsSync(config.defaultOutputsDir)) {
   console.log(`Output directory created successfully`);
 }
 
+if (!fs.existsSync(config.defaultRulesetFilePath)) {
+  console.error('Could not find ruleset file path', config.defaultRulesetFilePath);
+  process.exit(1);
+}
+
+if (!oasFilePath && !fs.existsSync(config.defaultOasFilePath)) {
+  console.error('Could not find default OAS file path', config.defaultOasFilePath);
+  process.exit(1);
+}
+
 const result = spawnSync('spectral', [
   'lint',
   oasFilePath ? oasFilePath : config.defaultOasFilePath,

--- a/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
+++ b/tools/spectral/ipa/metrics/scripts/runMetricCollection.js
@@ -28,7 +28,7 @@ if (oasFilePath && !fs.existsSync(oasFilePath)) {
   process.exit(1);
 }
 
-const result = spawnSync('spectral', [
+const result = spawnSync('npx spectral', [
   'lint',
   oasFilePath ? oasFilePath : config.defaultOasFilePath,
   '--ruleset',

--- a/tools/spectral/ipa/metrics/utils/dataDumpUtils.js
+++ b/tools/spectral/ipa/metrics/utils/dataDumpUtils.js
@@ -3,6 +3,8 @@ import dotenv from 'dotenv';
 import { S3Client } from '@aws-sdk/client-s3';
 
 function loadS3Config() {
+  console.log('Loading S3 config...');
+
   if (existsSync('.env') && !process.env.S3_BUCKET_PREFIX) {
     dotenv.config();
   }


### PR DESCRIPTION
## Proposed changes

Did some fixes of the IPA release workflow, added some extra error handling and logging for easier troubleshooting, and some refactoring, including splitting `release-IPA-metrics.yml` into two jobs, one for checking if the release should run, and the second for doing the release (skipped depending on the first step).

Tested the run manually on this branch, and it's passing: https://github.com/mongodb/openapi/actions/runs/12934985049

### Next steps

- Include workflow in OAS release workflow
- Pass secrets and vars from OAS release workflow to `release-IPA-metrics.yml`
- Download foas and use in `release-IPA-metrics.yml` instead of local v2.json

Later on, when we confirmed that it works as expected with the OAS release workflow, we'll change to start using the prod S3 bucket.

_Jira ticket:_ [CLOUDP-290416](https://jira.mongodb.org/browse/CLOUDP-290416)
