### PR TITLE
CLOUDP-301107: move the private preview folder under v2 and generate the version.json for private preview APIs

### DIFF
--- a/.github/scripts/split_spec.sh
+++ b/.github/scripts/split_spec.sh
@@ -13,7 +13,10 @@ foascli split -s openapi-foas.yaml --env "${target_env:?}" -o ./openapi/v2/opena
 mv -f "openapi-foas.yaml" "./openapi/v2.yaml"
 
 # Create folder if it does not exist
-mkdir -p ./openapi/private
+mkdir -p ./openapi/v2/private
 
 echo "Moving preview files to preview and private-preview folder"
-find ./openapi/v2 -type f -name "*private-preview*" -exec mv -f {} ./openapi/private/ \;
+find ./openapi/v2 -type f -name "*private-preview*" -exec mv -f {} ./openapi/v2/private/ \;
+
+# Generate the versions.json file for private preview APIs
+foascli versions --spec openapi-foas.json --stability-level PRIVATE-PREVIEW -o ./openapi/v2/private/versions.json

--- a/tools/cli/versions.json
+++ b/tools/cli/versions.json
@@ -1,3 +1,0 @@
-[
-  "private-preview-version-resource"
-]

--- a/tools/cli/versions.json
+++ b/tools/cli/versions.json
@@ -1,0 +1,3 @@
+[
+  "private-preview-version-resource"
+]


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [CLOUDP-301107](https://jira.mongodb.org/browse/CLOUDP-301107)


This PR updates the private preview release logic to generate the version.json file and move the private preview specs under v2/private