### PR TITLE
CLOUDP-304939: IPA 106: Create : A Request object must include only input fields (consider resource collection URIs only)

### DIFF
--- a/tools/spectral/ipa/__tests__/createMethodRequestHasNoReadonlyFields.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestHasNoReadonlyFields.test.js
@@ -72,7 +72,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
     document: {
       components: componentSchemas,
       paths: {
-        '/valid-resource': {
+        '/resource': {
           post: {
             requestBody: {
               content: {
@@ -89,6 +89,9 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
               },
             },
           },
+        },
+        '/resource/{id}': {
+          get: {},
         },
       },
     },
@@ -121,7 +124,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
     document: {
       components: componentSchemas,
       paths: {
-        '/invalid-resource': {
+        '/resource': {
           post: {
             requestBody: {
               content: {
@@ -140,6 +143,9 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
             },
           },
         },
+        '/resource/{id}': {
+          get: {},
+        },
       },
     },
     errors: [
@@ -147,14 +153,14 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
         code: 'xgen-IPA-106-create-method-request-has-no-readonly-fields',
         message:
           'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: id. http://go/ipa/106',
-        path: ['paths', '/invalid-resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
+        path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-has-no-readonly-fields',
         message:
           'The Create method request object must not include input fields (readOnly properties). Found readOnly property at one of the inline schemas. http://go/ipa/106',
-        path: ['paths', '/invalid-resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
+        path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -164,7 +170,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
     document: {
       components: componentSchemas,
       paths: {
-        '/nested-invalid-resource': {
+        '/resource': {
           post: {
             requestBody: {
               content: {
@@ -177,6 +183,9 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
             },
           },
         },
+        '/resource/{id}': {
+          get: {},
+        },
       },
     },
     errors: [
@@ -184,14 +193,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
         code: 'xgen-IPA-106-create-method-request-has-no-readonly-fields',
         message:
           'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: user.userId. http://go/ipa/106',
-        path: [
-          'paths',
-          '/nested-invalid-resource',
-          'post',
-          'requestBody',
-          'content',
-          'application/vnd.atlas.2023-01-01+json',
-        ],
+        path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -201,7 +203,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
     document: {
       components: componentSchemas,
       paths: {
-        '/array-invalid-resource': {
+        '/resource': {
           post: {
             requestBody: {
               content: {
@@ -214,6 +216,9 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
             },
           },
         },
+        '/resource/{id}': {
+          get: {},
+        },
       },
     },
     errors: [
@@ -221,14 +226,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
         code: 'xgen-IPA-106-create-method-request-has-no-readonly-fields',
         message:
           'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: items.items.itemId. http://go/ipa/106',
-        path: [
-          'paths',
-          '/array-invalid-resource',
-          'post',
-          'requestBody',
-          'content',
-          'application/vnd.atlas.2023-01-01+json',
-        ],
+        path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -238,7 +236,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
     document: {
       components: componentSchemas,
       paths: {
-        '/excepted-resource': {
+        '/resource': {
           post: {
             requestBody: {
               content: {
@@ -253,6 +251,9 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
               },
             },
           },
+        },
+        '/resource/{id}': {
+          get: {},
         },
       },
     },

--- a/tools/spectral/ipa/rulesets/functions/createMethodRequestHasNoReadonlyFields.js
+++ b/tools/spectral/ipa/rulesets/functions/createMethodRequestHasNoReadonlyFields.js
@@ -1,4 +1,9 @@
-import { isCustomMethodIdentifier } from './utils/resourceEvaluation.js';
+import {
+  getResourcePathItems,
+  isCustomMethodIdentifier,
+  isResourceCollectionIdentifier,
+  isSingletonResource,
+} from './utils/resourceEvaluation.js';
 import { resolveObject } from './utils/componentUtils.js';
 import { hasException } from './utils/exceptions.js';
 import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
@@ -10,9 +15,12 @@ const ERROR_MESSAGE = 'The Create method request object must not include input f
 export default (input, _, { path, documentInventory }) => {
   const resourcePath = path[1];
   const oas = documentInventory.resolved;
+  const resourcePaths = getResourcePathItems(resourcePath, oas.paths);
   let mediaType = input;
 
-  if (isCustomMethodIdentifier(resourcePath) || !mediaType.endsWith('json')) {
+  const isResourceCollection = isResourceCollectionIdentifier(resourcePath) && !isSingletonResource(resourcePaths);
+
+  if (isCustomMethodIdentifier(resourcePath) || !isResourceCollection || !mediaType.endsWith('json')) {
     return;
   }
 


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-304939

Include resource collection URI check for `xgen-IPA-106-create-method-request-has-no-readonly-fields` rule

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
