### PR TITLE
CLOUDP-297242: Fix parquet file creation for IPA metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,6 @@
 
 *.out
 **/*ipa-collector-results-combined.log
-**/*metric-collection-results.json
+**/*metric-collection-results.parquet
 **/*spectral-output.txt
 **/*spectral-report.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
                 "apache-arrow": "^19.0.0",
                 "dotenv": "^16.4.7",
                 "eslint-plugin-jest": "^28.10.0",
-                "openapi-to-postmanv2": "4.24.0"
+                "openapi-to-postmanv2": "4.24.0",
+                "parquet-wasm": "^0.6.1"
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.26.0",
@@ -9405,6 +9406,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/parquet-wasm": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/parquet-wasm/-/parquet-wasm-0.6.1.tgz",
+            "integrity": "sha512-wTM/9Y4EHny8i0qgcOlL9UHsTXftowwCqDsAD8axaZbHp0Opp3ue8oxexbzTVNhqBjFhyhLiU3MT0rnEYnYU0Q==",
+            "license": "MIT OR Apache-2.0"
         },
         "node_modules/parse-json": {
             "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
         "apache-arrow": "^19.0.0",
         "dotenv": "^16.4.7",
         "eslint-plugin-jest": "^28.10.0",
-        "openapi-to-postmanv2": "4.24.0"
+        "openapi-to-postmanv2": "4.24.0",
+        "parquet-wasm": "^0.6.1"
     },
     "devDependencies": {
         "@babel/preset-env": "^7.26.0",

--- a/tools/spectral/ipa/metrics/config.js
+++ b/tools/spectral/ipa/metrics/config.js
@@ -11,6 +11,9 @@ const config = {
   defaultOutputsDir: path.join(dirname, 'outputs'),
 };
 
-config.defaultMetricCollectionResultsFilePath = path.join(config.defaultOutputsDir, 'metric-collection-results.json');
+config.defaultMetricCollectionResultsFilePath = path.join(
+  config.defaultOutputsDir,
+  'metric-collection-results.parquet'
+);
 
 export default config;


### PR DESCRIPTION
## Proposed changes

The parquet file previously created in IPA metrics collection wasn't a valid parquet file, but an arrow file. This PR adds [parquet-wasm](https://github.com/kylebarron/parquet-wasm) which can coverts an arrow table in memory to parquet which is then written to file. The file is compressed with gzip.

Tested locally and confirmed the created parquet and the dumped parquet in s3 are readable as parquet.

_Jira ticket:_ [CLOUDP-297242](https://jira.mongodb.org/browse/CLOUDP-297242)
