### PR TITLE
task: [spectral] make description check deep prop

### DIFF
--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -249,6 +249,10 @@ overrides:
     rules:
         xgen-schema-name-pascal-case: "off"
   - files:
+      - "*.yaml#/components/schemas/charFiltermapping"
+    rules:
+      xgen-description: "off"
+  - files:
       - "*.yaml#/components/schemas/IndexOptions"
       - "*.yaml#/components/schemas/NetworkPermissionEntryStatus"
     rules:


### PR DESCRIPTION
## Proposed changes

We have a new addition to the openapi spec that's using deeply nested properties and this linter is not catching those

I tested the changes locally to make sure it now works