### PR TITLE
CLOUDP-306347: isSingleResourceIdentifier for delete operations

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA108DeleteMethod204Response.test.js
+++ b/tools/spectral/ipa/__tests__/IPA108DeleteMethod204Response.test.js
@@ -101,4 +101,45 @@ testRule('xgen-IPA-108-delete-method-return-204-response', [
     },
     errors: [],
   },
+  {
+    name: 'skipped for collection endpoint (no path parameter)',
+    document: {
+      paths: {
+        '/resources': {
+          delete: {
+            responses: {
+              200: {
+                description: 'Resource deleted',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'applied for single resource endpoint (with path parameter)',
+    document: {
+      paths: {
+        '/resources/{resourceId}': {
+          delete: {
+            responses: {
+              200: {
+                description: 'Resource deleted',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-108-delete-method-return-204-response',
+        message: 'DELETE method should return 204 No Content status code.',
+        path: ['paths', '/resources/{resourceId}', 'delete'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
 ]);

--- a/tools/spectral/ipa/__tests__/IPA108DeleteMethod404Response.test.js
+++ b/tools/spectral/ipa/__tests__/IPA108DeleteMethod404Response.test.js
@@ -98,4 +98,41 @@ testRule('xgen-IPA-108-delete-include-404-response', [
     },
     errors: [],
   },
+  {
+    name: 'skipped for collection endpoint (no path parameter)',
+    document: {
+      paths: {
+        '/resources': {
+          delete: {
+            responses: {
+              204: {},
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'applied for single resource endpoint (with path parameter)',
+    document: {
+      paths: {
+        '/resources/{resourceId}': {
+          delete: {
+            responses: {
+              204: {},
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-108-delete-include-404-response',
+        message: 'DELETE method should include 404 status code for not found resources.',
+        path: ['paths', '/resources/{resourceId}', 'delete'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
 ]);

--- a/tools/spectral/ipa/__tests__/IPA108DeleteMethodNoRequestBody.test.js
+++ b/tools/spectral/ipa/__tests__/IPA108DeleteMethodNoRequestBody.test.js
@@ -68,4 +68,49 @@ testRule('xgen-IPA-108-delete-request-no-body', [
     },
     errors: [],
   },
+  {
+    name: 'skipped for collection endpoint (no path parameter)',
+    document: {
+      paths: {
+        '/resources': {
+          delete: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { type: 'object' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'applied for single resource endpoint (with path parameter)',
+    document: {
+      paths: {
+        '/resources/{resourceId}': {
+          delete: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: { type: 'object' },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-108-delete-request-no-body',
+        message: 'DELETE method should not have a request body.',
+        path: ['paths', '/resources/{resourceId}', 'delete'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
 ]);

--- a/tools/spectral/ipa/__tests__/IPA108DeleteMethodResponseShouldNotHaveSchema.test.js
+++ b/tools/spectral/ipa/__tests__/IPA108DeleteMethodResponseShouldNotHaveSchema.test.js
@@ -95,4 +95,54 @@ testRule('xgen-IPA-108-delete-response-should-be-empty', [
     },
     errors: [],
   },
+  {
+    name: 'skipped for collection endpoint (no path parameter)',
+    document: {
+      paths: {
+        '/resources': {
+          delete: {
+            responses: {
+              204: {
+                content: {
+                  'application/vnd.atlas.2023-01-01+json': {
+                    schema: { type: 'object' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'applied for single resource endpoint (with path parameter)',
+    document: {
+      paths: {
+        '/resources/{resourceId}': {
+          delete: {
+            responses: {
+              204: {
+                content: {
+                  'application/vnd.atlas.2023-01-01+json': {
+                    schema: { type: 'object' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-108-delete-response-should-be-empty',
+        message:
+          'Error found for application/vnd.atlas.2023-01-01+json: DELETE method should return an empty response. The response should not have a schema property.',
+        path: ['paths', '/resources/{resourceId}', 'delete', 'responses', '204'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
 ]);

--- a/tools/spectral/ipa/rulesets/IPA-108.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-108.yaml
@@ -8,9 +8,10 @@ rules:
 
       ##### Implementation details
       Rule checks for the following conditions:
-        - Applies to 204 responses in DELETE methods
+        - Applies to 204 responses in DELETE methods for single resource endpoints (with path parameters)
         - Verifies that the response does not contain a schema property
         - Fails if any content type in the response has a defined schema as reference
+        - Skips validation for collection endpoints (without path parameters)
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-delete-response-should-be-empty'
     severity: warn
     given: $.paths[*].delete.responses[204]
@@ -23,11 +24,12 @@ rules:
 
       ##### Implementation details
       Rule checks for the following conditions:
-        - Applies to all DELETE methods
-         - Verifies the 204 No Content response code is present
+        - Applies to all DELETE methods for single resource endpoints (with path parameters)
+        - Verifies the 204 No Content response code is present
         - Fails if the method lacks a 204 No Content response or defines a different 2xx status code
         - Ensures no other 2xx response codes are defined
         - Fails if the 204 status code is missing or if other 2xx responses exist
+        - Skips validation for collection endpoints (without path parameters)
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-delete-method-return-204-response'
     severity: warn
     given: $.paths[*].delete
@@ -40,9 +42,10 @@ rules:
 
       ##### Implementation details
       Rule checks for the following conditions:
-        - Applies to all DELETE methods
+        - Applies to all DELETE methods for single resource endpoints (with path parameters)
         - Verifies that the method includes a 404 response code
         - Fails if the 404 status code is missing from the responses
+        - Skips validation for collection endpoints (without path parameters)
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-delete-include-404-response'
     severity: warn
     given: $.paths[*].delete
@@ -55,9 +58,10 @@ rules:
 
       ##### Implementation details
       Rule checks for the following conditions:
-        - Applies to all DELETE methods
+        - Applies to all DELETE methods for single resource endpoints (with path parameters)
         - Verifies that the operation object does not contain a requestBody property
         - Fails if any requestBody is defined for the DELETE method
+        - Skips validation for collection endpoints (without path parameters)
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-delete-request-no-body'
     severity: warn
     given: $.paths[*].delete

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -326,9 +326,10 @@ Delete method response should not have schema reference to object.
 
 ##### Implementation details
 Rule checks for the following conditions:
-  - Applies to 204 responses in DELETE methods
+  - Applies to 204 responses in DELETE methods for single resource endpoints (with path parameters)
   - Verifies that the response does not contain a schema property
   - Fails if any content type in the response has a defined schema as reference
+  - Skips validation for collection endpoints (without path parameters)
 
 #### xgen-IPA-108-delete-method-return-204-response
 
@@ -337,11 +338,12 @@ DELETE method must return 204 No Content.
 
 ##### Implementation details
 Rule checks for the following conditions:
-  - Applies to all DELETE methods
-   - Verifies the 204 No Content response code is present
+  - Applies to all DELETE methods for single resource endpoints (with path parameters)
+  - Verifies the 204 No Content response code is present
   - Fails if the method lacks a 204 No Content response or defines a different 2xx status code
   - Ensures no other 2xx response codes are defined
   - Fails if the 204 status code is missing or if other 2xx responses exist
+  - Skips validation for collection endpoints (without path parameters)
 
 #### xgen-IPA-108-delete-include-404-response
 
@@ -350,9 +352,10 @@ DELETE method must include 404 response and return it when resource not found.
 
 ##### Implementation details
 Rule checks for the following conditions:
-  - Applies to all DELETE methods
+  - Applies to all DELETE methods for single resource endpoints (with path parameters)
   - Verifies that the method includes a 404 response code
   - Fails if the 404 status code is missing from the responses
+  - Skips validation for collection endpoints (without path parameters)
 
 #### xgen-IPA-108-delete-request-no-body
 
@@ -361,9 +364,10 @@ DELETE method must not have request body.
 
 ##### Implementation details
 Rule checks for the following conditions:
-  - Applies to all DELETE methods
+  - Applies to all DELETE methods for single resource endpoints (with path parameters)
   - Verifies that the operation object does not contain a requestBody property
   - Fails if any requestBody is defined for the DELETE method
+  - Skips validation for collection endpoints (without path parameters)
 
 
 

--- a/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethod204Response.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethod204Response.js
@@ -4,6 +4,7 @@ import {
   collectException,
   handleInternalError,
 } from './utils/collectionUtils.js';
+import { isSingleResourceIdentifier } from './utils/resourceEvaluation.js';
 import { hasException } from './utils/exceptions.js';
 
 const RULE_NAME = 'xgen-IPA-108-delete-method-return-204-response';
@@ -17,6 +18,17 @@ const ERROR_MESSAGE = 'DELETE method should return 204 No Content status code.';
  * @param {object} context - The context object containing the path
  */
 export default (input, _, { path }) => {
+  // Check if the path is for a single resource (e.g., has path parameter)
+  // Extract the path from context.path which is an array
+  const pathString = path[1]; // Assuming path is ['paths', '/resource/{id}', 'delete']
+  if (!isSingleResourceIdentifier(pathString)) {
+    return;
+  }
+
+  if (!input || typeof input !== 'object') {
+    return;
+  }
+
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethod204Response.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethod204Response.js
@@ -25,10 +25,6 @@ export default (input, _, { path }) => {
     return;
   }
 
-  if (!input || typeof input !== 'object') {
-    return;
-  }
-
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethod404Response.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethod404Response.js
@@ -20,10 +20,6 @@ export default (input, _, { path }) => {
     return;
   }
 
-  if (!input || typeof input !== 'object') {
-    return;
-  }
-
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethod404Response.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethod404Response.js
@@ -1,4 +1,5 @@
 import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { isSingleResourceIdentifier } from './utils/resourceEvaluation.js';
 import { hasException } from './utils/exceptions.js';
 
 const RULE_NAME = 'xgen-IPA-108-delete-include-404-response';
@@ -12,6 +13,17 @@ const ERROR_MESSAGE = 'DELETE method should include 404 status code for not foun
  * @param {object} context - The context object containing the path
  */
 export default (input, _, { path }) => {
+  // Check if the path is for a single resource (e.g., has path parameter)
+  // Extract the path from context.path which is an array
+  const pathString = path[1]; // Assuming path is ['paths', '/resource/{id}', 'delete']
+  if (!isSingleResourceIdentifier(pathString)) {
+    return;
+  }
+
+  if (!input || typeof input !== 'object') {
+    return;
+  }
+
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethodNoRequestBody.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethodNoRequestBody.js
@@ -1,4 +1,5 @@
 import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { isSingleResourceIdentifier } from './utils/resourceEvaluation.js';
 import { hasException } from './utils/exceptions.js';
 
 const RULE_NAME = 'xgen-IPA-108-delete-request-no-body';
@@ -12,6 +13,17 @@ const ERROR_MESSAGE = 'DELETE method should not have a request body.';
  * @param {object} context - The context object containing the path
  */
 export default (input, _, { path }) => {
+  // Check if the path is for a single resource (e.g., has path parameter)
+  // Extract the path from context.path which is an array
+  const pathString = path[1]; // Assuming path is ['paths', '/resource/{id}', 'delete']
+  if (!isSingleResourceIdentifier(pathString)) {
+    return;
+  }
+
+  if (!input || typeof input !== 'object') {
+    return;
+  }
+
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethodNoRequestBody.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethodNoRequestBody.js
@@ -20,10 +20,6 @@ export default (input, _, { path }) => {
     return;
   }
 
-  if (!input || typeof input !== 'object') {
-    return;
-  }
-
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethodResponseShouldNotHaveSchema.js
@@ -17,20 +17,8 @@ const ERROR_MESSAGE = 'DELETE method should return an empty response. The respon
  * @param {object} context - The context object containing the path
  */
 export default (input, _, { path }) => {
-  // Since this rule is applied to the response object (204 response),
-  // we need to extract the path from the context.path array differently
-  // Assuming path is like ['paths', '/resource/{id}', 'delete', 'responses', '204']
-
-  if (path.length < 3) {
-    return;
-  }
-
   const pathString = path[1]; // Extract the resource path
   if (!isSingleResourceIdentifier(pathString)) {
-    return;
-  }
-
-  if (!input || typeof input !== 'object') {
     return;
   }
 

--- a/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethodResponseShouldNotHaveSchema.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA108DeleteMethodResponseShouldNotHaveSchema.js
@@ -5,6 +5,7 @@ import {
   collectException,
   handleInternalError,
 } from './utils/collectionUtils.js';
+import { isSingleResourceIdentifier } from './utils/resourceEvaluation.js';
 
 const RULE_NAME = 'xgen-IPA-108-delete-response-should-be-empty';
 const ERROR_MESSAGE = 'DELETE method should return an empty response. The response should not have a schema property.';
@@ -16,6 +17,23 @@ const ERROR_MESSAGE = 'DELETE method should return an empty response. The respon
  * @param {object} context - The context object containing the path
  */
 export default (input, _, { path }) => {
+  // Since this rule is applied to the response object (204 response),
+  // we need to extract the path from the context.path array differently
+  // Assuming path is like ['paths', '/resource/{id}', 'delete', 'responses', '204']
+
+  if (path.length < 3) {
+    return;
+  }
+
+  const pathString = path[1]; // Extract the resource path
+  if (!isSingleResourceIdentifier(pathString)) {
+    return;
+  }
+
+  if (!input || typeof input !== 'object') {
+    return;
+  }
+
   // 1. Handle exception on OpenAPI schema
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);


### PR DESCRIPTION
## Proposed changes

Refined DELETE operations validation rules (IPA-108) to only apply to single resource endpoints with path parameters. This ensures proper REST semantics where DELETE should operate on specific resources rather than collections.

### Changes include:
- Updated documentation to clarify rule application scope
- Added test cases to verify correct behavior for both resource and collection endpoints
- Added path parameter detection using the `isSingleResourceIdentifier` helper

Reused helper function created by @yelizhenden-mdb. Thank you for refinement and implementation!