### PR TITLE
CLOUDP-225860: Add support for sha in split command

### DIFF
--- a/tools/cli/internal/cli/split/split.go
+++ b/tools/cli/internal/cli/split/split.go
@@ -35,6 +35,7 @@ type Opts struct {
 	outputPath string
 	env        string
 	format     string
+	gitSha     string
 }
 
 func (o *Opts) Run() error {
@@ -53,6 +54,12 @@ func (o *Opts) Run() error {
 		filteredOAS, err := o.filter(specInfo.Spec, version)
 		if err != nil {
 			return err
+		}
+
+		if o.gitSha != "" {
+			filteredOAS.Info.Extensions = map[string]any{
+				"x-xgen-sha": o.gitSha,
+			}
 		}
 
 		if err := o.saveVersionedOas(filteredOAS, version); err != nil {
@@ -130,6 +137,7 @@ func Builder() *cobra.Command {
 	cmd.Flags().StringVar(&opts.env, flag.Environment, "", usage.Environment)
 	cmd.Flags().StringVarP(&opts.outputPath, flag.Output, flag.OutputShort, "", usage.Output)
 	cmd.Flags().StringVarP(&opts.format, flag.Format, flag.FormatShort, openapi.JSON, usage.Format)
+	cmd.Flags().StringVar(&opts.gitSha, flag.GitSha, "", usage.GitSha)
 
 	_ = cmd.MarkFlagRequired(flag.Output)
 

--- a/tools/cli/internal/cli/split/split_test.go
+++ b/tools/cli/internal/cli/split/split_test.go
@@ -115,6 +115,26 @@ func TestSplitMulitplePreviewsRun(t *testing.T) {
 	require.Contains(t, info.Spec.Paths.Map(), "/api/atlas/v2/groups/{groupId}/serviceAccounts")
 }
 
+func TestInjectSha_Run(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	opts := &Opts{
+		basePath:   "../../../test/data/base_spec.json",
+		outputPath: "foas.yaml",
+		fs:         fs,
+		gitSha:     "123456",
+	}
+
+	if err := opts.Run(); err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+
+	result, err := loadRunResultOas(fs, "foas-2023-01-01.yaml")
+	require.NoError(t, err)
+	// check sha
+	require.Contains(t, result.Spec.Info.Extensions, "x-xgen-sha")
+	require.Equal(t, "123456", result.Spec.Info.Extensions["x-xgen-sha"])
+}
+
 func TestOpts_PreRunE(t *testing.T) {
 	testCases := []struct {
 		wantErr  require.ErrorAssertionFunc


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-225860
<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

Closes #[issue number]

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [x] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
