### PR TITLE
CLOUDP-298521: Decouple IPA Metrics Collection Job from FOAS Release GH Workflow (fixes)

### DIFF
--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -53,9 +53,19 @@ jobs:
         with:
           name: oas-dev
 
+      - name: Debug Checkout
+        run: |
+          echo "Workspace Contents:"
+          ls -la
+          echo "Tools Spectral Contents:"
+          ls -la tools/spectral
+          echo "IPA Contents:"
+          ls -la tools/spectral/ipa || echo "ipa directory is missing!"
+
       - name: Run Metric Collection Job
         working-directory: tools/spectral/ipa/metrics/scripts
-        run: node runMetricCollection.js ${{ env.OAS_FILE }}
+        run: ls -la
+        # node runMetricCollection.js ${{ env.OAS_FILE }}
 
 #      - name: Dump Metric Collection Job Data to S3
 #        env:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -12,7 +12,6 @@ env:
   NODE_VERSION: '20.x'
   OAS_BRANCH: 'dev'
   OAS_FILE: 'openapi/v2.json'
-  IPA_PATH: ${{ github.workspace }}/ipa
   DEV_OAS_PATH: ${{ github.workspace }}/dev-oas
 
 jobs:
@@ -28,7 +27,6 @@ jobs:
               tools/spectral/ipa
               package.json
               package-lock.json
-          path: ipa
 
       - name: Checkout repository (dev branch)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -54,7 +52,7 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        working-directory: ${{ env.IPA_PATH }}/metrics/scripts
+        working-directory: ./tools/spectral/ipa/metrics/scripts
         run: node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 
       - name: Dump Metric Collection Job Data to S3
@@ -62,7 +60,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}
           S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}
-        working-directory: ${{ env.IPA_PATH }}/metrics/scripts
+        working-directory: ./tools/spectral/ipa/metrics/scripts
         run: node dataDump.js
 
 #  failure-handler:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           sparse-checkout:
-              tools/spectral
+              tools/spectral/ipa
               package.json
               package-lock.json
 
@@ -41,6 +41,15 @@ jobs:
             echo "::error::OAS file not found in ${{ env.OAS_BRANCH }} branch"
             exit 1
           fi
+
+      - name: Debug Checkout
+        run: |
+          echo "Workspace Contents:"
+          ls -la
+          echo "Tools Spectral Contents:"
+          ls -la tools/spectral
+          echo "IPA Contents:"
+          ls -la tools/spectral/ipa || echo "ipa directory is missing!"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           ref: ${{ env.OAS_BRANCH }}
           sparse-checkout: openapi/${{ env.OAS_FILE }}
-          path: dev-oas
 
       - name: Debug Checkout
         run: |

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -33,11 +33,11 @@ jobs:
 
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          sparse-checkout:
-            tools/spectral/ipa
-            package.json
-            package-lock.json
+#        with:
+#          sparse-checkout:
+#            tools/spectral/ipa
+#            package.json
+#            package-lock.json
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 permissions:
   issues: write
+  contents: write
 env:
   NODE_VERSION: '20.x'
   OAS_BRANCH: 'dev'

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Validate OAS file
         run: |
           if [ ! -f "${{ env.DEV_OAS_PATH }}/${{ env.OAS_FILE }}" ]; then
+            ls -la
             echo "::error::OAS file not found in ${{ env.OAS_BRANCH }} branch"
             exit 1
           fi

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Validate OAS file
         run: |
-          if [ ! -f "dev-oas/${{ env.OAS_FILE }}" ]; then
+          if [ ! -f "${{ env.DEV_OAS_PATH }}/${{ env.OAS_FILE }}" ]; then
             echo "::error::OAS file not found in ${{ env.OAS_BRANCH }} branch"
             exit 1
           fi

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -19,11 +19,12 @@ jobs:
     name: Release IPA Validation Metrics
     runs-on: ubuntu-latest
     steps:
-#      - name: Fetch OAS file from Dev Branch
-#        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-#        with:
-#          ref: ${{ env.OAS_BRANCH }}
-#          sparse-checkout: ${{ env.OAS_FILE }}
+      - name: Fetch OAS file from Dev Branch
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          ref: ${{ env.OAS_BRANCH }}
+          sparse-checkout: ${{ env.OAS_FILE }}
+          path: dev-oas
 #
 #      - name: Upload OAS file
 #        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        working-directory: tools
+        working-directory: tools/spectral
         run: ls -la
         #  node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -57,13 +57,13 @@ jobs:
         working-directory: tools/spectral/ipa/metrics/scripts
         run: node runMetricCollection.js "${{ github.workspace }}/${{ env.OAS_FILE }}"
 
-#      - name: Dump Metric Collection Job Data to S3
-#        env:
-#          AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}
-#          S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}
-#        working-directory: tools/spectral/ipa/metrics/scripts
-#        run: node dataDump.js
+      - name: Dump Metric Collection Job Data to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}
+          S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}
+        working-directory: tools/spectral/ipa/metrics/scripts
+        run: node dataDump.js
 
 #  failure-handler:
 #    name: Failure Handler

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -31,13 +31,13 @@ jobs:
       - name: Checkout repository (dev branch)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          ref: $OAS_BRANCH
-          sparse-checkout: $OAS_FILE
+          ref: ${{ env.OAS_BRANCH }}
+          sparse-checkout: ${{ env.OAS_FILE }}
           path: dev-oas
 
       - name: Validate OAS file
         run: |
-          if [ ! -f "dev-oas/$OAS_FILE" ]; then
+          if [ ! -f "dev-oas/${{ env.OAS_FILE }}" ]; then
             echo "::error::OAS file not found in $OAS_BRANCH branch"
             exit 1
           fi
@@ -52,24 +52,24 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        working-directory: $IPA_PATH/metrics/scripts
-        run: node runMetricCollection.js "$DEV_OAS_PATH/openapi/v2.json"
+        working-directory: ${{ env.IPA_PATH }}/metrics/scripts
+        run: node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 
       - name: Dump Metric Collection Job Data to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}
           S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}
-        working-directory: $IPA_PATH/metrics/scripts
+        working-directory: ${{ env.IPA_PATH }}/metrics/scripts
         run: node dataDump.js
 
-  failure-handler:
-    name: Failure Handler
-    needs: [ release-IPA-metrics ]
-    if: ${{ failure() }}
-    uses: ./.github/workflows/failure-handler.yml
-    with:
-      env: $OAS_BRANCH
-      release_name: "IPA Metrics"
-    secrets:
-      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+#  failure-handler:
+#    name: Failure Handler
+#    needs: [ release-IPA-metrics ]
+#    if: ${{ failure() }}
+#    uses: ./.github/workflows/failure-handler.yml
+#    with:
+#      env: $OAS_BRANCH
+#      release_name: "IPA Metrics"
+#    secrets:
+#      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
+          ref: 'main'
           sparse-checkout:
               tools/spectral/ipa
               package.json

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        #working-directory: tools/spectral/ipa/metrics/scripts
+        working-directory: tools/spectral/ipa/metrics/scripts
         run: ls -la
         #  node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -25,12 +25,12 @@ jobs:
           ref: ${{ env.OAS_BRANCH }}
           sparse-checkout: ${{ env.OAS_FILE }}
           path: dev-oas
-#
-#      - name: Upload OAS file
-#        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
-#        with:
-#          name: oas-dev
-#          path: ${{ env.OAS_FILE }}
+
+      - name: Upload OAS file
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: oas-dev
+          path: ${{ env.OAS_FILE }}
 
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -49,10 +49,10 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
-#      - name: Download oas-dev
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: oas-dev
+      - name: Download oas-dev
+        uses: actions/download-artifact@v4
+        with:
+          name: oas-dev
 
       - name: Debug Checkout
         run: |

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: oas-dev
-          path: ${{ env.OAS_FILE }}
+          path: openapi/${{ env.OAS_FILE }}
 
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -53,7 +53,9 @@ jobs:
 
       - name: Run Metric Collection Job
         working-directory: tools/spectral/ipa/metrics/scripts
-        run: node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
+        run: |
+          ls -la
+          node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 
       - name: Dump Metric Collection Job Data to S3
         env:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          ref: 'main'
           sparse-checkout:
               tools/spectral/ipa
               package.json
@@ -53,7 +52,7 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        working-directory: tools/spectral
+        working-directory: tools/spectral/ipa
         run: ls -la
         #  node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: $NODE_VERSION
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
       - name: Install npm dependencies

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Validate OAS file
         run: |
           if [ ! -f "dev-oas/${{ env.OAS_FILE }}" ]; then
-            echo "::error::OAS file not found in $OAS_BRANCH branch"
+            echo "::error::OAS file not found in ${{ env.OAS_BRANCH }} branch"
             exit 1
           fi
 
@@ -52,18 +52,17 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        working-directory: tools/spectral/ipa/metrics/scripts
-        run: |
-          ls -la
-          node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
+        #working-directory: tools/spectral/ipa/metrics/scripts
+        run: ls -la
+        #  node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 
-      - name: Dump Metric Collection Job Data to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}
-          S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}
-        working-directory: tools/spectral/ipa/metrics/scripts
-        run: node dataDump.js
+#      - name: Dump Metric Collection Job Data to S3
+#        env:
+#          AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}
+#          S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}
+#        working-directory: tools/spectral/ipa/metrics/scripts
+#        run: node dataDump.js
 
 #  failure-handler:
 #    name: Failure Handler

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -33,11 +33,11 @@ jobs:
 
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-#        with:
-#          sparse-checkout:
-#            tools/spectral/ipa
-#            package.json
-#            package-lock.json
+        with:
+          sparse-checkout:
+            tools
+            package.json
+            package-lock.json
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           sparse-checkout:
               tools/spectral/ipa
+              package.json
+              package-lock.json
           path: ipa
 
       - name: Checkout repository (dev branch)
@@ -69,7 +71,7 @@ jobs:
 #    if: ${{ failure() }}
 #    uses: ./.github/workflows/failure-handler.yml
 #    with:
-#      env: $OAS_BRANCH
+#      env: ${{ env.OAS_BRANCH }}
 #      release_name: "IPA Metrics"
 #    secrets:
 #      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -8,10 +8,6 @@ on:
 permissions:
   issues: write
   contents: write
-env:
-  NODE_VERSION: '20.x'
-  OAS_BRANCH: 'dev'
-  OAS_FILE: 'v2.json'
 
 jobs:
   # Generates and uploads the IPA validation metrics to S3
@@ -22,14 +18,14 @@ jobs:
       - name: Fetch OAS file from Dev Branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          ref: ${{ env.OAS_BRANCH }}
-          sparse-checkout: openapi/${{ env.OAS_FILE }}
+          ref: 'dev'
+          sparse-checkout: openapi/v2.json
 
       - name: Upload OAS file
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: oas-dev
-          path: openapi/${{ env.OAS_FILE }}
+          path: openapi/v2.json
 
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -42,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: '20.x'
           cache: 'npm'
 
       - name: Install npm dependencies
@@ -55,7 +51,7 @@ jobs:
 
       - name: Run Metric Collection Job
         working-directory: tools/spectral/ipa/metrics/scripts
-        run: node runMetricCollection.js "${{ github.workspace }}/${{ env.OAS_FILE }}"
+        run: node runMetricCollection.js "${{ github.workspace }}/v2.json"
 
       - name: Dump Metric Collection Job Data to S3
         env:
@@ -71,7 +67,7 @@ jobs:
     if: ${{ failure() }}
     uses: ./.github/workflows/failure-handler.yml
     with:
-      env: ${{ env.OAS_BRANCH }}
+      oas_env: 'dev'
       release_name: "IPA Metrics"
     secrets:
       jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -20,20 +20,20 @@ jobs:
     name: Release IPA Validation Metrics
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository (scripts)
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          sparse-checkout:
-              tools/spectral/ipa
-              package.json
-              package-lock.json
-
       - name: Checkout repository (dev branch)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           ref: ${{ env.OAS_BRANCH }}
           sparse-checkout: ${{ env.OAS_FILE }}
           path: dev-oas
+
+      - name: Checkout repository (scripts)
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          sparse-checkout:
+            tools/spectral/ipa
+            package.json
+            package-lock.json
 
       - name: Validate OAS file
         run: |

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -65,13 +65,13 @@ jobs:
         working-directory: tools/spectral/ipa/metrics/scripts
         run: node dataDump.js
 
-#  failure-handler:
-#    name: Failure Handler
-#    needs: [ release-IPA-metrics ]
-#    if: ${{ failure() }}
-#    uses: ./.github/workflows/failure-handler.yml
-#    with:
-#      env: ${{ env.OAS_BRANCH }}
-#      release_name: "IPA Metrics"
-#    secrets:
-#      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
+  failure-handler:
+    name: Failure Handler
+    needs: [ release-IPA-metrics ]
+    if: ${{ failure() }}
+    uses: ./.github/workflows/failure-handler.yml
+    with:
+      env: ${{ env.OAS_BRANCH }}
+      release_name: "IPA Metrics"
+    secrets:
+      jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -11,7 +11,7 @@ permissions:
 env:
   NODE_VERSION: '20.x'
   OAS_BRANCH: 'dev'
-  OAS_FILE: 'openapi/v2.json'
+  OAS_FILE: 'v2.json'
 
 jobs:
   # Generates and uploads the IPA validation metrics to S3
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           ref: ${{ env.OAS_BRANCH }}
-          sparse-checkout: ${{ env.OAS_FILE }}
+          sparse-checkout: openapi/${{ env.OAS_FILE }}
           path: dev-oas
 
       - name: Upload OAS file

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        working-directory: tools/spectral/ipa/metrics/scripts
+        working-directory: tools/spectral/ipa
         run: ls -la
         #  node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -12,7 +12,6 @@ env:
   NODE_VERSION: '20.x'
   OAS_BRANCH: 'dev'
   OAS_FILE: 'openapi/v2.json'
-  DEV_OAS_PATH: ${{ github.workspace }}/dev-oas
 
 jobs:
   # Generates and uploads the IPA validation metrics to S3
@@ -20,12 +19,17 @@ jobs:
     name: Release IPA Validation Metrics
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository (dev branch)
+      - name: Fetch OAS file from Dev Branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           ref: ${{ env.OAS_BRANCH }}
           sparse-checkout: ${{ env.OAS_FILE }}
-          path: dev-oas
+
+      - name: Upload OAS file
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: oas-dev
+          path: ${{ env.OAS_FILE }}
 
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
@@ -34,23 +38,6 @@ jobs:
             tools/spectral/ipa
             package.json
             package-lock.json
-
-      - name: Validate OAS file
-        run: |
-          if [ ! -f "${{ env.DEV_OAS_PATH }}/${{ env.OAS_FILE }}" ]; then
-            ls -la
-            echo "::error::OAS file not found in ${{ env.OAS_BRANCH }} branch"
-            exit 1
-          fi
-
-      - name: Debug Checkout
-        run: |
-          echo "Workspace Contents:"
-          ls -la
-          echo "Tools Spectral Contents:"
-          ls -la tools/spectral
-          echo "IPA Contents:"
-          ls -la tools/spectral/ipa || echo "ipa directory is missing!"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -61,10 +48,14 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
+      - name: Download oas-dev
+        uses: actions/download-artifact@v4
+        with:
+          name: oas-dev
+
       - name: Run Metric Collection Job
-        working-directory: tools/spectral/ipa
-        run: ls -la
-        #  node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
+        working-directory: tools/spectral/ipa/metrics/scripts
+        run: node runMetricCollection.js ${{ env.OAS_FILE }}
 
 #      - name: Dump Metric Collection Job Data to S3
 #        env:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -26,6 +26,11 @@ jobs:
           sparse-checkout: openapi/${{ env.OAS_FILE }}
           path: dev-oas
 
+      - name: Debug Checkout
+        run: |
+          echo "Workspace Contents:"
+          ls -la
+
       - name: Upload OAS file
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        working-directory: tools/spectral/ipa
+        working-directory: tools
         run: ls -la
         #  node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -52,7 +52,7 @@ jobs:
         run: npm install
 
       - name: Run Metric Collection Job
-        working-directory: ./tools/spectral/ipa/metrics/scripts
+        working-directory: tools/spectral/ipa/metrics/scripts
         run: node runMetricCollection.js "${{ env.DEV_OAS_PATH }}/openapi/v2.json"
 
       - name: Dump Metric Collection Job Data to S3
@@ -60,7 +60,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_USERNAME }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PASSWORD }}
           S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_STAGING_PREFIX }}
-        working-directory: ./tools/spectral/ipa/metrics/scripts
+        working-directory: tools/spectral/ipa/metrics/scripts
         run: node dataDump.js
 
 #  failure-handler:

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -67,7 +67,7 @@ jobs:
     if: ${{ failure() }}
     uses: ./.github/workflows/failure-handler.yml
     with:
-      oas_env: 'dev'
+      env: 'dev'
       release_name: "IPA Metrics"
     secrets:
       jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -19,23 +19,23 @@ jobs:
     name: Release IPA Validation Metrics
     runs-on: ubuntu-latest
     steps:
-      - name: Fetch OAS file from Dev Branch
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          ref: ${{ env.OAS_BRANCH }}
-          sparse-checkout: ${{ env.OAS_FILE }}
-
-      - name: Upload OAS file
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
-        with:
-          name: oas-dev
-          path: ${{ env.OAS_FILE }}
+#      - name: Fetch OAS file from Dev Branch
+#        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+#        with:
+#          ref: ${{ env.OAS_BRANCH }}
+#          sparse-checkout: ${{ env.OAS_FILE }}
+#
+#      - name: Upload OAS file
+#        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+#        with:
+#          name: oas-dev
+#          path: ${{ env.OAS_FILE }}
 
       - name: Checkout repository (scripts)
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
-          sparse-checkout:
-            tools
+          sparse-checkout: |
+            tools/spectral/ipa
             package.json
             package-lock.json
 
@@ -48,10 +48,10 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
-      - name: Download oas-dev
-        uses: actions/download-artifact@v4
-        with:
-          name: oas-dev
+#      - name: Download oas-dev
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: oas-dev
 
       - name: Debug Checkout
         run: |

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
         with:
           sparse-checkout:
-              tools/spectral/ipa
+              tools/spectral
               package.json
               package-lock.json
 

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -25,11 +25,6 @@ jobs:
           ref: ${{ env.OAS_BRANCH }}
           sparse-checkout: openapi/${{ env.OAS_FILE }}
 
-      - name: Debug Checkout
-        run: |
-          echo "Workspace Contents:"
-          ls -la
-
       - name: Upload OAS file
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
@@ -58,19 +53,9 @@ jobs:
         with:
           name: oas-dev
 
-      - name: Debug Checkout
-        run: |
-          echo "Workspace Contents:"
-          ls -la
-          echo "Tools Spectral Contents:"
-          ls -la tools/spectral
-          echo "IPA Contents:"
-          ls -la tools/spectral/ipa || echo "ipa directory is missing!"
-
       - name: Run Metric Collection Job
         working-directory: tools/spectral/ipa/metrics/scripts
-        run: ls -la
-        # node runMetricCollection.js ${{ env.OAS_FILE }}
+        run: node runMetricCollection.js "${{ github.workspace }}/${{ env.OAS_FILE }}"
 
 #      - name: Dump Metric Collection Job Data to S3
 #        env:


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-298521

The issue arises from performing two checkouts in the workflow. When a second checkout is executed, it resets the current workspace, causing the previously checked-out files to be lost. To address this:

1. First, checkout the dev branch and upload the OAS file as an artifact.
2. Then, perform the second checkout to the main branch and download the artifact (OAS file) to continue working with it. 

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
