### PR TITLE
Fix: Refine Create method descriptions with the resource collection applicability

### DIFF
--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -10,7 +10,7 @@ functions:
 
 rules:
   xgen-IPA-106-create-method-request-body-is-request-suffixed-object:
-    description: |
+    description: >-
       The Create method request should be a Request suffixed object. http://go/ipa/106
       This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
@@ -20,7 +20,7 @@ rules:
       field: '@key'
       function: 'createMethodRequestBodyIsRequestSuffixedObject'
   xgen-IPA-106-create-method-should-not-have-query-parameters:
-    description: |
+    description: >-
       Create operations should not use query parameters. http://go/ipa/106
       This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
@@ -29,7 +29,7 @@ rules:
     then:
       function: 'createMethodShouldNotHaveQueryParameters'
   xgen-IPA-106-create-method-request-body-is-get-method-response:
-    description: |
+    description: >-
       Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
       readOnly/writeOnly properties will be ignored.  
       This rule applies only to POST requests targeting resource collection URIs.
@@ -42,7 +42,7 @@ rules:
       functionOptions:
         ignoredValues: ['readOnly', 'writeOnly']
   xgen-IPA-106-create-method-request-has-no-readonly-fields:
-    description: |
+    description: >-
       Create method Request object must not include fields with readOnly:true. http://go/ipa/106
       This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
@@ -52,7 +52,7 @@ rules:
       field: '@key'
       function: 'createMethodRequestHasNoReadonlyFields'
   xgen-IPA-106-create-method-response-code-is-201:
-    description: |
+    description: >-
       Create methods must return a 201 Created response code. http://go/ipa/106
       This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -10,7 +10,9 @@ functions:
 
 rules:
   xgen-IPA-106-create-method-request-body-is-request-suffixed-object:
-    description: 'The Create method request should be a Request suffixed object. http://go/ipa/106'
+    description: |
+      The Create method request should be a Request suffixed object. http://go/ipa/106
+      This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
     severity: warn
     given: '$.paths[*].post.requestBody.content'
@@ -18,7 +20,9 @@ rules:
       field: '@key'
       function: 'createMethodRequestBodyIsRequestSuffixedObject'
   xgen-IPA-106-create-method-should-not-have-query-parameters:
-    description: 'Create operations should not use query parameters. http://go/ipa/106'
+    description: |
+      Create operations should not use query parameters. http://go/ipa/106
+      This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
     severity: warn
     given: '$.paths[*].post'
@@ -26,8 +30,9 @@ rules:
       function: 'createMethodShouldNotHaveQueryParameters'
   xgen-IPA-106-create-method-request-body-is-get-method-response:
     description: |
-      Request body content of the Create method and response content of the Get method should refer to the same resource.
-      readOnly/writeOnly properties will be ignored.  http://go/ipa/106
+      Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
+      readOnly/writeOnly properties will be ignored.  
+      This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
     severity: warn
     given: '$.paths[*].post.requestBody.content'
@@ -37,7 +42,9 @@ rules:
       functionOptions:
         ignoredValues: ['readOnly', 'writeOnly']
   xgen-IPA-106-create-method-request-has-no-readonly-fields:
-    description: 'Create method Request object must not include fields with readOnly:true. http://go/ipa/106'
+    description: |
+      Create method Request object must not include fields with readOnly:true. http://go/ipa/106
+      This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
     severity: warn
     given: '$.paths[*].post.requestBody.content'
@@ -45,7 +52,9 @@ rules:
       field: '@key'
       function: 'createMethodRequestHasNoReadonlyFields'
   xgen-IPA-106-create-method-response-code-is-201:
-    description: 'Create methods must return a 201 Created response code. http://go/ipa/106'
+    description: |
+      Create methods must return a 201 Created response code. http://go/ipa/106
+      This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
     severity: warn
     given: '$.paths[*].post'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -53,24 +53,13 @@ For rule definitions, see [IPA-105.yaml](https://github.com/mongodb/openapi/blob
 
 For rule definitions, see [IPA-106.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-106.yaml).
 
-| Rule Name                                                          | Description                                                                                                                                                                                                                                                         | Severity |
-| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| xgen-IPA-106-create-method-request-body-is-request-suffixed-object | The Create method request should be a Request suffixed object. http://go/ipa/106
-This rule applies only to POST requests targeting resource collection URIs.
-                                                                                                       | warn     |
-| xgen-IPA-106-create-method-should-not-have-query-parameters        | Create operations should not use query parameters. http://go/ipa/106
-This rule applies only to POST requests targeting resource collection URIs.
-                                                                                                                   | warn     |
-| xgen-IPA-106-create-method-request-body-is-get-method-response     | Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
-readOnly/writeOnly properties will be ignored.  
-This rule applies only to POST requests targeting resource collection URIs.
- | warn     |
-| xgen-IPA-106-create-method-request-has-no-readonly-fields          | Create method Request object must not include fields with readOnly:true. http://go/ipa/106
-This rule applies only to POST requests targeting resource collection URIs.
-                                                                                             | warn     |
-| xgen-IPA-106-create-method-response-code-is-201                    | Create methods must return a 201 Created response code. http://go/ipa/106
-This rule applies only to POST requests targeting resource collection URIs.
-                                                                                                              | warn     |
+| Rule Name                                                          | Description                                                                                                                                                                                                                                                        | Severity |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- |
+| xgen-IPA-106-create-method-request-body-is-request-suffixed-object | The Create method request should be a Request suffixed object. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.                                                                                                       | warn     |
+| xgen-IPA-106-create-method-should-not-have-query-parameters        | Create operations should not use query parameters. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.                                                                                                                   | warn     |
+| xgen-IPA-106-create-method-request-body-is-get-method-response     | Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106 readOnly/writeOnly properties will be ignored.   This rule applies only to POST requests targeting resource collection URIs. | warn     |
+| xgen-IPA-106-create-method-request-has-no-readonly-fields          | Create method Request object must not include fields with readOnly:true. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.                                                                                             | warn     |
+| xgen-IPA-106-create-method-response-code-is-201                    | Create methods must return a 201 Created response code. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.                                                                                                              | warn     |
 
 ### IPA-108
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -53,15 +53,24 @@ For rule definitions, see [IPA-105.yaml](https://github.com/mongodb/openapi/blob
 
 For rule definitions, see [IPA-106.yaml](https://github.com/mongodb/openapi/blob/main/tools/spectral/ipa/rulesets/IPA-106.yaml).
 
-| Rule Name                                                          | Description                                                                                                                                                                            | Severity |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| xgen-IPA-106-create-method-request-body-is-request-suffixed-object | The Create method request should be a Request suffixed object. http://go/ipa/106                                                                                                       | warn     |
-| xgen-IPA-106-create-method-should-not-have-query-parameters        | Create operations should not use query parameters. http://go/ipa/106                                                                                                                   | warn     |
-| xgen-IPA-106-create-method-request-body-is-get-method-response     | Request body content of the Create method and response content of the Get method should refer to the same resource.
-readOnly/writeOnly properties will be ignored.  http://go/ipa/106
+| Rule Name                                                          | Description                                                                                                                                                                                                                                                         | Severity |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
+| xgen-IPA-106-create-method-request-body-is-request-suffixed-object | The Create method request should be a Request suffixed object. http://go/ipa/106
+This rule applies only to POST requests targeting resource collection URIs.
+                                                                                                       | warn     |
+| xgen-IPA-106-create-method-should-not-have-query-parameters        | Create operations should not use query parameters. http://go/ipa/106
+This rule applies only to POST requests targeting resource collection URIs.
+                                                                                                                   | warn     |
+| xgen-IPA-106-create-method-request-body-is-get-method-response     | Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
+readOnly/writeOnly properties will be ignored.  
+This rule applies only to POST requests targeting resource collection URIs.
  | warn     |
-| xgen-IPA-106-create-method-request-has-no-readonly-fields          | Create method Request object must not include fields with readOnly:true. http://go/ipa/106                                                                                             | warn     |
-| xgen-IPA-106-create-method-response-code-is-201                    | Create methods must return a 201 Created response code. http://go/ipa/106                                                                                                              | warn     |
+| xgen-IPA-106-create-method-request-has-no-readonly-fields          | Create method Request object must not include fields with readOnly:true. http://go/ipa/106
+This rule applies only to POST requests targeting resource collection URIs.
+                                                                                             | warn     |
+| xgen-IPA-106-create-method-response-code-is-201                    | Create methods must return a 201 Created response code. http://go/ipa/106
+This rule applies only to POST requests targeting resource collection URIs.
+                                                                                                              | warn     |
 
 ### IPA-108
 


### PR DESCRIPTION
## Proposed changes

Includes "This rule applies only to POST requests targeting resource collection URIs." sentence to the IPA-106:Create rules

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
