### PR TITLE
CLOUDP-297221: Add preview support to split command

### DIFF
--- a/tools/cli/internal/apiversion/version.go
+++ b/tools/cli/internal/apiversion/version.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -54,6 +55,13 @@ func New(opts ...Option) (*APIVersion, error) {
 // WithVersion sets the version on the APIVersion.
 func WithVersion(version string) Option {
 	return func(v *APIVersion) error {
+		if strings.EqualFold(version, PreviewStabilityLevel) {
+			v.version = version
+			v.stabilityVersion = PreviewStabilityLevel
+			v.versionDate = time.Now() // make preview look like the latest version
+			return nil
+		}
+
 		versionDate, err := DateFromVersion(version)
 		if err != nil {
 			return err
@@ -87,6 +95,7 @@ func WithContent(contentType string) Option {
 		v.stabilityVersion = StableStabilityLevel
 		if version == PreviewStabilityLevel {
 			v.stabilityVersion = PreviewStabilityLevel
+			v.versionDate = time.Now() // make preview look like the latest version
 			return nil
 		}
 

--- a/tools/cli/internal/apiversion/version.go
+++ b/tools/cli/internal/apiversion/version.go
@@ -57,7 +57,7 @@ func (v *APIVersion) newVersion(version string, date time.Time) {
 	v.stabilityVersion = StableStabilityLevel
 	v.versionDate = date
 
-	if IsPreviewVersion(version) {
+	if IsPreviewSabilityLevel(version) {
 		v.versionDate = time.Now().AddDate(10, 0, 0) // set preview date to the future
 		v.stabilityVersion = PreviewStabilityLevel
 	}
@@ -103,7 +103,7 @@ func WithContent(contentType string) Option {
 }
 
 func DateFromVersion(version string) (time.Time, error) {
-	if IsPreviewVersion(version) {
+	if IsPreviewSabilityLevel(version) {
 		return time.Now(), nil
 	}
 	return time.Parse(dateFormat, version)
@@ -142,11 +142,19 @@ func (v *APIVersion) StabilityLevel() string {
 }
 
 func (v *APIVersion) ExactMatchOnly() bool {
-	return v.stabilityVersion == PreviewStabilityLevel
+	return v.IsPreview()
 }
 
-func IsPreviewVersion(version string) bool {
-	return strings.EqualFold(version, PreviewStabilityLevel)
+func (v *APIVersion) IsPreview() bool {
+	return IsPreviewSabilityLevel(v.version)
+}
+
+func IsPreviewSabilityLevel(value string) bool {
+	return strings.EqualFold(value, PreviewStabilityLevel)
+}
+
+func IsStableSabilityLevel(value string) bool {
+	return strings.EqualFold(value, StableStabilityLevel)
 }
 
 func FindMatchesFromContentType(contentType string) []string {

--- a/tools/cli/internal/apiversion/version.go
+++ b/tools/cli/internal/apiversion/version.go
@@ -58,7 +58,7 @@ func (v *APIVersion) newVersion(version string, date time.Time) {
 	v.versionDate = date
 
 	if IsPreviewVersion(version) {
-		v.versionDate = time.Now()
+		v.versionDate = time.Now().AddDate(10, 0, 0) // set preview date to the future
 		v.stabilityVersion = PreviewStabilityLevel
 	}
 }

--- a/tools/cli/internal/apiversion/version_test.go
+++ b/tools/cli/internal/apiversion/version_test.go
@@ -49,6 +49,12 @@ func TestParseVersion(t *testing.T) {
 			wantErr:       false,
 		},
 		{
+			name:          "preview",
+			contentType:   "application/vnd.atlas.preview+json",
+			expectedMatch: "preview",
+			wantErr:       false,
+		},
+		{
 			name:          "invalid",
 			contentType:   "application/vnd.test.2023-01-01",
 			expectedMatch: "",
@@ -92,6 +98,12 @@ func TestNewAPIVersionFromContentType(t *testing.T) {
 			name:          "yaml",
 			contentType:   "application/vnd.atlas.2030-02-20+yaml",
 			expectedMatch: "2030-02-20",
+			wantErr:       false,
+		},
+		{
+			name:          "preview",
+			contentType:   "application/vnd.atlas.preview+json",
+			expectedMatch: "preview",
 			wantErr:       false,
 		},
 		{

--- a/tools/cli/internal/apiversion/version_test.go
+++ b/tools/cli/internal/apiversion/version_test.go
@@ -49,8 +49,20 @@ func TestParseVersion(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name:          "preview",
+			name:          "preview_json",
 			contentType:   "application/vnd.atlas.preview+json",
+			expectedMatch: "preview",
+			wantErr:       false,
+		},
+		{
+			name:          "preview_yaml",
+			contentType:   "application/vnd.atlas.preview+yaml",
+			expectedMatch: "preview",
+			wantErr:       false,
+		},
+		{
+			name:          "preview_csv",
+			contentType:   "application/vnd.atlas.preview+csv",
 			expectedMatch: "preview",
 			wantErr:       false,
 		},
@@ -429,6 +441,11 @@ func TestFindLatestContentVersionMatched(t *testing.T) {
 			expectedMatch: "2023-01-01",
 		},
 		{
+			name:          "exact match preview",
+			targetVersion: "preview",
+			expectedMatch: "preview",
+		},
+		{
 			name:          "exact match 2023-11-15",
 			targetVersion: "2023-11-15",
 			expectedMatch: "2023-11-15",
@@ -482,6 +499,7 @@ func oasOperationAllVersions() *openapi3.Operation {
 	responses.Set("200", &openapi3.ResponseRef{
 		Value: &openapi3.Response{
 			Content: map[string]*openapi3.MediaType{
+				"application/vnd.atlas.preview+json":    {},
 				"application/vnd.atlas.2023-01-01+json": {},
 				"application/vnd.atlas.2023-01-01+csv":  {},
 				"application/vnd.atlas.2023-02-01+json": {},

--- a/tools/cli/internal/cli/versions/versions.go
+++ b/tools/cli/internal/cli/versions/versions.go
@@ -76,11 +76,11 @@ func (o *Opts) filterStabilityLevelVersions(apiVersions []string) []string {
 
 	var out []string
 	for _, v := range apiVersions {
-		if o.stabilityLevel == apiversion.PreviewStabilityLevel && strings.Contains(v, "preview") {
+		if (apiversion.IsStableSabilityLevel(o.stabilityLevel)) && !apiversion.IsPreviewSabilityLevel(v) {
 			out = append(out, v)
 		}
 
-		if o.stabilityLevel == apiversion.StableStabilityLevel && !strings.Contains(v, "preview") {
+		if (apiversion.IsPreviewSabilityLevel(o.stabilityLevel)) && apiversion.IsPreviewSabilityLevel(v) {
 			out = append(out, v)
 		}
 	}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-297221

- Allows the split command to handle preview, using exact match only, which means only the preview endpoints will get added to the preview spec
- Moves stability level checks into apiversion library, also making it use case insensitive

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
