### PR TITLE
Fix: Create method checks should apply resource collection URIs

### DIFF
--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -49,12 +49,12 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
               content: {
                 'application/vnd.atlas.2023-01-01+json': {
                   schema: {
-                    $ref: '#/components/schemas/SchemaRequest',
+                    $ref: '#/components/schemas/Schema',
                   },
                 },
                 'application/vnd.atlas.2024-01-01+json': {
                   schema: {
-                    $ref: '#/components/schemas/SchemaRequest',
+                    $ref: '#/components/schemas/Schema',
                   },
                 },
               },
@@ -109,7 +109,10 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
             },
           },
         },
-        '/resource2': {
+        '/resource/{id}': {
+          get: {},
+        },
+        '/resourceTwo': {
           post: {
             requestBody: {
               content: {
@@ -127,7 +130,10 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
             },
           },
         },
-        '/resource3': {
+        '/resourceTwo/{id}': {
+          get: {},
+        },
+        '/resourceThree': {
           post: {
             requestBody: {
               content: {
@@ -139,6 +145,9 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
               },
             },
           },
+        },
+        '/resourceThree/{id}': {
+          get: {},
         },
       },
     },
@@ -158,19 +167,19 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
         message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
-        path: ['paths', '/resource2', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
+        path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
         message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
-        path: ['paths', '/resource2', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
+        path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
         message: 'The response body schema is defined inline and must reference a predefined schema. http://go/ipa/106',
-        path: ['paths', '/resource3', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
+        path: ['paths', '/resourceThree', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -207,7 +216,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
             },
           },
         },
-        '/resource2': {
+        '/resourceTwo': {
           post: {
             requestBody: {
               content: {
@@ -231,7 +240,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
             },
           },
         },
-        '/resource3': {
+        '/resourceThree': {
           post: {
             requestBody: {
               content: {

--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -73,7 +73,7 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
             ],
           },
         },
-        '/resource2': {
+        '/resourceTwo': {
           post: {
             parameters: [],
           },
@@ -98,7 +98,7 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
             ],
           },
         },
-        '/resource2': {
+        '/resourceTwo': {
           post: {
             parameters: [
               {
@@ -127,14 +127,14 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
         message: 'Input parameter [query-param]: Create operations should not have query parameters. http://go/ipa/106',
-        path: ['paths', '/resource2', 'post'],
+        path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
         message:
           'Input parameter [query-param-2]: Create operations should not have query parameters. http://go/ipa/106',
-        path: ['paths', '/resource2', 'post'],
+        path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -158,7 +158,7 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
             },
           },
         },
-        '/resource2': {
+        '/resourceTwo': {
           post: {
             parameters: [
               {

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsGetResponse.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsGetResponse.js
@@ -1,7 +1,9 @@
 import {
   getResourcePathItems,
   getResponseOfGetMethodByMediaType,
-  isCustomMethodIdentifier, isResourceCollectionIdentifier, isSingletonResource,
+  isCustomMethodIdentifier,
+  isResourceCollectionIdentifier,
+  isSingletonResource,
 } from './utils/resourceEvaluation.js';
 import { resolveObject } from './utils/componentUtils.js';
 import { isDeepEqual, omitDeep } from './utils/compareUtils.js';
@@ -19,11 +21,7 @@ export default (input, opts, { path, documentInventory }) => {
   const resourcePaths = getResourcePathItems(resourcePath, oas.paths);
 
   const isResourceCollection = isResourceCollectionIdentifier(resourcePath) && !isSingletonResource(resourcePaths);
-  if (
-    isCustomMethodIdentifier(resourcePath) ||
-    !isResourceCollection ||
-    !mediaType.endsWith('json')
-  ) {
+  if (isCustomMethodIdentifier(resourcePath) || !isResourceCollection || !mediaType.endsWith('json')) {
     return;
   }
 

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsGetResponse.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsGetResponse.js
@@ -1,4 +1,8 @@
-import { getResponseOfGetMethodByMediaType, isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
+import {
+  getResourcePathItems,
+  getResponseOfGetMethodByMediaType,
+  isCustomMethodIdentifier, isResourceCollectionIdentifier, isSingletonResource,
+} from './utils/resourceEvaluation.js';
 import { resolveObject } from './utils/componentUtils.js';
 import { isDeepEqual, omitDeep } from './utils/compareUtils.js';
 import { hasException } from './utils/exceptions.js';
@@ -12,7 +16,14 @@ export default (input, opts, { path, documentInventory }) => {
   const oas = documentInventory.resolved;
   const resourcePath = path[1];
   let mediaType = input;
-  if (isCustomMethodIdentifier(resourcePath) || !mediaType.endsWith('json')) {
+  const resourcePaths = getResourcePathItems(resourcePath, oas.paths);
+
+  const isResourceCollection = isResourceCollectionIdentifier(resourcePath) && !isSingletonResource(resourcePaths);
+  if (
+    isCustomMethodIdentifier(resourcePath) ||
+    !isResourceCollection ||
+    !mediaType.endsWith('json')
+  ) {
     return;
   }
 

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestBodyIsRequestSuffixedObject.js
@@ -5,7 +5,12 @@ import {
   collectException,
   handleInternalError,
 } from './utils/collectionUtils.js';
-import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
+import {
+  getResourcePathItems,
+  isCustomMethodIdentifier,
+  isResourceCollectionIdentifier,
+  isSingletonResource,
+} from './utils/resourceEvaluation.js';
 import { resolveObject } from './utils/componentUtils.js';
 import { getSchemaRef } from './utils/methodUtils.js';
 
@@ -17,8 +22,15 @@ export default (input, _, { path, documentInventory }) => {
   const oas = documentInventory.unresolved;
   const resourcePath = path[1];
   const contentPerMediaType = resolveObject(oas, path);
+  const resourcePaths = getResourcePathItems(resourcePath, oas.paths);
 
-  if (isCustomMethodIdentifier(resourcePath) || !input.endsWith('json') || !contentPerMediaType.schema) {
+  const isResourceCollection = isResourceCollectionIdentifier(resourcePath) && !isSingletonResource(resourcePaths);
+  if (
+    isCustomMethodIdentifier(resourcePath) ||
+    !isResourceCollection ||
+    !input.endsWith('json') ||
+    !contentPerMediaType.schema
+  ) {
     return;
   }
 

--- a/tools/spectral/ipa/rulesets/functions/createMethodShouldNotHaveQueryParameters.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodShouldNotHaveQueryParameters.js
@@ -5,17 +5,25 @@ import {
   collectException,
   handleInternalError,
 } from './utils/collectionUtils.js';
-import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
+import {
+  getResourcePathItems,
+  isCustomMethodIdentifier,
+  isResourceCollectionIdentifier,
+  isSingletonResource,
+} from './utils/resourceEvaluation.js';
 
 const RULE_NAME = 'xgen-IPA-106-create-method-should-not-have-query-parameters';
 const ERROR_MESSAGE = 'Create operations should not have query parameters.';
 
 const ignoredParameters = ['envelope', 'pretty'];
 
-export default (input, _, { path }) => {
+export default (input, _, { path, documentInventory }) => {
   const resourcePath = path[1];
+  const oas = documentInventory.resolved;
+  const resourcePaths = getResourcePathItems(resourcePath, oas.paths);
 
-  if (isCustomMethodIdentifier(resourcePath)) {
+  const isResourceCollection = isResourceCollectionIdentifier(resourcePath) && !isSingletonResource(resourcePaths);
+  if (isCustomMethodIdentifier(resourcePath) || !isResourceCollection) {
     return;
   }
 


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Spectral custom rule functions regarding Custom methods are updated to skip if the URI does not belong to a resource collection identifier

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
