### PR TITLE
CLOUDP-271994: IPA-106: Validate Create methods accepts no query params (ignore envelope and pretty query params)

### DIFF
--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -22,6 +22,14 @@ const componentSchemas = {
         type: 'string',
       },
     },
+    envelope: {
+      name: 'envelope',
+      in: 'query',
+    },
+    pretty: {
+      name: 'pretty',
+      in: 'query',
+    },
   },
 };
 
@@ -48,6 +56,12 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
               },
               {
                 $ref: '#/components/parameters/PathParam',
+              },
+              {
+                $ref: '#/components/parameters/envelope',
+              },
+              {
+                $ref: '#/components/parameters/pretty',
               },
             ],
           },

--- a/tools/spectral/ipa/rulesets/functions/createMethodShouldNotHaveQueryParameters.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodShouldNotHaveQueryParameters.js
@@ -5,6 +5,8 @@ import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
 const RULE_NAME = 'xgen-IPA-106-create-method-should-not-have-query-parameters';
 const ERROR_MESSAGE = 'Create operations should not have query parameters.';
 
+const ignoredParameters = ['envelope', 'pretty'];
+
 export default (input, _, { path }) => {
   const resourcePath = path[1];
 
@@ -23,7 +25,7 @@ export default (input, _, { path }) => {
   }
 
   for (const parameter of postMethod.parameters) {
-    if (parameter.in === 'query') {
+    if (parameter.in === 'query' && !ignoredParameters.includes(parameter.name)) {
       return collectAndReturnViolation(path, RULE_NAME, ERROR_MESSAGE);
     }
   }


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-271994

Ignore `envelope` and `pretty` query params because they are about response object formatting, and they are widely used in the MMS OpenAPI spec

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
