### PR TITLE
CLOUDP-305831: Fix IPA validation failed on OAS release

### DIFF
--- a/tools/spectral/ipa/__tests__/getMethodReturnsResponseSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/getMethodReturnsResponseSuffixedObject.test.js
@@ -9,6 +9,15 @@ const componentSchemas = {
     Schema: {
       type: 'object',
     },
+    BadRequest: {
+      content: {
+        'application/json': {
+          schema: {
+            type: 'string',
+          },
+        },
+      },
+    },
   },
 };
 
@@ -41,6 +50,9 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
                     },
                   },
                 },
+              },
+              401: {
+                $ref: '#/components/schemas/BadRequest',
               },
               400: {
                 content: {
@@ -140,7 +152,7 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
     errors: [
       {
         code: 'xgen-IPA-104-get-method-returns-response-suffixed-object',
-        message: 'The request schema must reference a schema with a Response suffix. http://go/ipa/104',
+        message: 'The response body schema must reference a schema with a Response suffix. http://go/ipa/104',
         path: [
           'paths',
           '/resource/{id}',
@@ -154,7 +166,7 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
       },
       {
         code: 'xgen-IPA-104-get-method-returns-response-suffixed-object',
-        message: 'The request schema must reference a schema with a Response suffix. http://go/ipa/104',
+        message: 'The response body schema must reference a schema with a Response suffix. http://go/ipa/104',
         path: [
           'paths',
           '/resource/{id}',
@@ -168,7 +180,7 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
       },
       {
         code: 'xgen-IPA-104-get-method-returns-response-suffixed-object',
-        message: 'The request schema must reference a schema with a Response suffix. http://go/ipa/104',
+        message: 'The response body schema must reference a schema with a Response suffix. http://go/ipa/104',
         path: [
           'paths',
           '/resource/{id}',
@@ -182,7 +194,7 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
       },
       {
         code: 'xgen-IPA-104-get-method-returns-response-suffixed-object',
-        message: 'The request schema must reference a schema with a Response suffix. http://go/ipa/104',
+        message: 'The response body schema must reference a schema with a Response suffix. http://go/ipa/104',
         path: [
           'paths',
           '/resource/{id}/singleton',

--- a/tools/spectral/ipa/rulesets/functions/deleteMethod204Response.js
+++ b/tools/spectral/ipa/rulesets/functions/deleteMethod204Response.js
@@ -31,9 +31,7 @@ export default (input, _, { path }) => {
 
 function checkViolationsAndReturnErrors(input, path) {
   try {
-    console.log(input);
     const responses = input.responses;
-    console.log(responses);
     // If there is no 204 response, return a violation
     if (!responses || !responses['204']) {
       return [{ path, message: ERROR_MESSAGE }];

--- a/tools/spectral/ipa/rulesets/functions/getMethodResponseHasNoInputFields.js
+++ b/tools/spectral/ipa/rulesets/functions/getMethodResponseHasNoInputFields.js
@@ -19,8 +19,9 @@ export default (input, _, { path, documentInventory }) => {
   const contentPerMediaType = resolveObject(oas, path);
 
   if (
-    !contentPerMediaType.schema ||
     !responseCode.startsWith('2') ||
+    !contentPerMediaType ||
+    !contentPerMediaType.schema ||
     !input.endsWith('json') ||
     (!isSingleResourceIdentifier(resourcePath) &&
       !(isResourceCollectionIdentifier(resourcePath) && isSingletonResource(resourcePaths)))

--- a/tools/spectral/ipa/rulesets/functions/getMethodReturnsResponseSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/getMethodReturnsResponseSuffixedObject.js
@@ -15,7 +15,7 @@ import {
 import { getSchemaRef } from './utils/methodUtils.js';
 
 const RULE_NAME = 'xgen-IPA-104-get-method-returns-response-suffixed-object';
-const ERROR_MESSAGE_SCHEMA_NAME = 'The request schema must reference a schema with a Response suffix.';
+const ERROR_MESSAGE_SCHEMA_NAME = 'The response body schema must reference a schema with a Response suffix.';
 const ERROR_MESSAGE_SCHEMA_REF = 'The response body schema is defined inline and must reference a predefined schema.';
 
 export default (input, _, { path, documentInventory }) => {
@@ -26,8 +26,9 @@ export default (input, _, { path, documentInventory }) => {
   const contentPerMediaType = resolveObject(oas, path);
 
   if (
-    !contentPerMediaType.schema ||
     !responseCode.startsWith('2') ||
+    !contentPerMediaType ||
+    !contentPerMediaType.schema ||
     !input.endsWith('json') ||
     (!isSingleResourceIdentifier(resourcePath) &&
       !(isResourceCollectionIdentifier(resourcePath) && isSingletonResource(resourcePaths)))

--- a/tools/spectral/ipa/rulesets/functions/getMethodReturnsSingleResource.js
+++ b/tools/spectral/ipa/rulesets/functions/getMethodReturnsSingleResource.js
@@ -31,8 +31,9 @@ export default (input, _, { path, documentInventory }) => {
   const isSingleton = isResourceCollectionIdentifier(resourcePath) && isSingletonResource(resourcePaths);
 
   if (
-    !contentPerMediaType.schema ||
     !responseCode.startsWith('2') ||
+    !contentPerMediaType ||
+    !contentPerMediaType.schema ||
     !input.endsWith('json') ||
     (!isSingleResource && !isSingleton)
   ) {


### PR DESCRIPTION
## Proposed changes

Optional validations failed in OAS release due to bug in rule `xgen-IPA-104-get-method-returns-response-suffixed-object`. When resolving a schema for non-2xx responses, it's undefined and wasn't checked for before checking if it has a schema.

Also added a test that will catch this if it happens again.

See failures: https://github.com/mongodb/openapi/actions/runs/13786521109

_Jira ticket:_ [CLOUDP-305831](https://jira.mongodb.org/browse/CLOUDP-305831)
