### PR TITLE
CLOUDP-306161: Improve single resource path evaluation

### DIFF
--- a/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
+++ b/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
@@ -228,6 +228,11 @@ describe('tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js', ()
         isSingleResourceIdentifier: false,
       },
       {
+        description: 'invalid single identifier',
+        path: '/resource/resource/{id}',
+        isSingleResourceIdentifier: false,
+      },
+      {
         description: 'single identifier',
         path: '/resource/{id}',
         isSingleResourceIdentifier: true,
@@ -236,7 +241,7 @@ describe('tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js', ()
         description: 'single identifier child',
         path: '/resource/{id}/child/{id}',
         isSingleResourceIdentifier: true,
-      },
+      }
     ];
 
     testCases.forEach((testCase) => {

--- a/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
+++ b/tools/spectral/ipa/__tests__/utils/resourceEvaluation.test.js
@@ -241,7 +241,7 @@ describe('tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js', ()
         description: 'single identifier child',
         path: '/resource/{id}/child/{id}',
         isSingleResourceIdentifier: true,
-      }
+      },
     ];
 
     testCases.forEach((testCase) => {

--- a/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
@@ -20,8 +20,10 @@ export function isResourceCollectionIdentifier(path) {
 /**
  * Checks if a path represents a single resource. For example:
  * '/resource/{id}' returns true
+ * '/resource/{resourceId}/child/{childId}' returns true
  * '/resource/{id}/child' returns false
- * '/resource/{id}/{id}' returns false
+ * '/resource' returns false
+ * '/resource/child/{id}' returns false
  *
  * @param {string} path the path to evaluate
  * @returns {boolean} true if the path represents a single resource, false otherwise

--- a/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
@@ -27,8 +27,24 @@ export function isResourceCollectionIdentifier(path) {
  * @returns {boolean} true if the path represents a single resource, false otherwise
  */
 export function isSingleResourceIdentifier(path) {
-  const pattern = new RegExp(`^.*/[a-zA-Z]+/{[a-zA-Z]+}$`);
-  return pattern.test(path);
+  const p = removePrefix(path);
+
+  // Check if the path ends with /{paramName} pattern
+  const endsWithParamPattern = /\/\{[a-zA-Z][a-zA-Z0-9]*}$/;
+
+  if (!endsWithParamPattern.test(p)) {
+    return false;
+  }
+
+  // Extract the part before the final parameter
+  const lastSlashBeforeParam = p.lastIndexOf('/');
+  if (lastSlashBeforeParam === -1) {
+    return false;
+  }
+
+  // Check if the preceding part is a valid resource collection identifier
+  const collectionPath = p.substring(0, lastSlashBeforeParam);
+  return isResourceCollectionIdentifier(collectionPath);
 }
 
 export function isCustomMethodIdentifier(path) {


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-306161

Update `isSingleResourceIdentifier` function to check if the URI is
`Single resource path` = `resourceCollectionPath` + `/{resourceId}`

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->

All the rules regarding IPA-104:Get are affected. Following the PR merge, I will check if there are changes in exceptions defined in MMS
