### PR TITLE
CLOUDP-304706: add a retry step to the FOAS release process

### DIFF
--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -184,10 +184,20 @@ jobs:
         branch: ${{ inputs.branch }}
         foascli_version: ${{ inputs.foascli_version }}
 
-  failure-handler: 
-    name: Failure Handler
+  retry-handler:
     needs: [ release, release-postman, release-changelog]
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && contains(needs.*.result, 'failure') && fromJSON(github.run_attempt) < 3}}
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.api_bot_pat }}
+        run: gh workflow run retry-handler.yml -F run_id=${{ github.run_id }}
+
+  failure-handler:
+    name: Failure Handler
+    needs: [retry-handler, release, release-postman, release-changelog]
+    if: ${{ always() && contains(needs.*.result, 'failure') && needs.retry-handler.result == 'skipped' }}
     uses: ./.github/workflows/failure-handler.yml
     with:
       env: ${{ inputs.env }}

--- a/.github/workflows/retry-handler.yml
+++ b/.github/workflows/retry-handler.yml
@@ -1,0 +1,20 @@
+name: 'Retry failures in the Release Workflow'
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+        description: 'The ID of the workflow to rerun.'
+        type: string
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: api
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-304706

# Description:
This pull request introduces a retry mechanism for handling failures in the release workflow. The most important changes include adding a new job to retry the release process and updating the failure handler to account for this new retry mechanism.

Retry mechanism for release workflow:

* [`.github/workflows/release-spec.yml`](diffhunk://#diff-aea44faec3c0b85ba535263f9b540a317c4ab32d8a8c221871a5b231fc4468b1R187-R200): Added a new `retry-handler` job that attempts to rerun the release workflow up to three times if it fails. Updated the `failure-handler` job to depend on the `retry-handler` and only run if the `retry-handler` is skipped.

* [`.github/workflows/retry-handler.yml`](diffhunk://#diff-38ee054d4979e7cd4ab591947f935ea13e8686c8a337a6ec4bbb6015cd7d7280R1-R20): Created a new workflow file to define the `retry-handler` job, which reruns the failed workflow using the GitHub CLI.


I tested the changes in my fork: https://github.com/andreaangiolillo/openapi-test/actions/runs/13703067837

![Screenshot 2025-03-06 at 16 23 23](https://github.com/user-attachments/assets/c9721bdf-50f2-41ea-8c0c-1469e7fe2e7c)

