### PR TITLE
CLOUDP-300586: Add team vars to failure handler

### DIFF
--- a/.github/scripts/create_jira_ticket.sh
+++ b/.github/scripts/create_jira_ticket.sh
@@ -6,7 +6,7 @@
 # 2. URL encodes the JIRA ticket title.
 # 3. Checks if a JIRA ticket with the same title already exists in the specified project (id=10984) and component (id=35986).
 # 4. If a ticket already exists, it exits without creating a new ticket.
-# 5. If no ticket exists, it creates a new JIRA ticket with the provided title and description.
+# 5. If no ticket exists, it creates a new JIRA ticket with the provided title, description and team id.
 # 6. Outputs the ID of the created JIRA ticket and sets it as a GitHub Actions output variable.
 
 set -eou pipefail
@@ -64,7 +64,7 @@ json_response=$(curl --request POST \
     },
     "customfield_12751": [
       {
-        "id": "22223"
+        "id": "${JIRA_TEAM_ID:?}"
       }
     ],
     "description": "${JIRA_TICKET_DESCRIPTION:?}",

--- a/.github/workflows/failure-handler.yml
+++ b/.github/workflows/failure-handler.yml
@@ -10,6 +10,10 @@ on:
         description: 'Name of the release.'
         required: true
         type: string
+      team_id:
+        description: 'ID of Jira Team'
+        required: true
+        type: string
     secrets: # all secrets are passed explicitly in this workflow
       jira_api_token:
         required: true
@@ -72,6 +76,7 @@ jobs:
                 JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
                 JIRA_TICKET_TITLE: "(${{inputs.env}}) The ${{inputs.release_name}} release has failed. GH Issue: ${{steps.create-issue.outputs.number}}"
                 JIRA_TICKET_DESCRIPTION: "The release process ${{inputs.release_name}} in [mongodb/openapi|https://github.com/mongodb/openapi] has failed. Please, look at the [issue-${{steps.create-issue.outputs.number}}|https://github.com/mongodb/openapi/issues/${{steps.create-issue.outputs.number}}] for more details."
+                JIRA_TEAM_ID: ${{ inputs.team_id }}
               run: .github/scripts/create_jira_ticket.sh
             - name: Add comment to GH Issue
               if: ${{ steps.create-issue.outputs.number != null }}

--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -56,5 +56,6 @@ jobs:
     with:
       env: 'dev'
       release_name: "IPA Metrics"
+      team_id: ${{ vars.JIRA_TEAM_ID_APIX_1 }}
     secrets:
       jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -80,5 +80,6 @@ jobs:
     with:
       env: "prod"
       release_name: "FOASCLI"
+      team_id: ${{ vars.JIRA_TEAM_ID_APIX_2 }}
     secrets:
       jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -192,5 +192,6 @@ jobs:
     with:
       env: ${{ inputs.env }}
       release_name: "OpenAPI Spec"
+      team_id: ${{ vars.JIRA_TEAM_ID_APIX_2 }}
     secrets:
       jira_api_token: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
## Proposed changes

- Passing Jira team ID to failure handler to enable setting different teams depending on what failed
- Added variables for IDs to the repo
- APIx 1 used for IPA release, APIx 2 used for OAS and CLI release

_Jira ticket:_ [CLOUDP-300586](https://jira.mongodb.org/browse/CLOUDP-300586)