### PR TITLE
chore: separate code health gh action per tools to run only when specific paths are changed

### DIFF
--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -5,7 +5,11 @@ on:
       - main
     paths: 
       - 'tools/cli/**'
-  pull_request: {}
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'tools/cli/**'
   workflow_dispatch: {}
   workflow_call: {}
 

--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -74,6 +74,11 @@ jobs:
         with:
           sparse-checkout: |
             .github
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -1,0 +1,94 @@
+name: 'Code Health FoasCLI'
+on:
+  push:
+    branches:
+      - main
+    paths: 
+      - 'tools/cli/**'
+  pull_request: {}
+  workflow_dispatch: {}
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout CLI
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+    - name: Install Go
+      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+      with:
+        go-version-file: 'tools/cli/go.mod'
+    - name: Build CLI
+      working-directory: tools/cli
+      run: make build
+  unit-tests:
+    needs: build
+    env:
+      COVERAGE: coverage.out
+      UNIT_TAGS: unit
+      INTEGRATION_TAGS: integration
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+        with:
+          go-version-file: 'tools/cli/go.mod'
+      - name: Run unit tests
+        working-directory: tools/cli
+        run: make unit-test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          sparse-checkout: |
+            .github
+            tools
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+        with:
+          go-version-file: 'tools/cli/go.mod'
+          cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837
+        with:
+          version: v1.64.5
+          working-directory: tools/cli
+      - name: Checkout GitHub actions
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+        with:
+          sparse-checkout: |
+            .github
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash
+  e2e-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
+        with:
+          go-version-file: 'tools/cli/go.mod'
+      - name: Run e2e tests
+        working-directory: tools/cli
+        run: make e2e-test

--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -6,7 +6,12 @@ on:
     paths: 
       - 'tools/postman/**'
       - 'tools/spectral/**'
-  pull_request: {}
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'tools/postman/**'
+      - 'tools/spectral/**'
   workflow_dispatch: {}
   workflow_call: {}
 

--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
     paths: 
-      - 'tools/**'
+      - 'tools/postman/**'
+      - 'tools/spectral/**'
   pull_request: {}
   workflow_dispatch: {}
   workflow_call: {}
@@ -13,39 +14,6 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout CLI
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-    - name: Install Go
-      uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
-      with:
-        go-version-file: 'tools/cli/go.mod'
-    - name: Build CLI
-      working-directory: tools/cli
-      run: make build
-  unit-tests:
-    needs: build
-    env:
-      COVERAGE: coverage.out
-      UNIT_TAGS: unit
-      INTEGRATION_TAGS: integration
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - name: Install Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
-        with:
-          go-version-file: 'tools/cli/go.mod'
-      - name: Run unit tests
-        working-directory: tools/cli
-        run: make unit-test
   js-tests:
     runs-on: ubuntu-latest
     steps:
@@ -95,21 +63,6 @@ jobs:
             exit 1
           fi
           exit 0
-      - name: Install Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
-        with:
-          go-version-file: 'tools/cli/go.mod'
-          cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837
-        with:
-          version: v1.64.5
-          working-directory: tools/cli
-      - name: Checkout GitHub actions
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-        with:
-          sparse-checkout: |
-            .github
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -119,16 +72,3 @@ jobs:
           echo "::add-matcher::.github/actionlint-matcher.json"
           ${{ steps.get_actionlint.outputs.executable }} -color
         shell: bash
-  e2e-tests:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
-      - name: Install Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34
-        with:
-          go-version-file: 'tools/cli/go.mod'
-      - name: Run e2e tests
-        working-directory: tools/cli
-        run: make e2e-test


### PR DESCRIPTION
## Proposed changes
This pull request includes changes to the GitHub Actions workflows to improve the code health checks for different tools. The most significant changes involve creating a new workflow for the CLI tool and updating the existing workflow for other tools.

### New Workflow for CLI Tool:
* Added a new workflow file `.github/workflows/code-health-foascli.yml` to handle code health checks specifically for the CLI tool, including build, unit tests, lint, and end-to-end tests.

### Updates to Existing Workflow:
* Modified the `.github/workflows/code-health-tools.yml` file to narrow the scope to only `tools/postman` and `tools/spectral` directories, and removed CLI-specific jobs from this workflow. [[1]](diffhunk://#diff-b2f6e857d1e8357cfffb4a0389831809a40aeb2bb404959caa74e4f2f75a4d75L7-L48) [[2]](diffhunk://#diff-b2f6e857d1e8357cfffb4a0389831809a40aeb2bb404959caa74e4f2f75a4d75L98-L112) [[3]](diffhunk://#diff-b2f6e857d1e8357cfffb4a0389831809a40aeb2bb404959caa74e4f2f75a4d75L122-L134)
