### PR TITLE
CLOUDP-296431: Add IPA metrics release to OAS release workflow

### DIFF
--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -2,25 +2,19 @@ name: IPA Validation Metrics Release
 on:
   workflow_call:
     secrets: # all secrets are passed explicitly in this workflow
-#      aws_access_key:
-#        required: true
-#      aws_secret_key:
-#        required: true
-#      aws_s3_bucket_prefix:
-#        required: true
+      aws_access_key:
+        required: true
+      aws_secret_key:
+        required: true
+      aws_s3_bucket_prefix:
+        required: true
       api_bot_pat:
         required: true
-      IPA_S3_BUCKET_DW_STAGING_USERNAME:
+    inputs:
+      env:
+        description: 'Environment for the FOAS to use for IPA metrics collection'
         required: true
-      IPA_S3_BUCKET_DW_STAGING_PASSWORD:
-        required: true
-      IPA_S3_BUCKET_DW_STAGING_PREFIX:
-        required: true
-#    inputs:
-#      env:
-#        description: 'Environment for the FOAS to use for IPA metrics collection'
-#        required: true
-#        type: string
+        type: string
   workflow_dispatch:
 
 permissions:
@@ -67,21 +61,21 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
-#      - name: Download openapi-foas
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: openapi-foas-dev  # TODO: Change to passed input env
-#          github-token: ${{ secrets.api_bot_pat }}
-#          run-id: ${{ github.run_id }}
+      - name: Download openapi-foas
+        uses: actions/download-artifact@v4
+        with:
+          name: openapi-foas-${{ inputs.env }}
+          github-token: ${{ secrets.api_bot_pat }}
+          run-id: ${{ github.run_id }}
 
       - name: Run Metric Collection Job
         working-directory: ./tools/spectral/ipa/metrics/scripts
-        run: node runMetricCollection.js ../../../../../openapi/v2.json # TODO: Change to foas from above
+        run: node runMetricCollection.js ../../../../../openapi-foas.json
 
       - name: Dump Metric Collection Job Data to S3
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}       # TODO: Change to passed secret
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}   # TODO: Change to passed secret
-          S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}          # TODO: Change to passed secret
+          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_key }}
+          S3_BUCKET_PREFIX: ${{ secrets.aws_s3_bucket_prefix }}
         working-directory: ./tools/spectral/ipa/metrics/scripts
         run: node dataDump.js

--- a/.github/workflows/release-spec-runner.yml
+++ b/.github/workflows/release-spec-runner.yml
@@ -52,6 +52,9 @@ jobs:
     secrets:
       api_bot_pat: ${{ secrets.API_BOT_PAT }}
       jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+      ipa_aws_access_key: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME}}
+      ipa_aws_secret_key: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD}}
+      ipa_aws_s3_bucket_prefix: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX}}
     with:
       aws_default_region: ${{ vars.AWS_DEFAULT_REGION}}
       aws_s3_bucket: ${{ vars.S3_BUCKET_DEV}}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -43,6 +43,12 @@ on:
         required: false
       jira_api_token:
         required: true
+      ipa_s3_bucket_dw_staging_username:
+        required: true
+      ipa_s3_bucket_dw_staging_password:
+        required: true
+      ipa_s3_bucket_dw_staging_prefix:
+        required: true
 
 permissions:
   contents: write
@@ -184,11 +190,11 @@ jobs:
     if: ${{ inputs.env == 'dev' && needs.release.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/release-IPA-metrics.yml
     secrets:
-      aws_access_key: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME}}
-      aws_secret_key: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD}}
-      aws_s3_bucket_prefix: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX}}
+      aws_access_key: ${{ secrets.ipa_s3_bucket_dw_staging_username}}
+      aws_secret_key: ${{ secrets.ipa_s3_bucket_dw_staging_password}}
+      aws_s3_bucket_prefix: ${{ secrets.ipa_s3_bucket_dw_staging_prefix}}
       api_bot_pat: ${{ secrets.api_bot_pat }}
-    inputs:
+    with:
       env: ${{ inputs.env }}
 
   failure-handler: 

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -178,9 +178,22 @@ jobs:
         branch: ${{ inputs.branch }}
         foascli_version: ${{ inputs.foascli_version }}
 
+  release-IPA-metrics:
+    name: Release IPA Validation Metrics
+    needs: release
+    if: ${{ inputs.env == 'dev' && needs.release.outputs.changes_detected == 'true' }}
+    uses: ./.github/workflows/release-IPA-metrics.yml
+    secrets:
+      aws_access_key: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME}}
+      aws_secret_key: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD}}
+      aws_s3_bucket_prefix: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX}}
+      api_bot_pat: ${{ secrets.api_bot_pat }}
+    inputs:
+      env: ${{ inputs.env }}
+
   failure-handler: 
     name: Failure Handler
-    needs: [ release, release-postman, release-changelog ]
+    needs: [ release, release-postman, release-changelog, release-IPA-metrics ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     uses: ./.github/workflows/failure-handler.yml
     with:

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -43,12 +43,12 @@ on:
         required: false
       jira_api_token:
         required: true
-      ipa_s3_bucket_dw_staging_username:
-        required: true
-      ipa_s3_bucket_dw_staging_password:
-        required: true
-      ipa_s3_bucket_dw_staging_prefix:
-        required: true
+      ipa_aws_access_key:
+        required: false
+      ipa_aws_secret_key:
+        required: false
+      ipa_aws_s3_bucket_prefix:
+        required: false
 
 permissions:
   contents: write
@@ -190,9 +190,9 @@ jobs:
     if: ${{ inputs.env == 'dev' && needs.release.outputs.changes_detected == 'true' }}
     uses: ./.github/workflows/release-IPA-metrics.yml
     secrets:
-      aws_access_key: ${{ secrets.ipa_s3_bucket_dw_staging_username}}
-      aws_secret_key: ${{ secrets.ipa_s3_bucket_dw_staging_password}}
-      aws_s3_bucket_prefix: ${{ secrets.ipa_s3_bucket_dw_staging_prefix}}
+      aws_access_key: ${{ secrets.ipa_aws_access_key}}
+      aws_secret_key: ${{ secrets.ipa_aws_secret_key}}
+      aws_s3_bucket_prefix: ${{ secrets.ipa_aws_s3_bucket_prefix}}
       api_bot_pat: ${{ secrets.api_bot_pat }}
     with:
       env: ${{ inputs.env }}


### PR DESCRIPTION
## Proposed changes

- Include workflow in OAS release workflow
- Pass secrets and vars from OAS release workflow to `release-IPA-metrics.yml`
- Download FOAS and use in `release-IPA-metrics.yml` instead of local `v2.json`
- Include IPA release workflow in `failure-handler.yml`

_Jira ticket:_ [CLOUDP-296431](https://jira.mongodb.org/browse/CLOUDP-296431)

Will follow up and update to prod credentials and bucket in this ticket: [CLOUDP-296432](https://jira.mongodb.org/browse/CLOUDP-296432)
