### PR TITLE
CLOUDP-298233: Postman SA support

### DIFF
--- a/.github/workflows/release-postman.yml
+++ b/.github/workflows/release-postman.yml
@@ -48,8 +48,7 @@ jobs:
           BASE_URL: ${{ inputs.atlas_prod_base_url }}
         working-directory: ./tools/postman
         run: |
-          make transform_collection 
-          make transform_collection_test
+          make transform_collection_js
 
       - name: Upload Collection to Postman
         env:

--- a/tools/postman/collection-description.md
+++ b/tools/postman/collection-description.md
@@ -7,10 +7,27 @@ This collection is an introduction to the [MongoDB Atlas Administration API](htt
 To test out the MongoDB Atlas Admin API collection, start by [creating a free MongoDB Atlas cluster](https://www.mongodb.com/docs/atlas/tutorial/deploy-free-tier-cluster/).  
 Once you have a cluster, you can [fork this collection](https://learning.postman.com/docs/collaborating-in-postman/using-version-control/forking-elements/\#create-a-fork) into your own workspace in order to manage your MongoDB Atlas resources. Make sure to also fork the MongoDB Atlas Administration API Environment at the same time.
 
-Once you have your cluster up and running, follow [this guide](https://www.mongodb.com/docs/atlas/configure-api-access/) to find your public and private API keys. Set each of these values as secrets in the [Postman Vault](https://learning.postman.com/docs/sending-requests/postman-vault/postman-vault-secrets/): 
+### Authentication Using Service Accounts (OAuth)
+
+Once you have your cluster up and running, follow [this guide](https://www.mongodb.com/docs/atlas/configure-api-access/) to create new Service Account.
+Once created copy your public and private API keys.
+Set each of these values as secrets in the [Postman Vault](https://learning.postman.com/docs/sending-requests/postman-vault/postman-vault-secrets/): 
+
+- Service Account Client ID: \`mongodb-public-clientid\`  
+- Service Account Client Secret: \`mongodb-private-clientsecret\`
+
+#### Digest Authentication
+
+Alternatively to Service Account you can use [API Keys](https://www.mongodb.com/docs/atlas/configure-api-access/) authentication.
+Set each of these values as secrets in the [Postman Vault](https://learning.postman.com/docs/sending-requests/postman-vault/postman-vault-secrets/): 
 
 - public API key as the value for a key named \`mongodb-public-api-key\`  
 - private API key as the value for a key named  \`mongodb-private-api-key\`
+
+Additionally to setting those values you would need to manually configure[Digest Authentication in the Collection Authentication Settings](https://learning.postman.com/docs/sending-requests/authorization/digest-auth/)
+
+
+### Using API 
 
 You can now explore the various endpoints. For each endpoint, edit the query and path variables such as group ID and organization ID. For some requests, like POST requests, editing the body of the request is also required. 
 

--- a/tools/postman/scripts/transform-for-api.sh
+++ b/tools/postman/scripts/transform-for-api.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+## NOTE: Use JS script instead.
+## Script is kept only for backwards compatibilty
+
 #########################################################
 # Prepare collection for Postman API
 # Environment variables:
@@ -27,7 +30,6 @@ DESCRIPTION_FILE=${DESCRIPTION_FILE:-"../collection-description.md"}
 
 TOGGLE_INCLUDE_BODY=${TOGGLE_INCLUDE_BODY:-true}
 TOGGLE_ADD_DOCS_LINKS=${TOGGLE_ADD_DOCS_LINKS:-true}
-TOKEN_URL_ENV=${TOKEN_URL_ENV:-""}
 
 current_api_revision=$(<"$OPENAPI_FOLDER/$VERSION_FILE_NAME")
 

--- a/tools/postman/scripts/transform-postman.js
+++ b/tools/postman/scripts/transform-postman.js
@@ -26,7 +26,6 @@ const VERSION_FILE_NAME = process.env.VERSION_FILE_NAME || 'version.txt';
 const DESCRIPTION_FILE = process.env.DESCRIPTION_FILE || './collection-description.md';
 const TOGGLE_INCLUDE_BODY = process.env.TOGGLE_INCLUDE_BODY !== 'false';
 const TOGGLE_ADD_DOCS_LINKS = process.env.TOGGLE_ADD_DOCS_LINKS === 'true';
-const TOKEN_URL_ENV = process.env.TOKEN_URL_ENV || '';
 const BASE_URL = process.env.BASE_URL || '';
 
 // Dedicated transformation for postman collection.json file.
@@ -103,9 +102,21 @@ const transform = () => {
     });
   }
 
-  if (TOKEN_URL_ENV) {
-    console.log(`Adding client credentials auth url variable ${TOKEN_URL_ENV}`);
-    collection.collection.variable.push({ key: 'clientCredentialsTokenUrl', value: TOKEN_URL_ENV });
+  if (collection.collection.auth && collection.collection.auth.oauth2) {
+    collection.collection.auth.oauth2.push[
+      ({
+        key: 'clientSecret',
+        value: '{{vault:mongodb-private-clientsecret}}',
+        type: 'string',
+      },
+      {
+        key: 'clientId',
+        value: '{{vault:mongodb-public-clientid}}',
+        type: 'string',
+      })
+    ];
+  } else {
+    throw 'Failed to add required authentication variables';
   }
 
   saveJsonFile(path.join(TMP_FOLDER, COLLECTION_TRANSFORMED_FILE_NAME), collection);


### PR DESCRIPTION
## Proposed changes
CLOUDP-298233

SA GA changes. Not to be merged. 

## Impact

1. Moved to JS transformation (verified correctness by loading collection into postman.
2. Added missing operations post transformation

## Notes

Cannot be merged before OpenAPI has Service Account listed as first item.
Post merge we should update section in existing blog post: 
https://www.mongodb.com/developer/products/atlas/admin-api-postman/
 

 