### PR TITLE
fix: allow to use custom openapi file

### DIFF
--- a/tools/spectral/ipa/scripts/filter-ipa-violations.js
+++ b/tools/spectral/ipa/scripts/filter-ipa-violations.js
@@ -88,12 +88,11 @@ async function filterIpaViolations() {
     // Generate markdown content
     let markdownContent = `# ${ruleId} Violations Checklist\n\n`;
     markdownContent += `Generated on: ${new Date().toLocaleString()}\n\n`;
-
     Object.keys(groupedBySource).forEach((source) => {
       const violations = groupedBySource[source];
 
       violations.forEach((violation) => {
-        markdownContent += `## ${violation.source}\n\n`;
+        markdownContent += `## ${violation.message}\n\n`;
         markdownContent += `Path: \`${violation.path.join('/')}\`\n\n`;
         markdownContent += `- [ ] Fixed\n\n`;
       });

--- a/tools/spectral/ipa/scripts/filter-ipa-violations.js
+++ b/tools/spectral/ipa/scripts/filter-ipa-violations.js
@@ -1,27 +1,47 @@
 import fs from 'node:fs/promises';
 import { execSync } from 'child_process';
 import path from 'path';
+import http from 'http';
+import https from 'https';
 
 async function filterIpaViolations() {
   try {
     // Check if rule ID is provided
     const ruleId = process.argv[2];
     if (!ruleId) {
-      console.error('Usage: node filter-ipa-violations.js <rule-id>');
+      console.error('Usage: node filter-ipa-violations.js <rule-id> [remote-openapi-url]');
       console.error('Example: node filter-ipa-violations.js xgen-IPA-102-collection-identifier-camelCase');
+      console.error(
+        'Example with remote file: node filter-ipa-violations.js xgen-IPA-102-collection-identifier-camelCase https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/.raw/v2.yaml'
+      );
       process.exit(1);
     }
 
+    // Check if a remote OpenAPI file URL is provided
+    const remoteUrl = process.argv[3];
     const outputFile = path.join(process.cwd(), `${ruleId}-violations.md`);
 
     console.log(`Filtering violations for rule ID: ${ruleId}`);
     console.log('Running IPA validation...');
 
+    // If remote URL provided, download it to a temp file
+    let openapiFilePath = './openapi/.raw/v2.yaml'; // Default local file
+    let tempFile = null;
+
+    if (remoteUrl) {
+      console.log(`Using remote OpenAPI file: ${remoteUrl}`);
+      tempFile = path.join(process.cwd(), 'temp_openapi_file.yaml');
+      await downloadFile(remoteUrl, tempFile);
+      openapiFilePath = tempFile;
+    } else {
+      console.log('Using local OpenAPI file');
+    }
+
     let validationOutput;
     try {
       // Run IPA validation and get output as JSON
       execSync(
-        'spectral lint --format=json -o results.json ./openapi/.raw/v2.yaml --ruleset=./tools/spectral/ipa/ipa-spectral.yaml',
+        `spectral lint --format=json -o results.json ${openapiFilePath} --ruleset=./tools/spectral/ipa/ipa-spectral.yaml`,
         {
           encoding: 'utf-8',
           timeout: 4000,
@@ -30,6 +50,15 @@ async function filterIpaViolations() {
       );
     } catch (error) {
       console.error('Error (expected):', error.message);
+    } finally {
+      // Clean up temp file if it exists
+      if (tempFile) {
+        try {
+          await fs.unlink(tempFile);
+        } catch (err) {
+          console.error('Error removing temporary file:', err.message);
+        }
+      }
     }
 
     // Read the JSON output
@@ -80,6 +109,36 @@ async function filterIpaViolations() {
     console.error('Error:', error.message);
     process.exit(1);
   }
+}
+
+// Function to download a file from a URL
+function downloadFile(url, outputPath) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https') ? https : http;
+
+    console.log(`Downloading OpenAPI file from ${url}...`);
+
+    const request = client.get(url, (response) => {
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        return reject(new Error(`Failed to download file, status code: ${response.statusCode}`));
+      }
+
+      const file = fs.open(outputPath, 'w').then((fileHandle) => fileHandle.createWriteStream());
+      file
+        .then((fileStream) => {
+          response.pipe(fileStream);
+          response.on('end', () => {
+            console.log('Download complete');
+            resolve();
+          });
+        })
+        .catch(reject);
+    });
+
+    request.on('error', (err) => {
+      reject(err);
+    });
+  });
 }
 
 filterIpaViolations();


### PR DESCRIPTION
## Proposed changes

For exception management I have been manually copying downstream PR's openAPI so far. This PR automates it so you can automatically refresh exceptions based on new openapi changes.


Example:
```
 npm run ipa-filter-violations xgen-IPA-102-collection-identifier-camelCase https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/.raw/v2.yaml
```

Example for fixed issues (verification of exception PR):

```
npm run ipa-filter-violations xgen-IPA-108-delete-response-should-be-empty https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/.raw/v2.yaml 

> ipa-filter-violations
> node tools/spectral/ipa/scripts/filter-ipa-violations.js xgen-IPA-108-delete-response-should-be-empty https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/.raw/v2.yaml

Filtering violations for rule ID: xgen-IPA-108-delete-response-should-be-empty
Running IPA validation...
Using remote OpenAPI file: xxx
Downloading OpenAPI file from xxx
Download complete
(node:35488) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Filtering results...
Results saved to/openapi/xgen-IPA-108-delete-response-should-be-empty-violations.md
Found 0 violations to fix
....
Results saved to /Users/w.trocki/Projects/sandbox/openapi/xgen-IPA-108-delete-request-no-body-violations.md
Found 0 violations to fix
```