### PR TITLE
CLOUDP-271994: IPA-106: Validate Create methods accepts no query params

### DIFF
--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -1,0 +1,135 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+const componentSchemas = {
+  schemas: {
+    Schema: {
+      type: 'object',
+    },
+  },
+};
+
+testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
+  {
+    name: 'valid methods',
+    document: {
+      components: componentSchemas,
+      paths: {
+        '/resource': {
+          post: {
+            parameters: [
+              {
+                name: 'header-param',
+                in: 'header',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'resource-id',
+                in: 'path',
+                schema: {
+                  $ref: '#/components/schemas/Schema',
+                },
+              },
+            ],
+          },
+        },
+        '/resource2': {
+          post: {
+            parameters: [],
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid methods',
+    document: {
+      components: componentSchemas,
+      paths: {
+        '/resource': {
+          post: {
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+            ],
+          },
+        },
+        '/resource2': {
+          post: {
+            parameters: [
+              {
+                name: 'header-param',
+                in: 'header',
+                schema: { type: 'string' },
+              },
+              {
+                name: 'query-param',
+                in: 'query',
+                schema: {
+                  $ref: '#/components/schemas/Schema',
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
+        message: 'Create operations should not have query parameters. http://go/ipa/106',
+        path: ['paths', '/resource', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
+        message: 'Create operations should not have query parameters. http://go/ipa/106',
+        path: ['paths', '/resource2', 'post'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid methods with exceptions',
+    document: {
+      components: componentSchemas,
+      paths: {
+        '/resource': {
+          post: {
+            parameters: [
+              {
+                name: 'filter',
+                in: 'query',
+                schema: { type: 'string' },
+              },
+            ],
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-106-create-method-should-not-have-query-parameters': 'Reason',
+            },
+          },
+        },
+        '/resource2': {
+          post: {
+            parameters: [
+              {
+                name: 'query-param',
+                in: 'query',
+                schema: {
+                  $ref: '#/components/schemas/Schema',
+                },
+              },
+            ],
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-106-create-method-should-not-have-query-parameters': 'Reason',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -7,6 +7,22 @@ const componentSchemas = {
       type: 'object',
     },
   },
+  parameters: {
+    QueryParam: {
+      name: 'query-param',
+      in: 'query',
+      schema: {
+        type: 'string'
+      },
+    },
+    PathParam: {
+      name: 'resource-id',
+      in: 'path',
+      schema: {
+        type: 'string'
+      },
+    }
+  }
 };
 
 testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
@@ -30,6 +46,9 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
                   $ref: '#/components/schemas/Schema',
                 },
               },
+              {
+                $ref: '#/components/parameters/PathParam',
+              }
             ],
           },
         },
@@ -67,12 +86,8 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
                 schema: { type: 'string' },
               },
               {
-                name: 'query-param',
-                in: 'query',
-                schema: {
-                  $ref: '#/components/schemas/Schema',
-                },
-              },
+                $ref: '#/components/parameters/QueryParam',
+              }
             ],
           },
         },
@@ -116,12 +131,8 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
           post: {
             parameters: [
               {
-                name: 'query-param',
-                in: 'query',
-                schema: {
-                  $ref: '#/components/schemas/Schema',
-                },
-              },
+                $ref: '#/components/parameters/QueryParam',
+              }
             ],
             'x-xgen-IPA-exception': {
               'xgen-IPA-106-create-method-should-not-have-query-parameters': 'Reason',

--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -12,17 +12,17 @@ const componentSchemas = {
       name: 'query-param',
       in: 'query',
       schema: {
-        type: 'string'
+        type: 'string',
       },
     },
     PathParam: {
       name: 'resource-id',
       in: 'path',
       schema: {
-        type: 'string'
+        type: 'string',
       },
-    }
-  }
+    },
+  },
 };
 
 testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
@@ -48,7 +48,7 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
               },
               {
                 $ref: '#/components/parameters/PathParam',
-              }
+              },
             ],
           },
         },
@@ -87,7 +87,7 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
               },
               {
                 $ref: '#/components/parameters/QueryParam',
-              }
+              },
             ],
           },
         },
@@ -132,7 +132,7 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
             parameters: [
               {
                 $ref: '#/components/parameters/QueryParam',
-              }
+              },
             ],
             'x-xgen-IPA-exception': {
               'xgen-IPA-106-create-method-should-not-have-query-parameters': 'Reason',

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -3,6 +3,7 @@
 
 functions:
   - createMethodRequestBodyIsRequestSuffixedObject
+  - createMethodShouldNotHaveQueryParameters
 
 rules:
   xgen-IPA-106-create-method-request-body-is-request-suffixed-object:
@@ -13,3 +14,10 @@ rules:
     then:
       field: '@key'
       function: 'createMethodRequestBodyIsRequestSuffixedObject'
+  xgen-IPA-106-create-method-should-not-have-query-parameters:
+    description: 'Create operations should not use query parameters. http://go/ipa/xxx'
+    message: '{{error}} http://go/ipa/106'
+    severity: warn
+    given: '$.paths[*].post'
+    then:
+      function: 'createMethodShouldNotHaveQueryParameters'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -41,6 +41,7 @@ For rule definitions, see [IPA-106.yaml](https://github.com/mongodb/openapi/blob
 | Rule Name                                                          | Description                                                                      | Severity |
 | ------------------------------------------------------------------ | -------------------------------------------------------------------------------- | -------- |
 | xgen-IPA-106-create-method-request-body-is-request-suffixed-object | The Create method request should be a Request suffixed object. http://go/ipa/106 | warn     |
+| xgen-IPA-106-create-method-should-not-have-query-parameters        | Create operations should not use query parameters. http://go/ipa/xxx             | warn     |
 
 ### IPA-109
 

--- a/tools/spectral/ipa/rulesets/functions/createMethodShouldNotHaveQueryParameters.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodShouldNotHaveQueryParameters.js
@@ -1,20 +1,18 @@
 import { hasException } from './utils/exceptions.js';
 import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
 import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
-import { resolveObject } from './utils/componentUtils.js';
 
 const RULE_NAME = 'xgen-IPA-106-create-method-should-not-have-query-parameters';
 const ERROR_MESSAGE = 'Create operations should not have query parameters.';
 
-export default (input, _, { path, documentInventory }) => {
-  const oas = documentInventory.unresolved;
+export default (input, _, { path }) => {
   const resourcePath = path[1];
 
   if (isCustomMethodIdentifier(resourcePath)) {
     return;
   }
 
-  const postMethod = resolveObject(oas, path);
+  const postMethod = input;
   if (!postMethod.parameters || postMethod.parameters.length === 0) {
     return;
   }

--- a/tools/spectral/ipa/rulesets/functions/createMethodShouldNotHaveQueryParameters.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodShouldNotHaveQueryParameters.js
@@ -1,0 +1,34 @@
+import { hasException } from './utils/exceptions.js';
+import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
+import { resolveObject } from './utils/componentUtils.js';
+
+const RULE_NAME = 'xgen-IPA-106-create-method-should-not-have-query-parameters';
+const ERROR_MESSAGE = 'Create operations should not have query parameters.';
+
+export default (input, _, { path, documentInventory }) => {
+  const oas = documentInventory.unresolved;
+  const resourcePath = path[1];
+
+  if (isCustomMethodIdentifier(resourcePath)) {
+    return;
+  }
+
+  const postMethod = resolveObject(oas, path);
+  if (!postMethod.parameters || postMethod.parameters.length === 0) {
+    return;
+  }
+
+  if (hasException(postMethod, RULE_NAME)) {
+    collectException(postMethod, RULE_NAME, path);
+    return;
+  }
+
+  for (const parameter of postMethod.parameters) {
+    if (parameter.in === 'query') {
+      return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
+    }
+  }
+
+  collectAdoption(path, RULE_NAME);
+};


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-271994

Verify that the parameters (inline or referenced schemas) of POST operation does not have "in":"query"

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
