### PR TITLE
fix: update changelog release process to avoid using preview version

### DIFF
--- a/.github/scripts/generate_changelog.sh
+++ b/.github/scripts/generate_changelog.sh
@@ -11,7 +11,7 @@ mkdir -p changelog/revision
 cp openapi/v2/openapi-*.json changelog/revision/
 
 echo "Generating revision metadata file"
-revision_version=$(< openapi/v2/versions.json jq -r '.[]' | paste -sd ',' -)
+revision_version=$(< openapi/v2/versions.json jq -r '.[]' | paste -sd ',' - | sed "s/,preview//")
 RELEASE_SHA=$(< foas-metadata.json jq -r '.services[] | select(.name=="mms") | .sha')
 foascli changelog metadata create --sha "${RELEASE_SHA}" --versions="${revision_version}" > changelog/revision/metadata.json
 cat changelog/revision/metadata.json


### PR DESCRIPTION
## Proposed changes

This PR fixes the [error](https://github.com/mongodb/openapi/actions/runs/13453516296/job/37592561455#step:10:14) in the changelog release process:

```
Step 1: Preparing revision folder....
Generating revision metadata file
Error: invalid version date: parsing time "preview" as "2006-01-02": cannot parse "preview" as "2006". Make sure to use the format YYYY-MM-DD
Error: Process completed with exit code 1.
```