### PR TITLE
CLOUDP-298469: Fix notificaiton GH aciton to not create a ticket in the event of error

### DIFF
--- a/.github/scripts/create_jira_ticket.sh
+++ b/.github/scripts/create_jira_ticket.sh
@@ -21,17 +21,26 @@ url_encode() {
 encoded_jira_ticket_title=$(url_encode "${JIRA_TICKET_TITLE:?}")
 echo "encoded_jira_ticket_title: ${encoded_jira_ticket_title}"
 
-found_issue=$(curl --request GET \
+found_issue_response=$(curl --request GET \
                 --url 'https://jira.mongodb.org/rest/api/2/search?jql=project=10984%20AND%20issuetype=12%20AND%20component=35986%20AND%20summary~"'"${encoded_jira_ticket_title:?}"'"' \
                 --header 'Authorization: Bearer '"${JIRA_API_TOKEN:?}" \
                 --header 'Accept: application/json' \
-                --header 'Content-Type: application/json' | jq .total)
+                --header 'Content-Type: application/json')
 
+echo "found_issue_response: ${found_issue_response}"
+
+found_issue=$(echo "${found_issue_response}" | jq .total)
 echo "found_issue: ${found_issue}"
 if [ "$found_issue" -ne 0 ]; then
     echo "There is already a Jira ticket with the title \"${JIRA_TICKET_TITLE:?}\""
     echo "No new Jira ticket will be created."
     exit 0
+fi
+
+if [ "${found_issue}" == "null" ]; then
+    echo "There was an error in retrieving the jira ticket: ${found_issue_response}"
+    echo "No new Jira ticket will be created."
+    exit 1
 fi
 
 echo "Creating Jira ticket...."

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -3,7 +3,7 @@ name: 'Send a Slack Notification for APIs important events'
 on:
   workflow_dispatch: # Allow manual triggering
   schedule:
-    - cron: '0 9 * * 1-5' # Run once a day at 09:00 UTC between Monday and Friday
+    - cron: '0 9 * * 1' # Run once a day at 09:00 UTC on Monday
 
 jobs:
   new-api-version-reminder:
@@ -24,16 +24,6 @@ jobs:
       - name: Check if there are upcoming API versions releases
         id: check-api-versions
         run: .github/scripts/upcoming_api_releases.sh
-
-      # Create a JIRA ticket for the upcoming API versions only if the there is not already a ticket with the same title
-      - name: Create JIRA Ticket
-        id: create-jira-ticket
-        if: steps.check-api-versions.outputs.api_versions != null
-        env:
-          JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
-          JIRA_TICKET_TITLE: "[API Platform] API Versions (${{steps.check-api-versions.outputs.api_versions}}) are about to be released"
-          JIRA_TICKET_DESCRIPTION: "The following API Versions are scheduled to be released in the next 3 weeks: ${{steps.check-api-versions.outputs.api_versions}}. Please follow https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APIVersionReleasechecks"
-        run: .github/scripts/create_jira_ticket.sh
 
       # Send Slack notification only if the Jira ticket was created
       - name: Send Slack Notification

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -103,7 +103,7 @@ jobs:
         if: steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis != null
         env:
           JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
-          JIRA_TICKET_TITLE: "[API Platform] Some APIs are approaching their sunset date in the next 3 months. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
+          JIRA_TICKET_TITLE: "Some APIs are approaching their sunset date in the next 3 months. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
         run: |
           sunset_apis=$(sed 's/"/\\"/g' sunset_apis.json)
           JIRA_TICKET_DESCRIPTION="The following APIs will be sunset in the next 3 months. Please follow our [wiki|https://wiki.corp.mongodb.com/display/MMS/API+eXperience+Production+Checklist#APIeXperienceProductionChecklist-APISunsetActionItems]. {noformat}${sunset_apis}{noformat}"

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -27,15 +27,15 @@ jobs:
 
       # Send Slack notification only if the Jira ticket was created
       - name: Send Slack Notification
+        if: steps.check-api-versions.outputs.api_versions != null
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_APIX_2 }}
           SLACK_BEARER_TOKEN: ${{ secrets.SLACK_BEARER_TOKEN }}
           API_VERSIONS: ${{ steps.check-api-versions.outputs.api_versions }}
-          JIRA_TICKET_ID: ${{ steps.create-jira-ticket.outputs.jira-ticket-id }}
         run: |
           message_id=$(curl -X POST -H 'Authorization: Bearer '"${SLACK_BEARER_TOKEN}" \
           -H 'Content-type: application/json' \
-          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following API Versions are scheduled to be released in the next 3 weeks: '"${API_VERSIONS}"'. Jira Ticket: https://jira.mongodb.org/browse/'"${JIRA_TICKET_ID}"'","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
+          --data '{"channel":"'"${SLACK_CHANNEL_ID}"'","text":"The following API Versions are scheduled to be released in the next 3 weeks: '"${API_VERSIONS}"'.","parse": "full",}' https://slack.com/api/chat.postMessage | jq '.ts')
           echo "message_id=${message_id}"
 
   sunset-api-version-reminder:

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -3,7 +3,7 @@ name: 'Send a Slack Notification for APIs important events'
 on:
   workflow_dispatch: # Allow manual triggering
   schedule:
-    - cron: '0 9 * * 1' # Run once a day at 09:00 UTC on Monday
+    - cron: '0 9 * * 1' # at 9:00 UTC on Monday
 
 jobs:
   new-api-version-reminder:

--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -27,7 +27,6 @@ jobs:
 
       # Send Slack notification only if the Jira ticket was created
       - name: Send Slack Notification
-        if: steps.create-jira-ticket.outputs.jira-ticket-id != null
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID_APIX_2 }}
           SLACK_BEARER_TOKEN: ${{ secrets.SLACK_BEARER_TOKEN }}


### PR DESCRIPTION
## Proposed changes


_Jira ticket:_ CLOUDP-298469


Bug: the action was creating a new Jira ticket when the JIRA API to find similar ticket returned an error.

This PR updates the logic to: 

- avoid creating a new JIRA ticket in the event of error from the Jira API call that search for similar Jira ticket
- Update the title of the ticket. During my local testing, I discovered that the JIRA API returns an error if using `[API Platform]` in the title. Removing this prefix makes the JIRA API happy again. 