### PR TITLE
CLOUDP-306812: update gh action to use new raw spec

### DIFF
--- a/.github/workflows/api-versions-reminder.yml
+++ b/.github/workflows/api-versions-reminder.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Retrieve Sunset APIs
         id: retrieve-sunset-apis
         env:
-          openapi_spec_url: "https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/v2.json"
+          openapi_spec_url: "https://raw.githubusercontent.com/mongodb/openapi/refs/heads/dev/openapi/.raw/v2.json"
         run: |
           three_months_date=""
           


### PR DESCRIPTION
## Proposed changes
CLOUDP-306812
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-306812
 ## Bug:
The Sunset Reminder action is using the OpenAPI spec file (openapi/v2.json), which was recently updated to remove all x-gen extensions (see PR [#497](https://github.com/mongodb/openapi/pull/497)). As a result of this change, the action could no longer retrieve the x-xgen-owner-team extension, leading to a different SHA value compared to the one generated the week before.

This PR updates the action to use the .raw/v2.json file which contains all the extensions