### PR TITLE
CLOUDP-301224: Generate README with IPA rules

### DIFF
--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -87,6 +87,14 @@ jobs:
       - name: Run ESLint on JS files
         run: |
           npm run lint-js
+      - name: Check IPA docs up-to-date
+        run: |
+          npm run gen-ipa-docs
+          if [ -n $(git status --porcelain) ]; then
+            echo "IPA docs not up to date, please run 'npm run gen-ipa-docs' and commit the changes"
+            exit 1
+          fi
+          exit 0
       - name: Install Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
         with:

--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Check IPA docs up-to-date
         run: |
           npm run gen-ipa-docs
-          if [ -n $(git status --porcelain) ]; then
+          if [[ -n $(git status --porcelain) ]]; then
             echo "IPA docs not up to date, please run 'npm run gen-ipa-docs' and commit the changes"
             exit 1
           fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "apache-arrow": "^19.0.0",
                 "dotenv": "^16.4.7",
                 "eslint-plugin-jest": "^28.10.0",
+                "markdown-table": "^3.0.4",
                 "openapi-to-postmanv2": "4.25.0",
                 "parquet-wasm": "^0.6.1"
             },
@@ -30,6 +31,9 @@
                 "globals": "^15.14.0",
                 "jest": "^29.7.0",
                 "prettier": "3.5.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -8875,6 +8879,15 @@
             "resolved": "https://registry.npmjs.org/markdown-escape/-/markdown-escape-2.0.0.tgz",
             "integrity": "sha512-Trz4v0+XWlwy68LJIyw3bLbsJiC8XAbRCKF9DbEtZjyndKOGVx6n+wNB0VfoRmY2LKboQLeniap3xrb6LGSJ8A==",
             "license": "MIT"
+        },
+        "node_modules/markdown-table": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "format": "npx prettier . --write",
         "format-check": "npx prettier . --check",
         "lint-js": "npx eslint **/*.js",
+        "gen-ipa-docs": "node tools/spectral/ipa/scripts/generateRulesetReadme.js",
         "ipa-validation": "spectral lint ./openapi/v2.yaml --ruleset=./tools/spectral/ipa/ipa-spectral.yaml",
         "test": "jest"
     },
@@ -28,6 +29,7 @@
         "apache-arrow": "^19.0.0",
         "dotenv": "^16.4.7",
         "eslint-plugin-jest": "^28.10.0",
+        "markdown-table": "^3.0.4",
         "openapi-to-postmanv2": "4.25.0",
         "parquet-wasm": "^0.6.1"
     },

--- a/tools/spectral/ipa/metrics/metricCollection.js
+++ b/tools/spectral/ipa/metrics/metricCollection.js
@@ -3,10 +3,9 @@ import {
   extractTeamOwnership,
   getSeverityPerRule,
   loadCollectorResults,
-  loadOpenAPIFile,
-  loadRuleset,
   merge,
 } from './utils/metricCollectionUtils.js';
+import { loadJsonFile, loadRuleset } from '../utils.js';
 
 export async function runMetricCollectionJob(
   {
@@ -18,7 +17,7 @@ export async function runMetricCollectionJob(
 ) {
   try {
     console.log(`Loading OpenAPI file: ${oasFilePath}`);
-    const oasContent = loadOpenAPIFile(oasFilePath);
+    const oasContent = loadJsonFile(oasFilePath);
 
     console.log('Extracting team ownership data...');
     const ownershipData = extractTeamOwnership(oasContent);

--- a/tools/spectral/ipa/metrics/utils/metricCollectionUtils.js
+++ b/tools/spectral/ipa/metrics/utils/metricCollectionUtils.js
@@ -1,15 +1,5 @@
-import fs from 'node:fs';
-import { bundleAndLoadRuleset } from '@stoplight/spectral-ruleset-bundler/with-loader';
 import { EntryType } from '../collector.js';
-
-export function loadOpenAPIFile(filePath) {
-  try {
-    const content = fs.readFileSync(filePath, 'utf8');
-    return JSON.parse(content);
-  } catch (error) {
-    throw new Error(`Failed to load OpenAPI file: ${error.message}`);
-  }
-}
+import { loadJsonFile } from '../../utils.js';
 
 export function getSeverityPerRule(ruleset) {
   const rules = ruleset.rules || {};
@@ -18,16 +8,6 @@ export function getSeverityPerRule(ruleset) {
     map[name] = ruleObject.definition.severity;
   }
   return map;
-}
-
-export async function loadRuleset(rulesetPath, spectral) {
-  try {
-    const ruleset = await bundleAndLoadRuleset(rulesetPath, { fs, fetch });
-    await spectral.setRuleset(ruleset);
-    return ruleset;
-  } catch (error) {
-    throw new Error(`Failed to load ruleset: ${error.message}`);
-  }
 }
 
 export function extractTeamOwnership(oasContent) {
@@ -53,15 +33,14 @@ export function extractTeamOwnership(oasContent) {
 
 export function loadCollectorResults(collectorResultsFilePath) {
   try {
-    const content = fs.readFileSync(collectorResultsFilePath, 'utf8');
-    const contentParsed = JSON.parse(content);
+    const content = loadJsonFile(collectorResultsFilePath);
     return {
-      [EntryType.VIOLATION]: contentParsed[EntryType.VIOLATION],
-      [EntryType.ADOPTION]: contentParsed[EntryType.ADOPTION],
-      [EntryType.EXCEPTION]: contentParsed[EntryType.EXCEPTION],
+      [EntryType.VIOLATION]: content[EntryType.VIOLATION],
+      [EntryType.ADOPTION]: content[EntryType.ADOPTION],
+      [EntryType.EXCEPTION]: content[EntryType.EXCEPTION],
     };
   } catch (error) {
-    throw new Error(`Failed to load Collector Results file: ${error.message}`);
+    throw new Error(`Failed to parse Collector Results: ${error.message}`);
   }
 }
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -1,0 +1,48 @@
+<!--- NOTE: This README file is generated, please see /scripts/generateRulesetReadme.js --->
+
+# IPA Validation Rules
+
+All Spectral rules used in the IPA validation are defined in rulesets grouped by IPA number (`IPA-XXX.yaml`). These rulesets are imported into the main IPA ruleset [ipa-spectral.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/ipa-spectral.yaml) which is used for running the validation.
+
+## Rulesets
+
+The tables below lists all available rules, their descriptions and severity level.
+
+### IPA-005
+
+| Rule Name                               | Description                                                              | Severity |
+| --------------------------------------- | ------------------------------------------------------------------------ | -------- |
+| xgen-IPA-005-exception-extension-format | IPA exception extensions must follow the correct format. http://go/ipa/5 | warn     |
+
+### IPA-102
+
+| Rule Name                                            | Description                                                                      | Severity |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------- | -------- |
+| xgen-IPA-102-path-alternate-resource-name-path-param | Paths should alternate between resource names and path params. http://go/ipa/102 | warn     |
+
+### IPA-104
+
+| Rule Name                     | Description                                                     | Severity |
+| ----------------------------- | --------------------------------------------------------------- | -------- |
+| xgen-IPA-104-resource-has-GET | APIs must provide a get method for resources. http://go/ipa/104 | warn     |
+
+### IPA-109
+
+| Rule Name                                      | Description                                                               | Severity |
+| ---------------------------------------------- | ------------------------------------------------------------------------- | -------- |
+| xgen-IPA-109-custom-method-must-be-GET-or-POST | The HTTP method for custom methods must be GET or POST. http://go/ipa/109 | warn     |
+| xgen-IPA-109-custom-method-must-use-camel-case | The custom method must use camelCase format. http://go/ipa/109            | warn     |
+
+### IPA-113
+
+| Rule Name                               | Description                                                                                 | Severity |
+| --------------------------------------- | ------------------------------------------------------------------------------------------- | -------- |
+| xgen-IPA-113-singleton-must-not-have-id | Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113 | warn     |
+
+### IPA-123
+
+| Rule Name                                         | Description                                             | Severity |
+| ------------------------------------------------- | ------------------------------------------------------- | -------- |
+| xgen-IPA-123-enum-values-must-be-upper-snake-case | Enum values must be UPPER_SNAKE_CASE. http://go/ipa/123 | warn     |
+
+

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -10,11 +10,15 @@ The tables below lists all available rules, their descriptions and severity leve
 
 ### IPA-005
 
+For rule definitions, see [IPA-005.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-005.yaml).
+
 | Rule Name                               | Description                                                              | Severity |
 | --------------------------------------- | ------------------------------------------------------------------------ | -------- |
 | xgen-IPA-005-exception-extension-format | IPA exception extensions must follow the correct format. http://go/ipa/5 | warn     |
 
 ### IPA-102
+
+For rule definitions, see [IPA-102.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-102.yaml).
 
 | Rule Name                                            | Description                                                                      | Severity |
 | ---------------------------------------------------- | -------------------------------------------------------------------------------- | -------- |
@@ -22,11 +26,15 @@ The tables below lists all available rules, their descriptions and severity leve
 
 ### IPA-104
 
+For rule definitions, see [IPA-104.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-104.yaml).
+
 | Rule Name                     | Description                                                     | Severity |
 | ----------------------------- | --------------------------------------------------------------- | -------- |
 | xgen-IPA-104-resource-has-GET | APIs must provide a get method for resources. http://go/ipa/104 | warn     |
 
 ### IPA-109
+
+For rule definitions, see [IPA-109.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-109.yaml).
 
 | Rule Name                                      | Description                                                               | Severity |
 | ---------------------------------------------- | ------------------------------------------------------------------------- | -------- |
@@ -35,11 +43,15 @@ The tables below lists all available rules, their descriptions and severity leve
 
 ### IPA-113
 
+For rule definitions, see [IPA-113.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-113.yaml).
+
 | Rule Name                               | Description                                                                                 | Severity |
 | --------------------------------------- | ------------------------------------------------------------------------------------------- | -------- |
 | xgen-IPA-113-singleton-must-not-have-id | Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113 | warn     |
 
 ### IPA-123
+
+For rule definitions, see [IPA-123.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-123.yaml).
 
 | Rule Name                                         | Description                                             | Severity |
 | ------------------------------------------------- | ------------------------------------------------------- | -------- |

--- a/tools/spectral/ipa/scripts/generateRulesetReadme.js
+++ b/tools/spectral/ipa/scripts/generateRulesetReadme.js
@@ -22,7 +22,6 @@ fs.writeFile(readmeFilePath, fileContent, (error) => {
     console.error('Error while generating the IPA rulesets README.md:', error);
     process.exit(1);
   }
-  console.log('Successfully updated the IPA rulesets README.md');
 });
 
 async function getRulesetsSection() {

--- a/tools/spectral/ipa/scripts/generateRulesetReadme.js
+++ b/tools/spectral/ipa/scripts/generateRulesetReadme.js
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import spectral from '@stoplight/spectral-core';
+import { markdownTable } from 'markdown-table';
+import { loadRuleset } from '../metrics/utils/metricCollectionUtils.js';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const readmeFilePath = path.join(dirname, '../rulesets', 'README.md');
+
+const rulesetsSection = await getRulesetsSection();
+
+const fileContent =
+  '<!--- NOTE: This README file is generated, please see /scripts/generateRulesetReadme.js --->\n\n' +
+  '# IPA Validation Rules\n\n' +
+  'All Spectral rules used in the IPA validation are defined in rulesets grouped by IPA number (`IPA-XXX.yaml`). These rulesets are imported into the main IPA ruleset [ipa-spectral.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/ipa-spectral.yaml) which is used for running the validation.\n\n' +
+  `${rulesetsSection}` +
+  '\n';
+
+fs.writeFile(readmeFilePath, fileContent, (error) => {
+  if (error) {
+    console.error('Error while generating the IPA rulesets README.md:', error);
+    process.exit(1);
+  }
+  console.log('Successfully updated the IPA rulesets README.md');
+});
+
+async function getRulesetsSection() {
+  let content =
+    '## Rulesets\n\n' + 'The tables below lists all available rules, their descriptions and severity level.\n\n';
+
+  const rules = await getAllRules();
+  const ruleNames = Object.keys(rules);
+  const ipaNumbers = getIpaNumbers(ruleNames);
+
+  ipaNumbers.forEach((ipaNumber) => {
+    const ipaRules = filterRulesByIpaNumber(ipaNumber, rules);
+    const table = generateRulesetTable(ipaRules);
+    content += `### ${ipaNumber}\n\n` + `${table}\n\n`;
+  });
+
+  return content;
+}
+
+function generateRulesetTable(rules) {
+  const table = [['Rule Name', 'Description', 'Severity']];
+  const tableRows = [];
+
+  const ruleNames = Object.keys(rules);
+  ruleNames.forEach((ruleName) => {
+    const rule = rules[ruleName];
+    tableRows.push([ruleName, rule.description, rule.definition.severity]);
+  });
+
+  tableRows.sort(sortBySeverity);
+  tableRows.forEach((row) => table.push(row));
+  return markdownTable(table);
+}
+
+async function getAllRules() {
+  const rulesetFilePath = path.join(dirname, '..', 'ipa-spectral.yaml');
+  const { Spectral } = spectral;
+  const ruleset = await loadRuleset(rulesetFilePath, new Spectral());
+  return ruleset.rules;
+}
+
+function getIpaNumbers(ruleNames) {
+  const ipaNumbers = [];
+  ruleNames.forEach((name) => {
+    const ipaName = name.substring(5, 12);
+    if (!ipaNumbers.includes(ipaName)) {
+      ipaNumbers.push(ipaName);
+    }
+  });
+  return ipaNumbers.sort();
+}
+
+function filterRulesByIpaNumber(ipaNumber, rules) {
+  return Object.keys(rules)
+    .filter((key) => key.includes(ipaNumber))
+    .reduce((obj, key) => {
+      return {
+        ...obj,
+        [key]: rules[key],
+      };
+    }, {});
+}
+
+function sortBySeverity(a, b) {
+  if (a[2] < b[2]) {
+    return -1;
+  } else if (a[2] > b[2]) {
+    return 1;
+  }
+  return 0;
+}

--- a/tools/spectral/ipa/scripts/generateRulesetReadme.js
+++ b/tools/spectral/ipa/scripts/generateRulesetReadme.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import spectral from '@stoplight/spectral-core';
 import { markdownTable } from 'markdown-table';
-import { loadRuleset } from '../metrics/utils/metricCollectionUtils.js';
+import { loadRuleset } from '../utils.js';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const readmeFilePath = path.join(dirname, '../rulesets', 'README.md');

--- a/tools/spectral/ipa/scripts/generateRulesetReadme.js
+++ b/tools/spectral/ipa/scripts/generateRulesetReadme.js
@@ -35,7 +35,8 @@ async function getRulesetsSection() {
   ipaNumbers.forEach((ipaNumber) => {
     const ipaRules = filterRulesByIpaNumber(ipaNumber, rules);
     const table = generateRulesetTable(ipaRules);
-    content += `### ${ipaNumber}\n\n` + `${table}\n\n`;
+    content +=
+      `### ${ipaNumber}\n\n` + `For rule definitions, see ${getIpaRulesetUrl(ipaNumber)}.\n\n` + `${table}\n\n`;
   });
 
   return content;
@@ -72,6 +73,10 @@ function getIpaNumbers(ruleNames) {
     }
   });
   return ipaNumbers.sort();
+}
+
+function getIpaRulesetUrl(ipaNumber) {
+  return `[${ipaNumber}.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/${ipaNumber}.yaml)`;
 }
 
 function filterRulesByIpaNumber(ipaNumber, rules) {

--- a/tools/spectral/ipa/utils.js
+++ b/tools/spectral/ipa/utils.js
@@ -1,0 +1,21 @@
+import { bundleAndLoadRuleset } from '@stoplight/spectral-ruleset-bundler/with-loader';
+import fs from 'node:fs';
+
+export async function loadRuleset(rulesetPath, spectral) {
+  try {
+    const ruleset = await bundleAndLoadRuleset(rulesetPath, { fs, fetch });
+    await spectral.setRuleset(ruleset);
+    return ruleset;
+  } catch (error) {
+    throw new Error(`Failed to load ruleset: ${error.message}`);
+  }
+}
+
+export function loadJsonFile(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(content);
+  } catch (error) {
+    throw new Error(`Failed to load file: ${error.message}`);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Adds a script to generate a README file in `tools/spectral/ipa/rulesets`. The file shows tables of all available rules (based on the `ipa-spectral.yaml` ruleset), and can be automatically updated when a new rule is added to the IPA validation by running:

```
npm run gen-ipa-docs
```

Also, a test is added to fail if the file is not updated, it looks like this when failed:

<img width="1323" alt="Screenshot 2025-02-24 at 17 32 19" src="https://github.com/user-attachments/assets/d4fb3e3e-b8d9-49f6-868d-5f64e46a9c53" />

_Jira ticket:_ [CLOUDP-301224](https://jira.mongodb.org/browse/CLOUDP-301224)
