### PR TITLE
fix: add JIRA_TEAM_ID to Send a Slack Notification for APIs importantevents

### DIFF
--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -71,6 +71,7 @@ jobs:
         if: steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis != null
         env:
           JIRA_API_TOKEN: ${{ secrets.jira_api_token }}
+          JIRA_TEAM_ID: ${{ vars.JIRA_TEAM_ID_APIX_2}}
           JIRA_TICKET_TITLE: "Some APIs are approaching their sunset date in the next 3 months. ID: ${{steps.retrieve-sunset-apis.outputs.hash_code_sunset_apis}}"
         run: |
           sunset_apis=$(sed 's/"/\\"/g' sunset_apis.json)


### PR DESCRIPTION


## Proposed changes
GH action is failing https://github.com/mongodb/openapi/actions/runs/13627045581/job/38086419558#step:6:170 with the error:
```log
.github/scripts/create_jira_ticket.sh: line 79: JIRA_TEAM_ID: parameter null or not set
```