### PR TITLE
CLOUDP-304053: IPA-106:Create - The resource must be the request body (exclude readOnly:true and writeOnly:true)

### DIFF
--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsGetResponse.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsGetResponse.test.js
@@ -6,13 +6,16 @@ const componentSchemas = {
     SchemaOne: {
       type: 'string',
     },
-    SchemaTwo: {
+    SchemaTwoRequest: {
       type: 'object',
       properties: {
         name: {
           type: 'string',
-          readOnly: true,
+          writeOnly: true,
         },
+        otherThing: {
+          type: 'string',
+        }
       },
     },
     SchemaThree: {
@@ -29,13 +32,16 @@ const componentSchemas = {
         },
       },
     },
-    SchemaFour: {
+    SchemaTwoResponse: {
       type: 'object',
       properties: {
         name: {
           type: 'string',
-          writeOnly: true,
+          readOnly: true,
         },
+        otherThing: {
+          type: 'string',
+        }
       },
     },
     SchemaCircularOne: {
@@ -132,12 +138,12 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
               content: {
                 'application/vnd.atlas.2023-01-01+json': {
                   schema: {
-                    $ref: '#/components/schemas/SchemaTwo',
+                    $ref: '#/components/schemas/SchemaTwoRequest',
                   },
                 },
                 'application/vnd.atlas.2024-01-01+json': {
                   schema: {
-                    $ref: '#/components/schemas/SchemaTwo',
+                    $ref: '#/components/schemas/SchemaTwoRequest',
                   },
                 },
               },
@@ -151,7 +157,12 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
                 content: {
                   'application/vnd.atlas.2023-01-01+json': {
                     schema: {
-                      $ref: '#/components/schemas/SchemaFour',
+                      $ref: '#/components/schemas/SchemaTwoResponse',
+                    },
+                  },
+                  'application/vnd.atlas.2024-01-01+json': {
+                    schema: {
+                      $ref: '#/components/schemas/SchemaTwoResponse',
                     },
                   },
                 },
@@ -244,7 +255,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
                 content: {
                   'application/vnd.atlas.2023-01-01+json': {
                     schema: {
-                      $ref: '#/components/schemas/SchemaTwo',
+                      $ref: '#/components/schemas/SchemaTwoRequest',
                     },
                   },
                 },
@@ -258,12 +269,12 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
               content: {
                 'application/vnd.atlas.2023-01-01+json': {
                   schema: {
-                    $ref: '#/components/schemas/SchemaTwo',
+                    $ref: '#/components/schemas/SchemaTwoResponse',
                   },
                 },
                 'application/vnd.atlas.2024-01-01+json': {
                   schema: {
-                    $ref: '#/components/schemas/SchemaTwo',
+                    $ref: '#/components/schemas/SchemaTwoResponse',
                   },
                 },
               },
@@ -511,14 +522,6 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
                     'xgen-IPA-106-create-method-request-body-is-get-method-response': 'reason',
                   },
                 },
-                'application/vnd.atlas.2024-01-01+json': {
-                  schema: {
-                    $ref: '#/components/schemas/SchemaOne',
-                  },
-                  'x-xgen-IPA-exception': {
-                    'xgen-IPA-106-create-method-request-body-is-get-method-response': 'reason',
-                  },
-                },
               },
             },
           },
@@ -530,7 +533,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
                 content: {
                   'application/vnd.atlas.2023-01-01+json': {
                     schema: {
-                      $ref: '#/components/schemas/SchemaTwo',
+                      $ref: '#/components/schemas/SchemaThree',
                     },
                   },
                 },
@@ -544,7 +547,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
               content: {
                 'application/vnd.atlas.2023-01-01+json': {
                   schema: {
-                    $ref: '#/components/schemas/SchemaTwo',
+                    $ref: '#/components/schemas/SchemaTwoRequest',
                   },
                   'x-xgen-IPA-exception': {
                     'xgen-IPA-106-create-method-request-body-is-get-method-response': 'reason',
@@ -552,7 +555,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
                 },
                 'application/vnd.atlas.2024-01-01+json': {
                   schema: {
-                    $ref: '#/components/schemas/SchemaTwo',
+                    $ref: '#/components/schemas/SchemaTwoRequest',
                   },
                   'x-xgen-IPA-exception': {
                     'xgen-IPA-106-create-method-request-body-is-get-method-response': 'reason',
@@ -569,43 +572,7 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
                 content: {
                   'application/vnd.atlas.2023-01-01+json': {
                     schema: {
-                      $ref: '#/components/schemas/SchemaThree',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        '/resourceThree': {
-          post: {
-            requestBody: {
-              content: {
-                'application/vnd.atlas.2023-01-01+json': {
-                  schema: {
-                    $ref: '#/components/schemas/SchemaOne',
-                  },
-                  'x-xgen-IPA-exception': {
-                    'xgen-IPA-106-create-method-request-body-is-get-method-response': 'reason',
-                  },
-                },
-                'application/vnd.atlas.2024-01-01+json': {
-                  schema: {
-                    $ref: '#/components/schemas/SchemaThree',
-                  },
-                },
-              },
-            },
-          },
-        },
-        '/resourceThree/{id}': {
-          get: {
-            responses: {
-              200: {
-                content: {
-                  'application/vnd.atlas.2023-01-01+json': {
-                    schema: {
-                      $ref: '#/components/schemas/SchemaThree',
+                      $ref: '#/components/schemas/SchemaTwoResponse',
                     },
                   },
                 },

--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsGetResponse.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsGetResponse.test.js
@@ -393,56 +393,56 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceThree', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'Could not validate that the Create request body schema matches the response schema of the Get method. The Get method does not have a schema. http://go/ipa/106',
+          'Could not validate that the Create request body schema matches the response schema of the Get method. The Get method does not have a schema. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceFour', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceCircular', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceCircular', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
@@ -492,14 +492,14 @@ testRule('xgen-IPA-106-create-method-request-body-is-get-method-response', [
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/animalResource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-get-method-response',
         message:
-          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa/106',
+          'The request body schema properties must match the response body schema properties of the Get method. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/animalResource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsGetResponse.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsGetResponse.test.js
@@ -15,7 +15,7 @@ const componentSchemas = {
         },
         otherThing: {
           type: 'string',
-        }
+        },
       },
     },
     SchemaThree: {
@@ -41,7 +41,7 @@ const componentSchemas = {
         },
         otherThing: {
           type: 'string',
-        }
+        },
       },
     },
     SchemaCircularOne: {

--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -154,31 +154,31 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
     errors: [
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
+        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
+        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
+        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa/106',
+        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema is defined inline and must reference a predefined schema. http://go/ipa/106',
+        message: 'The response body schema is defined inline and must reference a predefined schema. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceThree', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -154,31 +154,36 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
     errors: [
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
+        message:
+          'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
+        message:
+          'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
+        message:
+          'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
+        message:
+          'The response body schema must reference a schema with a Request suffix. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema is defined inline and must reference a predefined schema. http://go/ipa-spectral#IPA-106',
+        message:
+          'The response body schema is defined inline and must reference a predefined schema. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceThree', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodRequestHasNoReadonlyFields.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodRequestHasNoReadonlyFields.test.js
@@ -152,14 +152,14 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
       {
         code: 'xgen-IPA-106-create-method-request-has-no-readonly-fields',
         message:
-          'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: id. http://go/ipa/106',
+          'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: id. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-has-no-readonly-fields',
         message:
-          'The Create method request object must not include input fields (readOnly properties). Found readOnly property at one of the inline schemas. http://go/ipa/106',
+          'The Create method request object must not include input fields (readOnly properties). Found readOnly property at one of the inline schemas. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
@@ -192,7 +192,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
       {
         code: 'xgen-IPA-106-create-method-request-has-no-readonly-fields',
         message:
-          'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: user.userId. http://go/ipa/106',
+          'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: user.userId. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
@@ -225,7 +225,7 @@ testRule('xgen-IPA-106-create-method-request-has-no-readonly-fields', [
       {
         code: 'xgen-IPA-106-create-method-request-has-no-readonly-fields',
         message:
-          'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: items.items.itemId. http://go/ipa/106',
+          'The Create method request object must not include input fields (readOnly properties). Found readOnly property at: items.items.itemId. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodResponseCodeIs201Created.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodResponseCodeIs201Created.test.js
@@ -74,21 +74,21 @@ testRule('xgen-IPA-106-create-method-response-code-is-201', [
       {
         code: 'xgen-IPA-106-create-method-response-code-is-201',
         message:
-          'The Create method must return a 201 Created response. This method either lacks a 201 Created response or defines a different 2xx status code. http://go/ipa/106',
+          'The Create method must return a 201 Created response. This method either lacks a 201 Created response or defines a different 2xx status code. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceOne', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-response-code-is-201',
         message:
-          'The Create method must return a 201 Created response. This method either lacks a 201 Created response or defines a different 2xx status code. http://go/ipa/106',
+          'The Create method must return a 201 Created response. This method either lacks a 201 Created response or defines a different 2xx status code. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-response-code-is-201',
         message:
-          'The Create method must return a 201 Created response. This method either lacks a 201 Created response or defines a different 2xx status code. http://go/ipa/106',
+          'The Create method must return a 201 Created response. This method either lacks a 201 Created response or defines a different 2xx status code. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceThree', 'post'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -120,20 +120,20 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
     errors: [
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Input parameter [filter]: Create operations should not have query parameters. http://go/ipa/106',
+        message: 'Input parameter [filter]: Create operations should not have query parameters. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Input parameter [query-param]: Create operations should not have query parameters. http://go/ipa/106',
+        message: 'Input parameter [query-param]: Create operations should not have query parameters. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
         message:
-          'Input parameter [query-param-2]: Create operations should not have query parameters. http://go/ipa/106',
+          'Input parameter [query-param-2]: Create operations should not have query parameters. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -120,19 +120,19 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
     errors: [
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Create operations should not have query parameters. Found [filter]. http://go/ipa/106',
+        message: 'Create operations should not have query parameters. Found [filter]. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Create operations should not have query parameters. Found [query-param]. http://go/ipa/106',
+        message: 'Create operations should not have query parameters. Found [query-param]. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Create operations should not have query parameters. Found [query-param-2]. http://go/ipa/106',
+        message: 'Create operations should not have query parameters. Found [query-param-2]. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -120,13 +120,15 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
     errors: [
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Input parameter [filter]: Create operations should not have query parameters. http://go/ipa-spectral#IPA-106',
+        message:
+          'Input parameter [filter]: Create operations should not have query parameters. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resource', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Input parameter [query-param]: Create operations should not have query parameters. http://go/ipa-spectral#IPA-106',
+        message:
+          'Input parameter [query-param]: Create operations should not have query parameters. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
+++ b/tools/spectral/ipa/__tests__/createMethodShouldNotHaveQueryParameters.test.js
@@ -126,13 +126,15 @@ testRule('xgen-IPA-106-create-method-should-not-have-query-parameters', [
       },
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Create operations should not have query parameters. Found [query-param]. http://go/ipa-spectral#IPA-106',
+        message:
+          'Create operations should not have query parameters. Found [query-param]. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-should-not-have-query-parameters',
-        message: 'Create operations should not have query parameters. Found [query-param-2]. http://go/ipa-spectral#IPA-106',
+        message:
+          'Create operations should not have query parameters. Found [query-param-2]. http://go/ipa-spectral#IPA-106',
         path: ['paths', '/resourceTwo', 'post'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -31,7 +31,8 @@ rules:
   xgen-IPA-106-create-method-request-body-is-get-method-response:
     description: >-
       Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
-      readOnly/writeOnly properties will be ignored.  
+      readOnly:true properties of Get method response will be ignored. 
+      writeOnly:true properties of Create method request will be ignored.
       This rule applies only to POST requests targeting resource collection URIs.
     message: '{{error}} http://go/ipa/106'
     severity: warn
@@ -39,8 +40,6 @@ rules:
     then:
       field: '@key'
       function: 'createMethodRequestBodyIsGetResponse'
-      functionOptions:
-        ignoredValues: ['readOnly', 'writeOnly']
   xgen-IPA-106-create-method-request-has-no-readonly-fields:
     description: >-
       Create method Request object must not include fields with readOnly:true. http://go/ipa/106

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -12,8 +12,11 @@ rules:
   xgen-IPA-106-create-method-request-body-is-request-suffixed-object:
     description: >-
       The Create method request should be a Request suffixed object. http://go/ipa/106
-      This rule applies only to POST requests targeting resource collection URIs.
-    message: '{{error}} http://go/ipa/106'
+
+      ##### Implementation details
+
+      Validation checks the POST method for resource collection paths.
+    message: '{{error}} http://go/ipa-spectral#IPA-106'
     severity: warn
     given: '$.paths[*].post.requestBody.content'
     then:
@@ -22,8 +25,11 @@ rules:
   xgen-IPA-106-create-method-should-not-have-query-parameters:
     description: >-
       Create operations should not use query parameters. http://go/ipa/106
-      This rule applies only to POST requests targeting resource collection URIs.
-    message: '{{error}} http://go/ipa/106'
+
+      ##### Implementation details
+
+      Validation checks the POST method for resource collection paths.
+    message: '{{error}} http://go/ipa-spectral#IPA-106'
     severity: warn
     given: '$.paths[*].post'
     then:
@@ -31,10 +37,13 @@ rules:
   xgen-IPA-106-create-method-request-body-is-get-method-response:
     description: >-
       Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
-      readOnly:true properties of Get method response will be ignored. 
-      writeOnly:true properties of Create method request will be ignored.
-      This rule applies only to POST requests targeting resource collection URIs.
-    message: '{{error}} http://go/ipa/106'
+
+      ##### Implementation details
+
+      Validation checks the POST method for resource collection paths.
+      - `readOnly:true` properties of Get method response will be ignored. 
+      - `writeOnly:true` properties of Create method request will be ignored.
+    message: '{{error}} http://go/ipa-spectral#IPA-106'
     severity: warn
     given: '$.paths[*].post.requestBody.content'
     then:
@@ -43,8 +52,11 @@ rules:
   xgen-IPA-106-create-method-request-has-no-readonly-fields:
     description: >-
       Create method Request object must not include fields with readOnly:true. http://go/ipa/106
-      This rule applies only to POST requests targeting resource collection URIs.
-    message: '{{error}} http://go/ipa/106'
+
+      ##### Implementation details
+
+      Validation checks the POST method for resource collection paths.
+    message: '{{error}} http://go/ipa-spectral#IPA-106'
     severity: warn
     given: '$.paths[*].post.requestBody.content'
     then:
@@ -53,8 +65,11 @@ rules:
   xgen-IPA-106-create-method-response-code-is-201:
     description: >-
       Create methods must return a 201 Created response code. http://go/ipa/106
-      This rule applies only to POST requests targeting resource collection URIs.
-    message: '{{error}} http://go/ipa/106'
+
+      ##### Implementation details
+
+      Validation checks the POST method for resource collection paths.
+    message: '{{error}} http://go/ipa-spectral#IPA-106'
     severity: warn
     given: '$.paths[*].post'
     then:

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -41,8 +41,8 @@ rules:
       ##### Implementation details
 
       Validation checks the POST method for resource collection paths.
-      - `readOnly:true` properties of Get method response will be ignored. 
-      - `writeOnly:true` properties of Create method request will be ignored.
+        - `readOnly:true` properties of Get method response will be ignored. 
+        - `writeOnly:true` properties of Create method request will be ignored.
     message: '{{error}} http://go/ipa-spectral#IPA-106'
     severity: warn
     given: '$.paths[*].post.requestBody.content'

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -1,5 +1,5 @@
 # IPA-106: Create
-# http://go/ipa/106
+# http://go/ipa-spectral#IPA-106
 
 functions:
   - createMethodRequestBodyIsRequestSuffixedObject
@@ -11,7 +11,7 @@ functions:
 rules:
   xgen-IPA-106-create-method-request-body-is-request-suffixed-object:
     description: >-
-      The Create method request should be a Request suffixed object. http://go/ipa/106
+      The Create method request should be a Request suffixed object.
 
       ##### Implementation details
 
@@ -24,7 +24,7 @@ rules:
       function: 'createMethodRequestBodyIsRequestSuffixedObject'
   xgen-IPA-106-create-method-should-not-have-query-parameters:
     description: >-
-      Create operations should not use query parameters. http://go/ipa/106
+      Create operations should not use query parameters.
 
       ##### Implementation details
 
@@ -36,7 +36,7 @@ rules:
       function: 'createMethodShouldNotHaveQueryParameters'
   xgen-IPA-106-create-method-request-body-is-get-method-response:
     description: >-
-      Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
+      Request body content of the Create method and response content of the Get method should refer to the same resource.
 
       ##### Implementation details
 
@@ -51,7 +51,7 @@ rules:
       function: 'createMethodRequestBodyIsGetResponse'
   xgen-IPA-106-create-method-request-has-no-readonly-fields:
     description: >-
-      Create method Request object must not include fields with readOnly:true. http://go/ipa/106
+      Create method Request object must not include fields with readOnly:true.
 
       ##### Implementation details
 
@@ -64,7 +64,7 @@ rules:
       function: 'createMethodRequestHasNoReadonlyFields'
   xgen-IPA-106-create-method-response-code-is-201:
     description: >-
-      Create methods must return a 201 Created response code. http://go/ipa/106
+      Create methods must return a 201 Created response code.
 
       ##### Implementation details
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -101,7 +101,6 @@ The List method request must not include a body. http://go/ipa/105
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
 APIs must provide a List method for resources. http://go/ipa/105
-
 #### xgen-IPA-105-list-method-response-is-get-method-response
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
@@ -132,7 +131,7 @@ Create operations should not use query parameters. http://go/ipa/106 This rule a
 #### xgen-IPA-106-create-method-request-body-is-get-method-response
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106 readOnly/writeOnly properties will be ignored.   This rule applies only to POST requests targeting resource collection URIs.
+Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106 readOnly:true properties of Get method response will be ignored.  writeOnly:true properties of Create method request will be ignored. This rule applies only to POST requests targeting resource collection URIs.
 #### xgen-IPA-106-create-method-request-has-no-readonly-fields
 
  ![warn](https://img.shields.io/badge/warning-yellow) 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -14,16 +14,16 @@ Rule is based on [http://go/ipa/IPA-5](http://go/ipa/IPA-5).
 
 #### xgen-IPA-005-exception-extension-format
 
-![error](https://img.shields.io/badge/error-red)
+ ![error](https://img.shields.io/badge/error-red) 
 IPA exception extensions must follow the correct format. http://go/ipa/5
 
 ##### Implementation details
-
 Rule checks for the following conditions:
+  - Exception rule names must start with 'xgen-IPA-' prefix
+  - Each exception must include a non-empty reason as a string
+  - This rule itself does not allow exceptions
 
-- Exception rule names must start with 'xgen-IPA-' prefix
-- Each exception must include a non-empty reason as a string
-- This rule itself does not allow exceptions
+
 
 ### IPA-102
 
@@ -31,30 +31,29 @@ Rule is based on [http://go/ipa/IPA-102](http://go/ipa/IPA-102).
 
 #### xgen-IPA-102-path-alternate-resource-name-path-param
 
-![error](https://img.shields.io/badge/error-red)
+ ![error](https://img.shields.io/badge/error-red) 
 Paths should alternate between resource names and path params. http://go/ipa/102
-
 #### xgen-IPA-102-collection-identifier-camelCase
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 Collection identifiers must be in camelCase.
 
-##### Implementation details
+ ##### Implementation details
+ Rule checks for the following conditions:
 
-Rule checks for the following conditions:
-
-- All path segments that are not path parameters
-- Only the resource identifier part before any colon in custom method paths (e.g., `resource` in `/resource:customMethod`)
-- Path parameters should also follow camelCase naming
-- Certain values can be exempted via the ignoredValues configuration that can be supplied as `ignoredValues`
-  argument to the rule
-- Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
-- Double slashes (//) are not allowed in paths
+   - All path segments that are not path parameters
+   - Only the resource identifier part before any colon in custom method paths (e.g., `resource` in `/resource:customMethod`)
+   - Path parameters should also follow camelCase naming
+   - Certain values can be exempted via the ignoredValues configuration that can be supplied as `ignoredValues` 
+   argument to the rule
+   - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
+   - Double slashes (//) are not allowed in paths
 
 #### xgen-IPA-102-collection-identifier-pattern
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 Collection identifiers must begin with a lowercase letter and contain only ASCII letters and numbers. http://go/ipa/102
+
 
 ### IPA-104
 
@@ -62,33 +61,29 @@ Rule is based on [http://go/ipa/IPA-104](http://go/ipa/IPA-104).
 
 #### xgen-IPA-104-resource-has-GET
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 APIs must provide a Get method for resources. http://go/ipa/104
-
 #### xgen-IPA-104-get-method-returns-single-resource
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The purpose of the Get method is to return data from a single resource. http://go/ipa/104
-
 #### xgen-IPA-104-get-method-response-code-is-200
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The Get method must return a 200 OK response. http://go/ipa/104
-
 #### xgen-IPA-104-get-method-returns-response-suffixed-object
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The Get method of a resource should return a "Response" suffixed object. http://go/ipa/104
-
 #### xgen-IPA-104-get-method-response-has-no-input-fields
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The Get method response object must not include writeOnly properties (fields that should be used only on creation or update, ie output fields). http://go/ipa/104
-
 #### xgen-IPA-104-get-method-no-request-body
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The Get method request must not include a body. http://go/ipa/104
+
 
 ### IPA-105
 
@@ -96,34 +91,30 @@ Rule is based on [http://go/ipa/IPA-105](http://go/ipa/IPA-105).
 
 #### xgen-IPA-105-list-method-response-code-is-200
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The List method must return a 200 OK response. http://go/ipa/105
-
 #### xgen-IPA-105-list-method-no-request-body
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The List method request must not include a body. http://go/ipa/105
-
 #### xgen-IPA-105-resource-has-list
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 APIs must provide a List method for resources. http://go/ipa/105
-
 #### xgen-IPA-105-list-method-response-is-get-method-response
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The response body of the List method should consist of the same resource object returned by the Get method. http://go/ipa/105
-
 ##### Implementation details
-
 Validation checks that the List method response contains items property with reference to the same schema as the Get method response.
 
-- Validation applies to List methods for resource collections only
-- Validation applies to json response content only
-- Validation ignores responses without schema and non-paginated responses
-  - A response is considered paginated if it contains an array property named `results`
-- Validation ignores resources without a Get method
-- Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
+  - Validation applies to List methods for resource collections only
+  - Validation applies to json response content only
+  - Validation ignores responses without schema and non-paginated responses
+    - A response is considered paginated if it contains an array property named `results`
+  - Validation ignores resources without a Get method
+  - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
+
 
 ### IPA-106
 
@@ -131,28 +122,25 @@ Rule is based on [http://go/ipa/IPA-106](http://go/ipa/IPA-106).
 
 #### xgen-IPA-106-create-method-request-body-is-request-suffixed-object
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 The Create method request should be a Request suffixed object. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
-
 #### xgen-IPA-106-create-method-should-not-have-query-parameters
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 Create operations should not use query parameters. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
-
 #### xgen-IPA-106-create-method-request-body-is-get-method-response
 
-![warn](https://img.shields.io/badge/warning-yellow)
-Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106 readOnly:true properties of Get method response will be ignored. writeOnly:true properties of Create method request will be ignored. This rule applies only to POST requests targeting resource collection URIs.
-
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106 readOnly:true properties of Get method response will be ignored.  writeOnly:true properties of Create method request will be ignored. This rule applies only to POST requests targeting resource collection URIs.
 #### xgen-IPA-106-create-method-request-has-no-readonly-fields
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 Create method Request object must not include fields with readOnly:true. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
-
 #### xgen-IPA-106-create-method-response-code-is-201
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 Create methods must return a 201 Created response code. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
+
 
 ### IPA-108
 
@@ -160,23 +148,21 @@ Rule is based on [http://go/ipa/IPA-108](http://go/ipa/IPA-108).
 
 #### xgen-IPA-108-delete-response-should-be-empty
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 Delete method response should not have schema reference to object. http://go/ipa/108
-
 #### xgen-IPA-108-delete-method-return-204-response
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 DELETE method must return 204 No Content. http://go/ipa/108
-
 #### xgen-IPA-108-delete-include-404-response
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 DELETE method must include 404 response and return it when resource not found. http://go/ipa/108
-
 #### xgen-IPA-108-delete-request-no-body
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 DELETE method must not have request body. http://go/ipa/108
+
 
 ### IPA-109
 
@@ -184,13 +170,13 @@ Rule is based on [http://go/ipa/IPA-109](http://go/ipa/IPA-109).
 
 #### xgen-IPA-109-custom-method-must-be-GET-or-POST
 
-![error](https://img.shields.io/badge/error-red)
+ ![error](https://img.shields.io/badge/error-red) 
 The HTTP method for custom methods must be GET or POST. http://go/ipa/109
-
 #### xgen-IPA-109-custom-method-must-use-camel-case
 
-![error](https://img.shields.io/badge/error-red)
+ ![error](https://img.shields.io/badge/error-red) 
 The custom method must use camelCase format. http://go/ipa/109
+
 
 ### IPA-113
 
@@ -198,8 +184,9 @@ Rule is based on [http://go/ipa/IPA-113](http://go/ipa/IPA-113).
 
 #### xgen-IPA-113-singleton-must-not-have-id
 
-![warn](https://img.shields.io/badge/warning-yellow)
+ ![warn](https://img.shields.io/badge/warning-yellow) 
 Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113
+
 
 ### IPA-123
 
@@ -207,5 +194,8 @@ Rule is based on [http://go/ipa/IPA-123](http://go/ipa/IPA-123).
 
 #### xgen-IPA-123-enum-values-must-be-upper-snake-case
 
-![error](https://img.shields.io/badge/error-red)
+ ![error](https://img.shields.io/badge/error-red) 
 Enum values must be UPPER_SNAKE_CASE. http://go/ipa/123
+
+
+

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -123,23 +123,33 @@ Rule is based on [http://go/ipa/IPA-106](http://go/ipa/IPA-106).
 #### xgen-IPA-106-create-method-request-body-is-request-suffixed-object
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-The Create method request should be a Request suffixed object. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
+The Create method request should be a Request suffixed object. http://go/ipa/106
+##### Implementation details
+Validation checks the POST method for resource collection paths.
 #### xgen-IPA-106-create-method-should-not-have-query-parameters
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Create operations should not use query parameters. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
+Create operations should not use query parameters. http://go/ipa/106
+##### Implementation details
+Validation checks the POST method for resource collection paths.
 #### xgen-IPA-106-create-method-request-body-is-get-method-response
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106 readOnly:true properties of Get method response will be ignored.  writeOnly:true properties of Create method request will be ignored. This rule applies only to POST requests targeting resource collection URIs.
+Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
+##### Implementation details
+Validation checks the POST method for resource collection paths. - `readOnly:true` properties of Get method response will be ignored.  - `writeOnly:true` properties of Create method request will be ignored.
 #### xgen-IPA-106-create-method-request-has-no-readonly-fields
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Create method Request object must not include fields with readOnly:true. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
+Create method Request object must not include fields with readOnly:true. http://go/ipa/106
+##### Implementation details
+Validation checks the POST method for resource collection paths.
 #### xgen-IPA-106-create-method-response-code-is-201
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Create methods must return a 201 Created response code. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
+Create methods must return a 201 Created response code. http://go/ipa/106
+##### Implementation details
+Validation checks the POST method for resource collection paths.
 
 
 ### IPA-108

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -123,19 +123,19 @@ Rule is based on [http://go/ipa/IPA-106](http://go/ipa/IPA-106).
 #### xgen-IPA-106-create-method-request-body-is-request-suffixed-object
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-The Create method request should be a Request suffixed object. http://go/ipa/106
+The Create method request should be a Request suffixed object.
 ##### Implementation details
 Validation checks the POST method for resource collection paths.
 #### xgen-IPA-106-create-method-should-not-have-query-parameters
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Create operations should not use query parameters. http://go/ipa/106
+Create operations should not use query parameters.
 ##### Implementation details
 Validation checks the POST method for resource collection paths.
 #### xgen-IPA-106-create-method-request-body-is-get-method-response
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
+Request body content of the Create method and response content of the Get method should refer to the same resource.
 ##### Implementation details
 Validation checks the POST method for resource collection paths.
   - `readOnly:true` properties of Get method response will be ignored. 
@@ -143,13 +143,13 @@ Validation checks the POST method for resource collection paths.
 #### xgen-IPA-106-create-method-request-has-no-readonly-fields
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Create method Request object must not include fields with readOnly:true. http://go/ipa/106
+Create method Request object must not include fields with readOnly:true.
 ##### Implementation details
 Validation checks the POST method for resource collection paths.
 #### xgen-IPA-106-create-method-response-code-is-201
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Create methods must return a 201 Created response code. http://go/ipa/106
+Create methods must return a 201 Created response code.
 ##### Implementation details
 Validation checks the POST method for resource collection paths.
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -137,7 +137,9 @@ Validation checks the POST method for resource collection paths.
  ![warn](https://img.shields.io/badge/warning-yellow) 
 Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106
 ##### Implementation details
-Validation checks the POST method for resource collection paths. - `readOnly:true` properties of Get method response will be ignored.  - `writeOnly:true` properties of Create method request will be ignored.
+Validation checks the POST method for resource collection paths.
+  - `readOnly:true` properties of Get method response will be ignored. 
+  - `writeOnly:true` properties of Create method request will be ignored.
 #### xgen-IPA-106-create-method-request-has-no-readonly-fields
 
  ![warn](https://img.shields.io/badge/warning-yellow) 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -14,16 +14,16 @@ Rule is based on [http://go/ipa/IPA-5](http://go/ipa/IPA-5).
 
 #### xgen-IPA-005-exception-extension-format
 
- ![error](https://img.shields.io/badge/error-red) 
+![error](https://img.shields.io/badge/error-red)
 IPA exception extensions must follow the correct format. http://go/ipa/5
 
 ##### Implementation details
+
 Rule checks for the following conditions:
-  - Exception rule names must start with 'xgen-IPA-' prefix
-  - Each exception must include a non-empty reason as a string
-  - This rule itself does not allow exceptions
 
-
+- Exception rule names must start with 'xgen-IPA-' prefix
+- Each exception must include a non-empty reason as a string
+- This rule itself does not allow exceptions
 
 ### IPA-102
 
@@ -31,29 +31,30 @@ Rule is based on [http://go/ipa/IPA-102](http://go/ipa/IPA-102).
 
 #### xgen-IPA-102-path-alternate-resource-name-path-param
 
- ![error](https://img.shields.io/badge/error-red) 
+![error](https://img.shields.io/badge/error-red)
 Paths should alternate between resource names and path params. http://go/ipa/102
+
 #### xgen-IPA-102-collection-identifier-camelCase
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 Collection identifiers must be in camelCase.
 
- ##### Implementation details
- Rule checks for the following conditions:
+##### Implementation details
 
-   - All path segments that are not path parameters
-   - Only the resource identifier part before any colon in custom method paths (e.g., `resource` in `/resource:customMethod`)
-   - Path parameters should also follow camelCase naming
-   - Certain values can be exempted via the ignoredValues configuration that can be supplied as `ignoredValues` 
-   argument to the rule
-   - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
-   - Double slashes (//) are not allowed in paths
+Rule checks for the following conditions:
+
+- All path segments that are not path parameters
+- Only the resource identifier part before any colon in custom method paths (e.g., `resource` in `/resource:customMethod`)
+- Path parameters should also follow camelCase naming
+- Certain values can be exempted via the ignoredValues configuration that can be supplied as `ignoredValues`
+  argument to the rule
+- Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
+- Double slashes (//) are not allowed in paths
 
 #### xgen-IPA-102-collection-identifier-pattern
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 Collection identifiers must begin with a lowercase letter and contain only ASCII letters and numbers. http://go/ipa/102
-
 
 ### IPA-104
 
@@ -61,29 +62,33 @@ Rule is based on [http://go/ipa/IPA-104](http://go/ipa/IPA-104).
 
 #### xgen-IPA-104-resource-has-GET
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 APIs must provide a Get method for resources. http://go/ipa/104
+
 #### xgen-IPA-104-get-method-returns-single-resource
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The purpose of the Get method is to return data from a single resource. http://go/ipa/104
+
 #### xgen-IPA-104-get-method-response-code-is-200
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The Get method must return a 200 OK response. http://go/ipa/104
+
 #### xgen-IPA-104-get-method-returns-response-suffixed-object
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The Get method of a resource should return a "Response" suffixed object. http://go/ipa/104
+
 #### xgen-IPA-104-get-method-response-has-no-input-fields
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The Get method response object must not include writeOnly properties (fields that should be used only on creation or update, ie output fields). http://go/ipa/104
+
 #### xgen-IPA-104-get-method-no-request-body
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The Get method request must not include a body. http://go/ipa/104
-
 
 ### IPA-105
 
@@ -91,30 +96,34 @@ Rule is based on [http://go/ipa/IPA-105](http://go/ipa/IPA-105).
 
 #### xgen-IPA-105-list-method-response-code-is-200
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The List method must return a 200 OK response. http://go/ipa/105
+
 #### xgen-IPA-105-list-method-no-request-body
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The List method request must not include a body. http://go/ipa/105
+
 #### xgen-IPA-105-resource-has-list
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 APIs must provide a List method for resources. http://go/ipa/105
+
 #### xgen-IPA-105-list-method-response-is-get-method-response
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The response body of the List method should consist of the same resource object returned by the Get method. http://go/ipa/105
+
 ##### Implementation details
+
 Validation checks that the List method response contains items property with reference to the same schema as the Get method response.
 
-  - Validation applies to List methods for resource collections only
-  - Validation applies to json response content only
-  - Validation ignores responses without schema and non-paginated responses
-    - A response is considered paginated if it contains an array property named `results`
-  - Validation ignores resources without a Get method
-  - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
-
+- Validation applies to List methods for resource collections only
+- Validation applies to json response content only
+- Validation ignores responses without schema and non-paginated responses
+  - A response is considered paginated if it contains an array property named `results`
+- Validation ignores resources without a Get method
+- Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
 
 ### IPA-106
 
@@ -122,25 +131,28 @@ Rule is based on [http://go/ipa/IPA-106](http://go/ipa/IPA-106).
 
 #### xgen-IPA-106-create-method-request-body-is-request-suffixed-object
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 The Create method request should be a Request suffixed object. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
+
 #### xgen-IPA-106-create-method-should-not-have-query-parameters
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 Create operations should not use query parameters. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
+
 #### xgen-IPA-106-create-method-request-body-is-get-method-response
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
-Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106 readOnly:true properties of Get method response will be ignored.  writeOnly:true properties of Create method request will be ignored. This rule applies only to POST requests targeting resource collection URIs.
+![warn](https://img.shields.io/badge/warning-yellow)
+Request body content of the Create method and response content of the Get method should refer to the same resource. http://go/ipa/106 readOnly:true properties of Get method response will be ignored. writeOnly:true properties of Create method request will be ignored. This rule applies only to POST requests targeting resource collection URIs.
+
 #### xgen-IPA-106-create-method-request-has-no-readonly-fields
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 Create method Request object must not include fields with readOnly:true. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
+
 #### xgen-IPA-106-create-method-response-code-is-201
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 Create methods must return a 201 Created response code. http://go/ipa/106 This rule applies only to POST requests targeting resource collection URIs.
-
 
 ### IPA-108
 
@@ -148,21 +160,23 @@ Rule is based on [http://go/ipa/IPA-108](http://go/ipa/IPA-108).
 
 #### xgen-IPA-108-delete-response-should-be-empty
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 Delete method response should not have schema reference to object. http://go/ipa/108
+
 #### xgen-IPA-108-delete-method-return-204-response
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 DELETE method must return 204 No Content. http://go/ipa/108
+
 #### xgen-IPA-108-delete-include-404-response
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 DELETE method must include 404 response and return it when resource not found. http://go/ipa/108
+
 #### xgen-IPA-108-delete-request-no-body
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 DELETE method must not have request body. http://go/ipa/108
-
 
 ### IPA-109
 
@@ -170,13 +184,13 @@ Rule is based on [http://go/ipa/IPA-109](http://go/ipa/IPA-109).
 
 #### xgen-IPA-109-custom-method-must-be-GET-or-POST
 
- ![error](https://img.shields.io/badge/error-red) 
+![error](https://img.shields.io/badge/error-red)
 The HTTP method for custom methods must be GET or POST. http://go/ipa/109
+
 #### xgen-IPA-109-custom-method-must-use-camel-case
 
- ![error](https://img.shields.io/badge/error-red) 
+![error](https://img.shields.io/badge/error-red)
 The custom method must use camelCase format. http://go/ipa/109
-
 
 ### IPA-113
 
@@ -184,9 +198,8 @@ Rule is based on [http://go/ipa/IPA-113](http://go/ipa/IPA-113).
 
 #### xgen-IPA-113-singleton-must-not-have-id
 
- ![warn](https://img.shields.io/badge/warning-yellow) 
+![warn](https://img.shields.io/badge/warning-yellow)
 Singleton resources must not have a user-provided or system-generated ID. http://go/ipa/113
-
 
 ### IPA-123
 
@@ -194,8 +207,5 @@ Rule is based on [http://go/ipa/IPA-123](http://go/ipa/IPA-123).
 
 #### xgen-IPA-123-enum-values-must-be-upper-snake-case
 
- ![error](https://img.shields.io/badge/error-red) 
+![error](https://img.shields.io/badge/error-red)
 Enum values must be UPPER_SNAKE_CASE. http://go/ipa/123
-
-
-


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-304053

Refines the rule with the latest spec [changes](https://docs.google.com/document/d/1sMwvhyzUaAa8Y56WXHHj44MVoEaedLsQh45K0ZwnKE4/edit?tab=t.ptrwft2w5x35#bookmark=id.s543xrkvig2k)
Before comparing the schemas:
- Remove readOnly:true properties from Get response
- Remove writeOnly:true properties from Create request

Drive-by changes on the descriptions and error messages to follow the latest documentation format


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
