### PR TITLE
 CLOUDP-271997: IPA 108 - delete method schema

### DIFF
--- a/tools/spectral/ipa/__tests__/deleteMethodResponseShouldNotHaveSchema.test.js
+++ b/tools/spectral/ipa/__tests__/deleteMethodResponseShouldNotHaveSchema.test.js
@@ -30,6 +30,9 @@ testRule('xgen-IPA-108-delete-response-should-be-empty', [
                   'application/vnd.atlas.2023-01-01+json': {
                     'x-xgen-version': '2023-01-01',
                   },
+                  'application/vnd.atlas.2023-03-01+json': {
+                    'x-xgen-version': '2023-01-01',
+                  },
                 },
               },
             },
@@ -62,7 +65,7 @@ testRule('xgen-IPA-108-delete-response-should-be-empty', [
       {
         code: 'xgen-IPA-108-delete-response-should-be-empty',
         message:
-          'DELETE method should return an empty response. The response should not have a schema property and reference to models. http://go/ipa/108',
+          'Error found for application/vnd.atlas.2023-01-01+json: DELETE method should return an empty response. The response should not have a schema property. http://go/ipa/108',
         path: ['paths', '/resource/{id}', 'delete'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/deleteMethodResponseShouldNotHaveSchema.test.js
+++ b/tools/spectral/ipa/__tests__/deleteMethodResponseShouldNotHaveSchema.test.js
@@ -66,7 +66,7 @@ testRule('xgen-IPA-108-delete-response-should-be-empty', [
         code: 'xgen-IPA-108-delete-response-should-be-empty',
         message:
           'Error found for application/vnd.atlas.2023-01-01+json: DELETE method should return an empty response. The response should not have a schema property. http://go/ipa/108',
-        path: ['paths', '/resource/{id}', 'delete'],
+        path: ['paths', '/resource/{id}', 'delete', 'responses', '204'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -77,13 +77,13 @@ testRule('xgen-IPA-108-delete-response-should-be-empty', [
       paths: {
         '/resource/{id}': {
           delete: {
-            'x-xgen-IPA-exception': {
-              'xgen-IPA-108-delete-response-should-be-empty': 'Legacy API',
-            },
             responses: {
               204: {
-                content: {
-                  'application/vnd.atlas.2023-01-01+json': {
+                'application/vnd.atlas.2023-01-01+json': {
+                  'x-xgen-IPA-exception': {
+                    'xgen-IPA-108-delete-response-should-be-empty': 'Legacy API',
+                  },
+                  content: {
                     schema: { type: 'object' },
                   },
                 },

--- a/tools/spectral/ipa/__tests__/deleteMethodResponseShouldNotHaveSchema.test.js
+++ b/tools/spectral/ipa/__tests__/deleteMethodResponseShouldNotHaveSchema.test.js
@@ -18,7 +18,7 @@ testRule('xgen-IPA-108-delete-response-should-be-empty', [
     errors: [],
   },
   {
-    name: 'valid DELETE with void 204',
+    name: 'valid DELETE with void 204 versioned',
     document: {
       paths: {
         '/resource/{id}': {
@@ -62,7 +62,7 @@ testRule('xgen-IPA-108-delete-response-should-be-empty', [
       {
         code: 'xgen-IPA-108-delete-response-should-be-empty',
         message:
-          'DELETE method should return an empty response. The response should not have a schema property and reference to models http://go/ipa/108',
+          'DELETE method should return an empty response. The response should not have a schema property and reference to models. http://go/ipa/108',
         path: ['paths', '/resource/{id}', 'delete'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/deleteMethodResponseShouldNotHaveSchema.test.js
+++ b/tools/spectral/ipa/__tests__/deleteMethodResponseShouldNotHaveSchema.test.js
@@ -1,0 +1,95 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-108-delete-response-should-be-empty', [
+  {
+    name: 'valid DELETE with void 204',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          delete: {
+            responses: {
+              204: {},
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'valid DELETE with void 204',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          delete: {
+            responses: {
+              204: {
+                description: 'No Content',
+                content: {
+                  'application/vnd.atlas.2023-01-01+json': {
+                    'x-xgen-version': '2023-01-01',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid DELETE with non-void 204',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          delete: {
+            responses: {
+              204: {
+                content: {
+                  'application/vnd.atlas.2023-01-01+json': {
+                    schema: { type: 'object' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-108-delete-response-should-be-empty',
+        message:
+          'DELETE method should return an empty response. The response should not have a schema property and reference to models http://go/ipa/108',
+        path: ['paths', '/resource/{id}', 'delete'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'valid with exception',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          delete: {
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-108-delete-response-should-be-empty': 'Legacy API',
+            },
+            responses: {
+              204: {
+                content: {
+                  'application/vnd.atlas.2023-01-01+json': {
+                    schema: { type: 'object' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -6,6 +6,7 @@ extends:
   - ./rulesets/IPA-113.yaml
   - ./rulesets/IPA-123.yaml
   - ./rulesets/IPA-106.yaml
+  - ./rulesets/IPA-108.yaml
 
 overrides:
   - files:

--- a/tools/spectral/ipa/rulesets/IPA-108.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-108.yaml
@@ -1,0 +1,14 @@
+# IPA-108: Delete
+# http://go/ipa/108
+
+rules:
+  xgen-IPA-108-delete-response-should-be-empty:
+    description: Delete method response should not have schema reference to object http://go/ipa/108
+    message: '{{error}} http://go/ipa/108'
+    severity: warn
+    given: $.paths[*].delete
+    then:
+      function: deleteMethodResponseShouldNotHaveSchema
+
+functions:
+  - deleteMethodResponseShouldNotHaveSchema

--- a/tools/spectral/ipa/rulesets/IPA-108.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-108.yaml
@@ -3,7 +3,7 @@
 
 rules:
   xgen-IPA-108-delete-response-should-be-empty:
-    description: Delete method response should not have schema reference to object http://go/ipa/108
+    description: Delete method response should not have schema reference to object. http://go/ipa/108
     message: '{{error}} http://go/ipa/108'
     severity: warn
     given: $.paths[*].delete

--- a/tools/spectral/ipa/rulesets/IPA-108.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-108.yaml
@@ -6,7 +6,7 @@ rules:
     description: Delete method response should not have schema reference to object. http://go/ipa/108
     message: '{{error}} http://go/ipa/108'
     severity: warn
-    given: $.paths[*].delete
+    given: $.paths[*].delete.responses[204]
     then:
       function: deleteMethodResponseShouldNotHaveSchema
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -46,9 +46,9 @@ For rule definitions, see [IPA-106.yaml](https://github.com/mongodb/openapi/blob
 
 For rule definitions, see [IPA-108.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-108.yaml).
 
-| Rule Name                                    | Description                                                                         | Severity |
-| -------------------------------------------- | ----------------------------------------------------------------------------------- | -------- |
-| xgen-IPA-108-delete-response-should-be-empty | Delete method response should not have schema reference to object http://go/ipa/108 | warn     |
+| Rule Name                                    | Description                                                                          | Severity |
+| -------------------------------------------- | ------------------------------------------------------------------------------------ | -------- |
+| xgen-IPA-108-delete-response-should-be-empty | Delete method response should not have schema reference to object. http://go/ipa/108 | warn     |
 
 ### IPA-109
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -42,6 +42,14 @@ For rule definitions, see [IPA-106.yaml](https://github.com/mongodb/openapi/blob
 | ------------------------------------------------------------------ | -------------------------------------------------------------------------------- | -------- |
 | xgen-IPA-106-create-method-request-body-is-request-suffixed-object | The Create method request should be a Request suffixed object. http://go/ipa/106 | warn     |
 
+### IPA-108
+
+For rule definitions, see [IPA-108.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-108.yaml).
+
+| Rule Name                                    | Description                                                                         | Severity |
+| -------------------------------------------- | ----------------------------------------------------------------------------------- | -------- |
+| xgen-IPA-108-delete-response-should-be-empty | Delete method response should not have schema reference to object http://go/ipa/108 | warn     |
+
 ### IPA-109
 
 For rule definitions, see [IPA-109.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-109.yaml).

--- a/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
@@ -1,0 +1,34 @@
+import { hasException } from './utils/exceptions.js';
+import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+
+const RULE_NAME = 'xgen-IPA-108-delete-response-should-be-empty';
+const ERROR_MESSAGE =
+  'DELETE method should return an empty response. The response should not have a schema property and reference to models';
+
+/**
+ * Delete method should return an empty response
+ * @param {object} input - The delete operation object
+ * @param {object} _ - Unused
+ * @param {object} context - The context object containing the path
+ */
+export default (input, _, { path }) => {
+  const deleteOp = input;
+
+  if (hasException(deleteOp, RULE_NAME)) {
+    collectException(deleteOp, RULE_NAME, path);
+    return;
+  }
+
+  const responses = deleteOp.responses || {};
+  for (const [status, response] of Object.entries(responses)) {
+    if (status === '204' && response.content) {
+      for (const contentType of Object.keys(response.content)) {
+        if (response.content[contentType].schema) {
+          return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
+        }
+      }
+    }
+  }
+
+  collectAdoption(path, RULE_NAME);
+};

--- a/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
@@ -25,7 +25,7 @@ export default (input, _, { path }) => {
 
   // 3. Validation
   const errors = checkViolations(deleteOp.responses);
-  if (errors) {
+  if (errors.length > 0) {
     return collectAndReturnViolation(path, RULE_NAME, errors);
   }
 
@@ -35,14 +35,14 @@ export default (input, _, { path }) => {
 /**
  * Check if the operation has validation issues
  * @param {object} input - The  object to vefify
- * @return {Array<string>|undefined} - The content types that have a schema
+ * @return {Array<string>} - errors array (empty if no errors)
  */
 function checkViolations(input) {
+  const errors = [];
   try {
     if (input && input['204']) {
       const successResponse = input['204'];
       if (successResponse.content) {
-        const errors = [];
         for (const contentType of Object.keys(successResponse.content)) {
           if (successResponse.content[contentType] && successResponse.content[contentType].schema) {
             errors.push({
@@ -50,12 +50,10 @@ function checkViolations(input) {
             });
           }
         }
-        return errors.length > 0 ? errors : undefined;
       }
     }
   } catch (e) {
-    return ['Internal Rule Error without reporting violation' + e];
+    return [`${RULE_NAME} Internal Rule Error: ${e} Please report issue in https://github.com/mongodb/openapi/issues`];
   }
-  // No errors returning undefined
-  return undefined;
+  return errors;
 }

--- a/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
@@ -13,9 +13,9 @@ const ERROR_MESSAGE =
  */
 export default (input, _, { path }) => {
   const deleteOp = input;
-if(!deleteOp.responses || deleteOp.responses.length === 0) {
-    return; 
-}
+  if (!deleteOp.responses || deleteOp.responses.length === 0) {
+    return;
+  }
   if (hasException(deleteOp, RULE_NAME)) {
     collectException(deleteOp, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
@@ -22,15 +22,16 @@ export default (input, _, { path }) => {
   }
 
   const responses = deleteOp.responses;
-  for (const [status, response] of Object.entries(responses)) {
-    if (status === '204' && response.content) {
-      for (const contentType of Object.keys(response.content)) {
-        if (response.content[contentType].schema) {
+  if (responses && responses['204']) {
+    const successResponse = responses['204'];
+    if (successResponse.content) {
+      for (const contentType of Object.keys(successResponse.content)) {
+        // Check if the response has a schema property
+        if (successResponse.content[contentType] && successResponse.content[contentType].schema) {
           return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
         }
       }
     }
+    collectAdoption(path, RULE_NAME);
   }
-
-  collectAdoption(path, RULE_NAME);
 };

--- a/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
@@ -13,13 +13,15 @@ const ERROR_MESSAGE =
  */
 export default (input, _, { path }) => {
   const deleteOp = input;
-
+if(!deleteOp.responses || deleteOp.responses.length === 0) {
+    return; 
+}
   if (hasException(deleteOp, RULE_NAME)) {
     collectException(deleteOp, RULE_NAME, path);
     return;
   }
 
-  const responses = deleteOp.responses || {};
+  const responses = deleteOp.responses;
   for (const [status, response] of Object.entries(responses)) {
     if (status === '204' && response.content) {
       for (const contentType of Object.keys(response.content)) {

--- a/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
@@ -1,5 +1,10 @@
 import { hasException } from './utils/exceptions.js';
-import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
 
 const RULE_NAME = 'xgen-IPA-108-delete-response-should-be-empty';
 const ERROR_MESSAGE = 'DELETE method should return an empty response. The response should not have a schema property.';
@@ -11,20 +16,14 @@ const ERROR_MESSAGE = 'DELETE method should return an empty response. The respon
  * @param {object} context - The context object containing the path
  */
 export default (input, _, { path }) => {
-  // 1. Filter out not relevant use cases that should not lead to adoption.
-  const deleteOp = input;
-  if (!deleteOp.responses || deleteOp.responses.length === 0) {
+  // 1. Handle exception on OpenAPI schema
+  if (hasException(input, RULE_NAME)) {
+    collectException(input, RULE_NAME, path);
     return;
   }
 
-  // 2. Handle exception on OpenAPI schema
-  if (hasException(deleteOp, RULE_NAME)) {
-    collectException(deleteOp, RULE_NAME, path);
-    return;
-  }
-
-  // 3. Validation
-  const errors = checkViolations(deleteOp.responses);
+  // 2. Validation
+  const errors = checkViolations(input, path);
   if (errors.length > 0) {
     return collectAndReturnViolation(path, RULE_NAME, errors);
   }
@@ -35,25 +34,25 @@ export default (input, _, { path }) => {
 /**
  * Check if the operation has validation issues
  * @param {object} input - The  object to vefify
- * @return {Array<string>} - errors array (empty if no errors)
+ * @param {object} jsonPathArray - The jsonPathArray covering location in the OpenAPI schema
+ * @return {Array<string>} - errors array ()
  */
-function checkViolations(input) {
+function checkViolations(input, jsonPathArray) {
   const errors = [];
   try {
-    if (input && input['204']) {
-      const successResponse = input['204'];
-      if (successResponse.content) {
-        for (const contentType of Object.keys(successResponse.content)) {
-          if (successResponse.content[contentType] && successResponse.content[contentType].schema) {
-            errors.push({
-              message: `Error found for ${contentType}: ${ERROR_MESSAGE}`,
-            });
-          }
+    const successResponse = input;
+    if (successResponse.content) {
+      for (const contentType of Object.keys(successResponse.content)) {
+        if (successResponse.content[contentType] && successResponse.content[contentType].schema) {
+          errors.push({
+            path: jsonPathArray,
+            message: `Error found for ${contentType}: ${ERROR_MESSAGE}`,
+          });
         }
       }
     }
   } catch (e) {
-    return [`${RULE_NAME} Internal Rule Error: ${e} Please report issue in https://github.com/mongodb/openapi/issues`];
+    handleInternalError(RULE_NAME, jsonPathArray, e);
   }
   return errors;
 }

--- a/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
@@ -2,8 +2,7 @@ import { hasException } from './utils/exceptions.js';
 import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
 
 const RULE_NAME = 'xgen-IPA-108-delete-response-should-be-empty';
-const ERROR_MESSAGE =
-  'DELETE method should return an empty response. The response should not have a schema property and reference to models.';
+const ERROR_MESSAGE = 'DELETE method should return an empty response. The response should not have a schema property.';
 
 /**
  * Delete method should return an empty response
@@ -12,26 +11,51 @@ const ERROR_MESSAGE =
  * @param {object} context - The context object containing the path
  */
 export default (input, _, { path }) => {
+  // 1. Filter out not relevant use cases that should not lead to adoption.
   const deleteOp = input;
   if (!deleteOp.responses || deleteOp.responses.length === 0) {
     return;
   }
+
+  // 2. Handle exception on OpenAPI schema
   if (hasException(deleteOp, RULE_NAME)) {
     collectException(deleteOp, RULE_NAME, path);
     return;
   }
 
-  const responses = deleteOp.responses;
-  if (responses && responses['204']) {
-    const successResponse = responses['204'];
-    if (successResponse.content) {
-      for (const contentType of Object.keys(successResponse.content)) {
-        // Check if the response has a schema property
-        if (successResponse.content[contentType] && successResponse.content[contentType].schema) {
-          return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
+  // 3. Validation
+  const errors = checkViolations(deleteOp.responses);
+  if (errors) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+
+  collectAdoption(path, RULE_NAME);
+};
+
+/**
+ * Check if the operation has validation issues
+ * @param {object} input - The  object to vefify
+ * @return {Array<string>|undefined} - The content types that have a schema
+ */
+function checkViolations(input) {
+  try {
+    if (input && input['204']) {
+      const successResponse = input['204'];
+      if (successResponse.content) {
+        const errors = [];
+        for (const contentType of Object.keys(successResponse.content)) {
+          if (successResponse.content[contentType] && successResponse.content[contentType].schema) {
+            errors.push({
+              message: `Error found for ${contentType}: ${ERROR_MESSAGE}`,
+            });
+          }
         }
+        return errors.length > 0 ? errors : undefined;
       }
     }
-    collectAdoption(path, RULE_NAME);
+  } catch (e) {
+    return ['Internal Rule Error without reporting violation' + e];
   }
-};
+  // No errors returning undefined
+  return undefined;
+}

--- a/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethodResponseShouldNotHaveSchema.js
@@ -3,7 +3,7 @@ import { collectAdoption, collectAndReturnViolation, collectException } from './
 
 const RULE_NAME = 'xgen-IPA-108-delete-response-should-be-empty';
 const ERROR_MESSAGE =
-  'DELETE method should return an empty response. The response should not have a schema property and reference to models';
+  'DELETE method should return an empty response. The response should not have a schema property and reference to models.';
 
 /**
  * Delete method should return an empty response

--- a/tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/collectionUtils.js
@@ -46,3 +46,17 @@ export function collectException(object, ruleName, path) {
     collector.add(EntryType.EXCEPTION, path, ruleName, exceptionReason);
   }
 }
+
+/**
+ * Creates internal rule error entry for the collector in order to not fail validation process.
+ * @param {Array<string>} jsonPathArray - The JSON path for the object where the rule exception occurred.
+ * @param {string} ruleName - The name of the rule that was adopted.
+ */
+export function handleInternalError(ruleName, jsonPathArray, error) {
+  return [
+    {
+      path: jsonPathArray,
+      message: `${ruleName} Internal Rule Error: ${error} Please report issue in https://github.com/mongodb/openapi/issues`,
+    },
+  ];
+}


### PR DESCRIPTION
## Proposed changes
 
 CLOUDP-271997

# Changes Overview
This first PR implements OpenAPI specification validation for IPA-108 guidelines related to DELETE operations. The implementation adds linting rules that verify DELETE methods follow REST API best practices.

# Components Implemented
Rule: xgen-IPA-108-delete-response-should-be-empty

- Validates that DELETE operations return empty responses (204 No Content)
- Ensures response objects don't include schema definitions
- Implemented in deleteMethodResponseShouldNotHaveSchema.js
