### PR TITLE
CLOUDP-301830: Separate private and public preview stability levels in version command for granularity

### DIFF
--- a/tools/cli/internal/apiversion/stabilitylevel.go
+++ b/tools/cli/internal/apiversion/stabilitylevel.go
@@ -1,4 +1,4 @@
-// Copyright 2024 MongoDB Inc
+// Copyright 2025 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/cli/internal/apiversion/stabilitylevel.go
+++ b/tools/cli/internal/apiversion/stabilitylevel.go
@@ -30,7 +30,6 @@ var supportedValues = []string{StableStabilityLevel, PublicPreviewSabilityLevel,
 
 // IsPreviewSabilityLevel checks if the version is a preview version, public or private.
 func IsPreviewSabilityLevel(value string) bool {
-	// we also need string match given private preview versions like "private-preview-<name>"
 	return IsPrivatePreviewSabilityLevel(value) || IsPublicPreviewSabilityLevel(value)
 }
 

--- a/tools/cli/internal/apiversion/stabilitylevel.go
+++ b/tools/cli/internal/apiversion/stabilitylevel.go
@@ -1,0 +1,58 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiversion
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	StableStabilityLevel         = "stable"
+	PreviewStabilityLevel        = "preview"
+	PrivatePreviewStabilityLevel = "private-preview"
+)
+
+var supportedValues = []string{StableStabilityLevel, PreviewStabilityLevel, PrivatePreviewStabilityLevel}
+
+// IsPreviewSabilityLevel checks if the version is a preview version, public or private.
+func IsPreviewSabilityLevel(value string) bool {
+	// we also need string match given private preview versions like "private-preview-<name>"
+	return IsPrivatePreviewSabilityLevel(value) || IsPublicPreviewSabilityLevel(value)
+}
+
+// IsPrivatePreviewSabilityLevel checks if the version is a private preview version.
+func IsPrivatePreviewSabilityLevel(value string) bool {
+	return strings.Contains(value, PrivatePreviewStabilityLevel)
+}
+
+// IsPublicPreviewSabilityLevel checks if the version is a public preview version.
+func IsPublicPreviewSabilityLevel(value string) bool {
+	return strings.EqualFold(value, PreviewStabilityLevel)
+}
+
+// IsStableSabilityLevel checks if the version is a stable version.
+func IsStableSabilityLevel(value string) bool {
+	return strings.EqualFold(value, StableStabilityLevel)
+}
+
+// IsValidStabilityLevel checks if the version is a valid stability level.
+func ValidateStabilityLevel(value string) error {
+	if IsStableSabilityLevel(value) || IsPreviewSabilityLevel(value) {
+		return nil
+	}
+
+	return fmt.Errorf("invalid stability level value must be in %q, got %q", supportedValues, value)
+}

--- a/tools/cli/internal/apiversion/stabilitylevel.go
+++ b/tools/cli/internal/apiversion/stabilitylevel.go
@@ -49,6 +49,7 @@ func IsStableSabilityLevel(value string) bool {
 }
 
 // IsValidStabilityLevel checks if the version is a valid stability level.
+// ValidateStabilityLevel checks if the version is a valid stability level.
 func ValidateStabilityLevel(value string) error {
 	if IsStableSabilityLevel(value) || IsPreviewSabilityLevel(value) {
 		return nil

--- a/tools/cli/internal/apiversion/stabilitylevel.go
+++ b/tools/cli/internal/apiversion/stabilitylevel.go
@@ -23,9 +23,10 @@ const (
 	StableStabilityLevel         = "stable"
 	PreviewStabilityLevel        = "preview"
 	PrivatePreviewStabilityLevel = "private-preview"
+	PublicPreviewSabilityLevel   = "public-preview"
 )
 
-var supportedValues = []string{StableStabilityLevel, PreviewStabilityLevel, PrivatePreviewStabilityLevel}
+var supportedValues = []string{StableStabilityLevel, PublicPreviewSabilityLevel, PrivatePreviewStabilityLevel}
 
 // IsPreviewSabilityLevel checks if the version is a preview version, public or private.
 func IsPreviewSabilityLevel(value string) bool {
@@ -35,12 +36,12 @@ func IsPreviewSabilityLevel(value string) bool {
 
 // IsPrivatePreviewSabilityLevel checks if the version is a private preview version.
 func IsPrivatePreviewSabilityLevel(value string) bool {
-	return strings.Contains(value, PrivatePreviewStabilityLevel)
+	return strings.Contains(strings.ToLower(value), PrivatePreviewStabilityLevel)
 }
 
 // IsPublicPreviewSabilityLevel checks if the version is a public preview version.
 func IsPublicPreviewSabilityLevel(value string) bool {
-	return strings.EqualFold(value, PreviewStabilityLevel)
+	return strings.EqualFold(value, PublicPreviewSabilityLevel) || strings.EqualFold(value, PreviewStabilityLevel)
 }
 
 // IsStableSabilityLevel checks if the version is a stable version.

--- a/tools/cli/internal/apiversion/version.go
+++ b/tools/cli/internal/apiversion/version.go
@@ -32,10 +32,7 @@ type APIVersion struct {
 }
 
 const (
-	dateFormat                   = "2006-01-02"
-	StableStabilityLevel         = "stable"
-	PreviewStabilityLevel        = "preview"
-	PrivatePreviewStabilityLevel = "private-preview"
+	dateFormat = "2006-01-02"
 )
 
 var contentPattern = regexp.MustCompile(`application/vnd\.atlas\.((\d{4})-(\d{2})-(\d{2})|preview)\+(.+)`)
@@ -173,15 +170,6 @@ func (v *APIVersion) IsPrivatePreview() bool {
 
 func (v *APIVersion) IsPublicPreview() bool {
 	return v.IsPreview() && !v.IsPrivatePreview()
-}
-
-func IsPreviewSabilityLevel(value string) bool {
-	// we also need string match given private preview versions like "private-preview-<name>"
-	return strings.EqualFold(value, PreviewStabilityLevel) || strings.Contains(value, PreviewStabilityLevel)
-}
-
-func IsStableSabilityLevel(value string) bool {
-	return strings.EqualFold(value, StableStabilityLevel)
 }
 
 func FindMatchesFromContentType(contentType string) []string {

--- a/tools/cli/internal/apiversion/version.go
+++ b/tools/cli/internal/apiversion/version.go
@@ -104,7 +104,7 @@ func withContent(contentType string) Option {
 // WithFullContent returns an Option to generate a new APIVersion given the contentType and contentValue.
 func WithFullContent(contentType string, contentValue *openapi3.MediaType) Option {
 	return func(v *APIVersion) error {
-		if !IsPreviewSabilityLevel(contentType) {
+		if !strings.Contains(contentType, PreviewStabilityLevel) {
 			return withContent(contentType)(v)
 		}
 

--- a/tools/cli/internal/cli/usage/usage.go
+++ b/tools/cli/internal/cli/usage/usage.go
@@ -37,5 +37,5 @@ const (
 	SlackChannelID      = "Slack Channel ID."
 	From                = "Date in the format YYYY-MM-DD that indicates the start of a date range"
 	To                  = "Date in the format YYYY-MM-DD that indicates the end of a date range"
-	StabilityLevel      = "Stability level related to the API Version. Valid values: [STABLE, PREVIEW]"
+	StabilityLevel      = "Stability level related to the API Version. Valid values: [STABLE, PUBLIC-PREVIEW, PRIVATE-PREVIEW]"
 )

--- a/tools/cli/internal/cli/versions/versions.go
+++ b/tools/cli/internal/cli/versions/versions.go
@@ -70,7 +70,7 @@ func (o *Opts) Run() error {
 }
 
 func (o *Opts) filterStabilityLevelVersions(apiVersions []string) []string {
-	if o.stabilityLevel == nil || len(o.stabilityLevel) == 0 || apiVersions == nil {
+	if len(o.stabilityLevel) == 0 || apiVersions == nil {
 		return apiVersions
 	}
 
@@ -91,6 +91,9 @@ func (o *Opts) filterStabilityLevelVersions(apiVersions []string) []string {
 		}
 	}
 
+	if len(out) == 0 {
+		return []string{}
+	}
 	return out
 }
 
@@ -163,7 +166,7 @@ func Builder() *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.basePath, flag.Spec, flag.SpecShort, "", usage.Spec)
 	cmd.Flags().StringVar(&opts.env, flag.Environment, "", usage.Environment)
-	cmd.Flags().StringArrayP(flag.StabilityLevel, flag.StabilityLevelShort, opts.stabilityLevel, usage.StabilityLevel)
+	cmd.Flags().StringArrayVar(&opts.stabilityLevel, flag.StabilityLevel, nil, usage.StabilityLevel)
 	cmd.Flags().StringVarP(&opts.outputPath, flag.Output, flag.OutputShort, "", usage.Output)
 	cmd.Flags().StringVarP(&opts.format, flag.Format, flag.FormatShort, "json", usage.Format)
 	return cmd

--- a/tools/cli/internal/cli/versions/versions_test.go
+++ b/tools/cli/internal/cli/versions/versions_test.go
@@ -82,7 +82,7 @@ func TestVersion_RunStabilityLevelPreviewAndPrivatePreview(t *testing.T) {
 		outputPath:     "foas.json",
 		fs:             fs,
 		env:            "staging",
-		stabilityLevel: "PREVIEW",
+		stabilityLevel: []string{"PREVIEW"},
 	}
 
 	require.NoError(t, opts.Run())
@@ -102,7 +102,7 @@ func TestVersion_PreviewAndPublicPreview(t *testing.T) {
 		outputPath:     "foas.json",
 		fs:             fs,
 		env:            "staging",
-		stabilityLevel: "PREVIEW",
+		stabilityLevel: []string{"private-preview", "public-preview"},
 	}
 
 	require.NoError(t, opts.Run())
@@ -122,7 +122,7 @@ func TestVersion_RunStabilityLevelStable(t *testing.T) {
 		outputPath:     "foas.json",
 		fs:             fs,
 		env:            "staging",
-		stabilityLevel: "STABLE",
+		stabilityLevel: []string{"STABLE"},
 	}
 
 	require.NoError(t, opts.Run())
@@ -189,18 +189,18 @@ func TestVersion_PreRun(t *testing.T) {
 			basePath:       "base",
 			outputPath:     "output.yaml",
 			format:         "yaml",
-			stabilityLevel: "invalid",
+			stabilityLevel: []string{"invalid"},
 		}
 		err := opts.PreRunE(nil)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "stability level must be")
+		assert.Contains(t, err.Error(), "invalid stability level value m")
 	})
 	t.Run("ValidStabilityLevelPreview", func(t *testing.T) {
 		opts := &Opts{
 			basePath:       "base",
 			outputPath:     "output.yaml",
 			format:         "yaml",
-			stabilityLevel: "preview",
+			stabilityLevel: []string{"PREVIEW"},
 		}
 		err := opts.PreRunE(nil)
 		require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestVersion_PreRun(t *testing.T) {
 			basePath:       "base",
 			outputPath:     "output.yaml",
 			format:         "yaml",
-			stabilityLevel: "PREVIEW",
+			stabilityLevel: []string{"PREVIEW"},
 		}
 		err := opts.PreRunE(nil)
 		require.NoError(t, err)

--- a/tools/cli/internal/cli/versions/versions_test.go
+++ b/tools/cli/internal/cli/versions/versions_test.go
@@ -82,7 +82,7 @@ func TestVersion_RunStabilityLevelPreviewAndPrivatePreview(t *testing.T) {
 		outputPath:     "foas.json",
 		fs:             fs,
 		env:            "staging",
-		stabilityLevel: []string{"PREVIEW"},
+		stabilityLevel: []string{"private-preview"},
 	}
 
 	require.NoError(t, opts.Run())
@@ -102,7 +102,7 @@ func TestVersion_PreviewAndPublicPreview(t *testing.T) {
 		outputPath:     "foas.json",
 		fs:             fs,
 		env:            "staging",
-		stabilityLevel: []string{"private-preview", "public-preview"},
+		stabilityLevel: []string{"public-preview"},
 	}
 
 	require.NoError(t, opts.Run())


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-301830

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
