### PR TITLE
task: add ipa validation to run during CI/CD process

### DIFF
--- a/.github/workflows/spectral-lint.yml
+++ b/.github/workflows/spectral-lint.yml
@@ -6,16 +6,14 @@ on:
     paths: 
       - 'tools/spectral/**'
       - 'openapi/**.yaml'
-      - '.spectral.yaml'
-      - 'ipa-spectral.yaml'
+      - 'package.json'
   push:
     branches:
       - main
     paths: 
       - 'tools/spectral/**'
       - 'openapi/**.yaml'
-      - '.spectral.yaml'
-      - 'ipa-spectral.yaml'
+      - 'package.json'
 
 jobs:
   spectral-lint:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "lint-js": "npx eslint **/*.js",
         "gen-ipa-docs": "node tools/spectral/ipa/scripts/generateRulesetReadme.js",
         "ipa-validation": "spectral lint ./openapi/.raw/v2.yaml --ruleset=./tools/spectral/ipa/ipa-spectral.yaml",
+        "spectral-validation": "spectral lint ./openapi/.raw/v2.yaml --ruleset=./tools/spectral/.spectral.yaml",
         "test": "jest",
         "precommit": "husky install"
     },


### PR DESCRIPTION
## Proposed changes

IPA validation needs to run during PR process to verify if:

- IPA rule were not made error by mistake and covers existing API
- package bump does not break spectral ruleset

PR should be never merged with failed spectral validation as it will affect and break downstream builds.

## Testing

Run echo "Ensuring no error violations available in OpenAPI"
Ensuring no error violations available in OpenAPI

> ipa-validation
> spectral lint ./openapi/v2.yaml --ruleset=./tools/spectral/ipa/ipa-spectral.yaml

No results with a severity of 'error' found!

> spectral-validation
> spectral lint ./openapi/v2.yaml --ruleset=./tools/spectral/.spectral.yaml

No results with a severity of 'error' found!
