### PR TITLE
CLOUDP-305844: fix branded_preview to avoid listing v2.json/v2.yaml files

### DIFF
--- a/.github/scripts/branded_preview.sh
+++ b/.github/scripts/branded_preview.sh
@@ -16,13 +16,16 @@ while IFS= read -r version; do
     versions+=("$version")
 done < <(jq -r '.[]' versions.json)
 
-all_urls=(
-   "https://raw.githubusercontent.com/mongodb/openapi/${branch_name:?}/openapi/v2.json"
-   "https://raw.githubusercontent.com/mongodb/openapi/${branch_name:?}/openapi/v2.yaml"
-)
+all_urls=()
 
 # Fetch and append file URLs from each version
 for version in "${versions[@]}"; do
+    if [[ "${version}" == *"private"* ]]; then
+        all_urls+=("https://raw.githubusercontent.com/mongodb/openapi/${branch_name:?}/openapi/v2/private/openapi-${version}.json")
+        all_urls+=("https://raw.githubusercontent.com/mongodb/openapi/${branch_name:?}/openapi/v2/private/openapi-${version}.yaml")
+        continue
+    fi
+
     all_urls+=("https://raw.githubusercontent.com/mongodb/openapi/${branch_name:?}/openapi/v2/openapi-${version}.json")
     all_urls+=("https://raw.githubusercontent.com/mongodb/openapi/${branch_name:?}/openapi/v2/openapi-${version}.yaml")
 done


### PR DESCRIPTION
_Jira ticket:_ CLOUDP-305844

[Branded preview](https://htmlpreview.github.io/?https://github.com/mongodb/openapi/blob/dev/openapi/branded-preview.html) list v2.json and v2.yaml specs and the preview does not work for private preview specs.

This PR updates the branded_preview.sh logic to remove the v2.json|yaml files and to use the correct path for private preview specs