### PR TITLE
CLOUDP-304055: IPA-106 Create: The request should be a Request suffixed object

### DIFF
--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -129,25 +129,25 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
     errors: [
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
         path: ['paths', '/resource2', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
         path: ['paths', '/resource2', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        message: 'The response body schema is defined inline and must reference a predefined schema. http://go/ipa/106',
         path: ['paths', '/resource3', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -93,19 +93,6 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
             },
           },
         },
-        '/resource/{id}': {
-          post: {
-            requestBody: {
-              content: {
-                'application/vnd.atlas.2023-01-01+json': {
-                  schema: {
-                    $ref: '#/components/schemas/Schema',
-                  },
-                },
-              },
-            },
-          },
-        },
         '/resource2': {
           post: {
             requestBody: {
@@ -124,6 +111,19 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
             },
           },
         },
+        '/resource3': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    type: "object",
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     },
     errors: [
@@ -136,12 +136,6 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
         message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
-        path: ['paths', '/resource/{id}', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
         path: ['paths', '/resource2', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
@@ -149,6 +143,12 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
         message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
         path: ['paths', '/resource2', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
+        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        path: ['paths', '/resource3', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -166,9 +166,49 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
                   schema: {
                     $ref: '#/components/schemas/Schema',
                   },
+                  'x-xgen-IPA-exception': {
+                    'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',
+                  },
                 },
-                'x-xgen-IPA-exception': {
-                  'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',
+              },
+            },
+          },
+        },
+        '/resource/{id}': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                  'x-xgen-IPA-exception': {
+                    'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resource2': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                  'x-xgen-IPA-exception': {
+                    'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',
+                  },
+                },
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                  'x-xgen-IPA-exception': {
+                    'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',
+                  },
                 },
               },
             },

--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -174,22 +174,6 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
             },
           },
         },
-        '/resource/{id}': {
-          post: {
-            requestBody: {
-              content: {
-                'application/vnd.atlas.2023-01-01+json': {
-                  schema: {
-                    $ref: '#/components/schemas/Schema',
-                  },
-                  'x-xgen-IPA-exception': {
-                    'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',
-                  },
-                },
-              },
-            },
-          },
-        },
         '/resource2': {
           post: {
             requestBody: {
@@ -205,6 +189,22 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
                 'application/vnd.atlas.2024-01-01+json': {
                   schema: {
                     $ref: '#/components/schemas/Schema',
+                  },
+                  'x-xgen-IPA-exception': {
+                    'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resource3': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    type: "object",
                   },
                   'x-xgen-IPA-exception': {
                     'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',

--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -1,0 +1,181 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+const componentSchemas = {
+  schemas: {
+    SchemaRequest: {
+      type: 'object',
+    },
+    Schema: {
+      type: 'object',
+    },
+  },
+};
+testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
+  {
+    name: 'valid methods',
+    document: {
+      components: componentSchemas,
+      paths: {
+        '/resource': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/SchemaRequest',
+                  },
+                },
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/SchemaRequest',
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resource/{id}': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/SchemaRequest',
+                  },
+                },
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/SchemaRequest',
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resource/{id}:customMethod': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/SchemaRequest',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid methods',
+    document: {
+      components: componentSchemas,
+      paths: {
+        '/resource': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resource/{id}': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resource2': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
+        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
+        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        path: ['paths', '/resource/{id}', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
+        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        path: ['paths', '/resource2', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
+        message: 'Response body for the Create method should refer to Request suffixed schema. http://go/ipa/106',
+        path: ['paths', '/resource2', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid method with exception',
+    document: {
+      components: componentSchemas,
+      paths: {
+        '/resource': {
+          post: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2023-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -117,7 +117,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
               content: {
                 'application/vnd.atlas.2023-01-01+json': {
                   schema: {
-                    type: "object",
+                    type: 'object',
                   },
                 },
               },
@@ -204,7 +204,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
               content: {
                 'application/vnd.atlas.2023-01-01+json': {
                   schema: {
-                    type: "object",
+                    type: 'object',
                   },
                   'x-xgen-IPA-exception': {
                     'xgen-IPA-106-create-method-request-body-is-request-suffixed-object': 'reason',

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -5,6 +5,7 @@ extends:
   - ./rulesets/IPA-109.yaml
   - ./rulesets/IPA-113.yaml
   - ./rulesets/IPA-123.yaml
+  - ./rulesets/IPA-106.yaml
 
 overrides:
   - files:

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -11,4 +11,5 @@ rules:
     severity: warn
     given: '$.paths[*].post.requestBody.content'
     then:
+      field: '@key'
       function: 'createMethodRequestBodyIsRequestSuffixedObject'

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -1,0 +1,14 @@
+# IPA-104: Create
+# http://go/ipa/106
+
+functions:
+  - createMethodRequestBodyIsRequestSuffixedObject
+
+rules:
+  xgen-IPA-106-create-method-request-body-is-request-suffixed-object:
+    description: 'The Create method request should be a Request suffixed object. http://go/ipa/106'
+    message: '{{error}} http://go/ipa/106'
+    severity: warn
+    given: '$.paths[*].post.requestBody.content'
+    then:
+      function: 'createMethodRequestBodyIsRequestSuffixedObject'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -34,6 +34,14 @@ For rule definitions, see [IPA-104.yaml](https://github.com/mongodb/openapi/blob
 | xgen-IPA-104-get-method-returns-single-resource | The purpose of the get method is to return data from a single resource. http://go/ipa/104 | warn     |
 | xgen-IPA-104-get-method-response-code-is-200    | The Get method must return a 200 OK response. http://go/ipa/104                           | warn     |
 
+### IPA-106
+
+For rule definitions, see [IPA-106.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-106.yaml).
+
+| Rule Name                                                          | Description                                                                      | Severity |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------- | -------- |
+| xgen-IPA-106-create-method-request-body-is-request-suffixed-object | The Create method request should be a Request suffixed object. http://go/ipa/106 | warn     |
+
 ### IPA-109
 
 For rule definitions, see [IPA-109.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-109.yaml).

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -66,5 +66,3 @@ For rule definitions, see [IPA-123.yaml](https://github.com/mongodb/openapi/blob
 | Rule Name                                         | Description                                             | Severity |
 | ------------------------------------------------- | ------------------------------------------------------- | -------- |
 | xgen-IPA-123-enum-values-must-be-upper-snake-case | Enum values must be UPPER_SNAKE_CASE. http://go/ipa/123 | warn     |
-
-

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -66,3 +66,5 @@ For rule definitions, see [IPA-123.yaml](https://github.com/mongodb/openapi/blob
 | Rule Name                                         | Description                                             | Severity |
 | ------------------------------------------------- | ------------------------------------------------------- | -------- |
 | xgen-IPA-123-enum-values-must-be-upper-snake-case | Enum values must be UPPER_SNAKE_CASE. http://go/ipa/123 | warn     |
+
+

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
@@ -4,7 +4,8 @@ import { isCustomMethod } from './utils/resourceEvaluation.js';
 import { resolveObject } from './utils/componentUtils.js';
 
 const RULE_NAME = 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object';
-const ERROR_MESSAGE = 'Response body for the Create method should refer to Request suffixed schema.';
+const ERROR_MESSAGE_SCHEMA_NAME = 'The response body schema must reference a schema with a Request suffix.';
+const ERROR_MESSAGE_SCHEMA_REF = 'The response body schema is defined inline and must reference a predefined schema.';
 
 export default (input, _, { path, documentInventory }) => {
   const oas = documentInventory.unresolved;
@@ -24,11 +25,11 @@ export default (input, _, { path, documentInventory }) => {
   if (contentPerMediaType.schema) {
     const schema = contentPerMediaType.schema;
     if(!schema.$ref) {
-      return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
+      return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE_SCHEMA_REF);
     }
 
     if (!schema.$ref.endsWith('Request')) {
-      return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
+      return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE_SCHEMA_NAME);
     }
   }
 

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
@@ -1,0 +1,41 @@
+import { hasException } from './utils/exceptions.js';
+import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { isCustomMethod } from './utils/resourceEvaluation.js';
+import { resolveObject } from './utils/componentUtils.js';
+
+const RULE_NAME = 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object';
+const ERROR_MESSAGE = 'Response body for the Create method should refer to Request suffixed schema.';
+
+export default (input, _, { path, documentInventory }) => {
+  const oas = documentInventory.unresolved;
+  const resourcePath = path[1];
+  if (isCustomMethod(resourcePath)) {
+    return;
+  }
+
+  const content = resolveObject(oas, path);
+  if (hasException(content, RULE_NAME)) {
+    collectException(content, RULE_NAME, path);
+    return;
+  }
+
+  const errors = [];
+  for (const mediaType in content) {
+    const media = content[mediaType];
+    if (media.schema) {
+      const schema = media.schema;
+      if (schema.$ref && !schema.$ref.endsWith('Request')) {
+        errors.push({
+          path: path.concat(mediaType),
+          message: `${ERROR_MESSAGE}`,
+        });
+      }
+    }
+  }
+
+  if (errors.length === 0) {
+    collectAdoption(path, RULE_NAME);
+  } else {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+};

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
@@ -9,33 +9,27 @@ const ERROR_MESSAGE = 'Response body for the Create method should refer to Reque
 export default (input, _, { path, documentInventory }) => {
   const oas = documentInventory.unresolved;
   const resourcePath = path[1];
+
   if (isCustomMethod(resourcePath)) {
     return;
   }
 
-  const content = resolveObject(oas, path);
-  if (hasException(content, RULE_NAME)) {
-    collectException(content, RULE_NAME, path);
+  const contentPerMediaType = resolveObject(oas, path);
+
+  if (hasException(contentPerMediaType, RULE_NAME)) {
+    collectException(contentPerMediaType, RULE_NAME, path);
     return;
   }
 
-  const errors = [];
-  for (const mediaType in content) {
-    const media = content[mediaType];
-    if (media.schema) {
-      const schema = media.schema;
-      if (schema.$ref && !schema.$ref.endsWith('Request')) {
-        errors.push({
-          path: path.concat(mediaType),
-          message: `${ERROR_MESSAGE}`,
-        });
-      }
+  if (contentPerMediaType.schema) {
+    const schema = contentPerMediaType.schema;
+    if (schema.$ref && !schema.$ref.endsWith('Request')) {
+      return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
+    }
+    if(!schema.$ref) {
+      return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
     }
   }
 
-  if (errors.length === 0) {
-    collectAdoption(path, RULE_NAME);
-  } else {
-    return collectAndReturnViolation(path, RULE_NAME, errors);
-  }
+  collectAdoption(path, RULE_NAME);
 };

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
@@ -24,7 +24,7 @@ export default (input, _, { path, documentInventory }) => {
 
   if (contentPerMediaType.schema) {
     const schema = contentPerMediaType.schema;
-    if(!schema.$ref) {
+    if (!schema.$ref) {
       return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE_SCHEMA_REF);
     }
 

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
@@ -23,10 +23,11 @@ export default (input, _, { path, documentInventory }) => {
 
   if (contentPerMediaType.schema) {
     const schema = contentPerMediaType.schema;
-    if (schema.$ref && !schema.$ref.endsWith('Request')) {
+    if(!schema.$ref) {
       return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
     }
-    if(!schema.$ref) {
+
+    if (!schema.$ref.endsWith('Request')) {
       return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
     }
   }


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-304055

The Create method request body should be a Request suffixed object

**Assumptions**:
- Create method is defined by POST method for REST APIs. This rule validates against the POST method requests
- Multiple media types (versions) for `requestBody` content can exist. API producers can define exceptions for each of them, adding Java`ExtensionProperty` at `@Content` level
- The schema of content should refer to a predefined Request-suffixed schema. If the schema is defined inline, it is against the guideline

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
