### PR TITLE
DOP-5448: Integrate Bump GH action to generate spec pages

### DIFF
--- a/.github/scripts/generateSpecMapping.js
+++ b/.github/scripts/generateSpecMapping.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Add new specs to be deployed to Bump here
 const SPEC_MAPPING = [
   {
     doc: 'f929d2d7-27d7-4591-b22f-6c2e543a7874',
@@ -13,9 +14,6 @@ const SPEC_MAPPING = [
   },
 ];
 
-/**
- * Handles the resource versions for Atlas Admin API v2
- */
 function handleAdminAPIv2() {
   const docId = '2accf4b8-a543-426c-94c3-794ae26b68be';
   const directory = 'openapi/v2';

--- a/.github/scripts/generateSpecMapping.js
+++ b/.github/scripts/generateSpecMapping.js
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ATLAS_ADMIN_API_V2_DOC = 'atlas-admin-api-v2';
+
+const SPEC_MAPPING = [
+  {
+    doc: 'atlas-admin-api-v1',
+    file: 'openapi/v1-deprecated/v1.json',
+    branch: 'main',
+  },
+  // Need to programmatically handle resource versions separately
+  {
+    doc: ATLAS_ADMIN_API_V2_DOC,
+    file: 'openapi/v2.json',
+    branch: 'latest',
+  },
+];
+
+/**
+ * Handles the resource versions for Atlas Admin API v2
+ */
+function handleResourceVersions() {
+  const directory = 'openapi/v2';
+  const filePath = path.join(__dirname, `../../${directory}/versions.json`);
+  const versions = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+  for (const version of versions) {
+    const openapiFilename = `openapi-${version}.json`;
+    const openapiFilePath = path.join(path.dirname(filePath), openapiFilename);
+
+    if (!fs.existsSync(openapiFilePath)) {
+      continue;
+    }
+
+    SPEC_MAPPING.push({
+      doc: ATLAS_ADMIN_API_V2_DOC,
+      file: `${directory}/${openapiFilename}`,
+      branch: version,
+    });
+  }
+}
+
+handleResourceVersions();
+console.log(JSON.stringify(SPEC_MAPPING));

--- a/.github/scripts/generateSpecMapping.js
+++ b/.github/scripts/generateSpecMapping.js
@@ -4,31 +4,29 @@ import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const ATLAS_ADMIN_API_V2_DOC = 'atlas-admin-api-v2';
 
 const SPEC_MAPPING = [
   {
-    doc: 'atlas-admin-api-v1',
+    doc: 'f929d2d7-27d7-4591-b22f-6c2e543a7874',
     file: 'openapi/v1-deprecated/v1.json',
     branch: 'main',
-  },
-  // Need to programmatically handle resource versions separately
-  {
-    doc: ATLAS_ADMIN_API_V2_DOC,
-    file: 'openapi/v2.json',
-    branch: 'latest',
   },
 ];
 
 /**
  * Handles the resource versions for Atlas Admin API v2
  */
-function handleResourceVersions() {
+function handleAdminAPIv2() {
+  const docId = '2accf4b8-a543-426c-94c3-794ae26b68be';
   const directory = 'openapi/v2';
   const filePath = path.join(__dirname, `../../${directory}/versions.json`);
   const versions = JSON.parse(fs.readFileSync(filePath, 'utf8'));
 
-  for (const version of versions) {
+  if (!versions || !Array.isArray(versions)) {
+    return;
+  }
+
+  for (const [index, version] of versions.entries()) {
     const openapiFilename = `openapi-${version}.json`;
     const openapiFilePath = path.join(path.dirname(filePath), openapiFilename);
 
@@ -36,13 +34,24 @@ function handleResourceVersions() {
       continue;
     }
 
+    const file = `${directory}/${openapiFilename}`;
     SPEC_MAPPING.push({
-      doc: ATLAS_ADMIN_API_V2_DOC,
-      file: `${directory}/${openapiFilename}`,
+      doc: docId,
+      file,
       branch: version,
     });
+
+    // We want the latest version to have its own version AND be the latest/default branch
+    if (index === versions.length - 1) {
+      SPEC_MAPPING.push({
+        doc: docId,
+        file,
+        branch: 'latest',
+      });
+    }
   }
 }
 
-handleResourceVersions();
+handleAdminAPIv2();
+// Output to GH action
 console.log(JSON.stringify(SPEC_MAPPING));

--- a/.github/workflows/generate-bump-pages.yml
+++ b/.github/workflows/generate-bump-pages.yml
@@ -35,7 +35,7 @@ jobs:
 
   deploy-doc:
     needs: create-matrix
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     name: Deploy API documentation on Bump.sh
     strategy:
       matrix: 

--- a/.github/workflows/generate-bump-pages.yml
+++ b/.github/workflows/generate-bump-pages.yml
@@ -1,0 +1,72 @@
+name: Check & deploy API documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'openapi/**.json'
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'openapi/**.json'
+
+permissions:
+  contents: read
+
+jobs:
+  create-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+      - name: Generate matrix
+        id: set-matrix
+        run: |
+          spec_mapping=$(node .github/scripts/generateSpecMapping.js)
+          echo "matrix=$spec_mapping" >> "$GITHUB_OUTPUT"
+
+  deploy-doc:
+    needs: create-matrix
+    if: ${{ github.event_name == 'push' }}
+    name: Deploy API documentation on Bump.sh
+    strategy:
+      matrix: 
+        spec-mapping: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Deploy API documentation
+        uses: bump-sh/github-action@v1
+        with:
+          doc: ${{matrix.spec-mapping.doc}}
+          token: ${{secrets.BUMP_TOKEN}}
+          file: ${{matrix.spec-mapping.file}}
+          branch: ${{matrix.spec-mapping.branch}}
+  
+  api-preview:
+    needs: create-matrix
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Create API preview on Bump.sh
+    strategy:
+      matrix: 
+        spec-mapping: ${{ fromJSON(needs.create-matrix.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create API preview
+        uses: bump-sh/github-action@v1
+        with:
+          doc: ${{matrix.spec-mapping.doc}}
+          token: ${{secrets.BUMP_TOKEN}}
+          file: ${{matrix.spec-mapping.file}}
+          branch: ${{matrix.spec-mapping.branch}}
+          command: preview

--- a/.github/workflows/generate-bump-pages.yml
+++ b/.github/workflows/generate-bump-pages.yml
@@ -1,6 +1,7 @@
 name: Check & deploy API documentation
 
 on:
+  workflow_dispatch: # Allow manual trigger in case of quick fix
   push:
     branches:
       - main


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ [DOP-5448](https://jira.mongodb.org/browse/DOP-5448)

The main goal of this PR is to follow Bump.sh's recommendation for a GH action that deploys changes to an OpenAPI spec to Bump, to be uploaded to the DOP team's Bump account.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

Some implementation details to note:

* Each spec is separated into its own document on Bump under the same hub.
* I've tested this [out on a fork](https://github.com/rayangler/mdb-openapi), in case you're curious about uploads.
* I have a scoped Bump API token that must be added as a secret to allow the GH action to work properly. I can reach out on Slack about getting this added!
* For Atlas Admin API v2, we're trying to follow the current setup where each of its resource versions are separate versions (Bump calls these branches). This makes the assumption that the latest resource version will always be at the end of the `versions.json` array. Right now, the `generateSpecMapping` script is mostly for the Atlas Admin API, but hopefully the array/script can be extended to handle any future OpenAPI specs that may be added to this repo.