### PR TITLE
CLOUDP-304945: Add xgen-IPA-107-update-method-response-is-get-method-response

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA107UpdateMethodResponseIsGetMethodResponse.test.js
+++ b/tools/spectral/ipa/__tests__/IPA107UpdateMethodResponseIsGetMethodResponse.test.js
@@ -22,26 +22,11 @@ const componentSchemas = {
   },
 };
 
-testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
+testRule('xgen-IPA-107-update-method-response-is-get-method-response', [
   {
-    name: 'valid create responses',
+    name: 'valid update responses',
     document: {
       paths: {
-        '/resources': {
-          post: {
-            responses: {
-              201: {
-                content: {
-                  'application/vnd.atlas.2024-08-05+json': {
-                    schema: {
-                      $ref: '#/components/schemas/ResourceSchema',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
         '/resources/{id}': {
           get: {
             responses: {
@@ -56,12 +41,25 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
               },
             },
           },
+          patch: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-08-05+json': {
+                    schema: {
+                      $ref: '#/components/schemas/ResourceSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
         // Multiple versions
-        '/versionedResources': {
-          post: {
+        '/versionedResources/{id}': {
+          get: {
             responses: {
-              201: {
+              200: {
                 content: {
                   'application/vnd.atlas.2024-08-05+json': {
                     schema: {
@@ -77,9 +75,7 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
               },
             },
           },
-        },
-        '/versionedResources/{id}': {
-          get: {
+          patch: {
             responses: {
               200: {
                 content: {
@@ -108,10 +104,10 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
     document: {
       paths: {
         // Path not ending in collection
-        '/not/a/collection/resource': {
-          post: {
+        '/not/a/collection/resource/{id}': {
+          patch: {
             responses: {
-              201: {
+              200: {
                 content: {
                   'application/vnd.atlas.2024-08-05+json': {
                     schema: {
@@ -125,14 +121,11 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
               },
             },
           },
-        },
-        // Version mismatch but will be ignored
-        '/versionMismatchResources': {
-          post: {
+          get: {
             responses: {
-              201: {
+              200: {
                 content: {
-                  'application/vnd.atlas.2024-01-05+json': {
+                  'application/vnd.atlas.2024-08-05+json': {
                     schema: {
                       $ref: '#/components/schemas/ResourceSchema',
                     },
@@ -142,6 +135,7 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
             },
           },
         },
+        // Version mismatch but will be ignored
         '/versionMismatchResources/{id}': {
           get: {
             responses: {
@@ -156,21 +150,9 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
               },
             },
           },
-        },
-      },
-      components: componentSchemas,
-    },
-    errors: [],
-  },
-  {
-    name: 'invalid create responses',
-    document: {
-      paths: {
-        // Get without schema
-        '/resourcesOne': {
-          post: {
+          patch: {
             responses: {
-              201: {
+              200: {
                 content: {
                   'application/vnd.atlas.2024-01-05+json': {
                     schema: {
@@ -182,7 +164,48 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
             },
           },
         },
-        '/resourcesOne/{id}': {
+        // Non-200 will be ignored
+        '/resource/{id}': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-08-05+json': {
+                    schema: {
+                      $ref: '#/components/schemas/ResourceSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          patch: {
+            responses: {
+              202: {
+                requestBody: {
+                  content: {
+                    'application/vnd.atlas.2024-01-05+json': {
+                      schema: {
+                        $ref: '#/components/schemas/OtherSchema',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: componentSchemas,
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid update responses',
+    document: {
+      paths: {
+        // Get without schema - Patch
+        '/resourceOne/{id}': {
           get: {
             responses: {
               200: {
@@ -192,12 +215,9 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
               },
             },
           },
-        },
-        // Get without schema ref
-        '/resourcesTwo': {
-          post: {
+          patch: {
             responses: {
-              201: {
+              200: {
                 content: {
                   'application/vnd.atlas.2024-01-05+json': {
                     schema: {
@@ -209,7 +229,33 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
             },
           },
         },
-        '/resourcesTwo/{id}': {
+        // Get without schema - Put
+        '/resourceTwo/{id}': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-01-05+json': {},
+                },
+              },
+            },
+          },
+          put: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-01-05+json': {
+                    schema: {
+                      $ref: '#/components/schemas/ResourceSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        // Get without schema ref
+        '/resourceThree/{id}': {
           get: {
             responses: {
               200: {
@@ -223,53 +269,11 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
               },
             },
           },
-        },
-      },
-      components: componentSchemas,
-    },
-    errors: [
-      {
-        code: 'xgen-IPA-106-create-method-response-is-get-method-response',
-        message:
-          'Could not validate that the Create method returns the same resource object as the Get method. The Get method does not have a schema.',
-        path: [
-          'paths',
-          '/resourcesOne',
-          'post',
-          'responses',
-          '201',
-          'content',
-          'application/vnd.atlas.2024-01-05+json',
-        ],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        code: 'xgen-IPA-106-create-method-response-is-get-method-response',
-        message:
-          'Could not validate that the Create method returns the same resource object as the Get method. The Get method does not have a schema reference.',
-        path: [
-          'paths',
-          '/resourcesTwo',
-          'post',
-          'responses',
-          '201',
-          'content',
-          'application/vnd.atlas.2024-01-05+json',
-        ],
-        severity: DiagnosticSeverity.Warning,
-      },
-    ],
-  },
-  {
-    name: 'invalid with version mismatch',
-    document: {
-      paths: {
-        '/resources': {
-          post: {
+          patch: {
             responses: {
-              201: {
+              200: {
                 content: {
-                  'application/vnd.atlas.2024-08-05+json': {
+                  'application/vnd.atlas.2024-01-05+json': {
                     schema: {
                       $ref: '#/components/schemas/ResourceSchema',
                     },
@@ -279,8 +283,22 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
             },
           },
         },
-        '/resources/{id}': {
+        // Schema mismatch
+        '/resourceFour/{id}': {
           get: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-01-05+json': {
+                    schema: {
+                      $ref: '#/components/schemas/ResourceSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          patch: {
             responses: {
               200: {
                 content: {
@@ -299,9 +317,114 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
     },
     errors: [
       {
-        code: 'xgen-IPA-106-create-method-response-is-get-method-response',
-        message: 'The schema in the Create method response must be the same schema as the response of the Get method.',
-        path: ['paths', '/resources', 'post', 'responses', '201', 'content', 'application/vnd.atlas.2024-08-05+json'],
+        code: 'xgen-IPA-107-update-method-response-is-get-method-response',
+        message:
+          'Could not validate that the Update method returns the same resource object as the Get method. The Get method does not have a schema.',
+        path: [
+          'paths',
+          '/resourceOne/{id}',
+          'patch',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.atlas.2024-01-05+json',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-107-update-method-response-is-get-method-response',
+        message:
+          'Could not validate that the Update method returns the same resource object as the Get method. The Get method does not have a schema.',
+        path: [
+          'paths',
+          '/resourceTwo/{id}',
+          'put',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.atlas.2024-01-05+json',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-107-update-method-response-is-get-method-response',
+        message:
+          'Could not validate that the Update method returns the same resource object as the Get method. The Get method does not have a schema reference.',
+        path: [
+          'paths',
+          '/resourceThree/{id}',
+          'patch',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.atlas.2024-01-05+json',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-107-update-method-response-is-get-method-response',
+        message: 'The schema in the Update method response must be the same schema as the response of the Get method.',
+        path: [
+          'paths',
+          '/resourceFour/{id}',
+          'patch',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.atlas.2024-01-05+json',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid with version mismatch',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-01-05+json': {
+                    schema: {
+                      $ref: '#/components/schemas/OtherSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          patch: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-08-05+json': {
+                    schema: {
+                      $ref: '#/components/schemas/ResourceSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: componentSchemas,
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-107-update-method-response-is-get-method-response',
+        message: 'The schema in the Update method response must be the same schema as the response of the Get method.',
+        path: [
+          'paths',
+          '/resource/{id}',
+          'patch',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.atlas.2024-08-05+json',
+        ],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -310,14 +433,27 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
     name: 'invalid with exception',
     document: {
       paths: {
-        '/resources': {
-          post: {
+        '/resource/{id}': {
+          get: {
             responses: {
-              201: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-08-05+json': {
+                    schema: {
+                      $ref: '#/components/schemas/ResourceSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          patch: {
+            responses: {
+              200: {
                 content: {
                   'application/vnd.atlas.2024-08-05+json': {
                     'x-xgen-IPA-exception': {
-                      'xgen-IPA-106-create-method-response-is-get-method-response': 'Exception reason',
+                      'xgen-IPA-107-update-method-response-is-get-method-response': 'Exception reason',
                     },
                     schema: {
                       type: 'object',
@@ -331,7 +467,7 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
             },
           },
         },
-        '/resources/{id}': {
+        '/resourceTwo/{id}': {
           get: {
             responses: {
               200: {
@@ -339,6 +475,22 @@ testRule('xgen-IPA-106-create-method-response-is-get-method-response', [
                   'application/vnd.atlas.2024-08-05+json': {
                     schema: {
                       $ref: '#/components/schemas/ResourceSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          patch: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-08-05+json': {
+                    'x-xgen-IPA-exception': {
+                      'xgen-IPA-107-update-method-response-is-get-method-response': 'Exception reason',
+                    },
+                    schema: {
+                      $ref: '#/components/schemas/OtherSchema',
                     },
                   },
                 },

--- a/tools/spectral/ipa/rulesets/IPA-107.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-107.yaml
@@ -4,6 +4,7 @@
 functions:
   - IPA107UpdateMethodMustNotHaveQueryParams
   - IPA107UpdateResponseCodeShouldBe200OK
+  - IPA107UpdateMethodResponseIsGetMethodResponse
 
 rules:
   xgen-IPA-107-put-must-not-have-query-params:
@@ -68,3 +69,20 @@ rules:
     given: '$.paths[*].patch'
     then:
       function: 'IPA107UpdateResponseCodeShouldBe200OK'
+  xgen-IPA-107-update-method-response-is-get-method-response:
+    description: >-
+      The response body of the Update method should consist of the same resource object returned by the Get method.
+
+      ##### Implementation details
+      Rule checks for the following conditions:
+        - Applies only to single resource paths with JSON content types
+        - Ignores singleton resources and responses without a schema 
+        - Validation ignores resources without a Get method
+        - Fails if the Get method doesn't have a schema reference or if the schemas don't match
+        - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-method-response-is-get-method-response'
+    severity: warn
+    given: '$.paths[*][put,patch].responses.200.content'
+    then:
+      field: '@key'
+      function: 'IPA107UpdateMethodResponseIsGetMethodResponse'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -313,6 +313,16 @@ The Update method response status code should be 200 OK.
 Validation checks the PATCH method for single resource paths and [singleton resources](https://go/ipa/113).
 
   - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
+#### xgen-IPA-107-update-method-response-is-get-method-response
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+The response body of the Update method should consist of the same resource object returned by the Get method.
+##### Implementation details Rule checks for the following conditions:
+  - Applies only to single resource paths with JSON content types
+  - Ignores singleton resources and responses without a schema 
+  - Validation ignores resources without a Get method
+  - Fails if the Get method doesn't have a schema reference or if the schemas don't match
+  - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
 
 
 ### IPA-108

--- a/tools/spectral/ipa/rulesets/functions/IPA107UpdateMethodResponseIsGetMethodResponse.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA107UpdateMethodResponseIsGetMethodResponse.js
@@ -1,0 +1,95 @@
+import { isSingleResourceIdentifier } from './utils/resourceEvaluation.js';
+import { resolveObject } from './utils/componentUtils.js';
+import { hasException } from './utils/exceptions.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
+import { getSchemaRef, getGETMethodResponseSchemaFromPathItem } from './utils/methodUtils.js';
+
+const RULE_NAME = 'xgen-IPA-107-update-method-response-is-get-method-response';
+const ERROR_MESSAGE =
+  'The schema in the Update method response must be the same schema as the response of the Get method.';
+
+/**
+ * Update method (PUT, PATCH) responses should reference the same schema as the Get method.
+ *
+ * @param {object} input - An update operation 200 response content version
+ * @param {object} _ - Unused
+ * @param {{ path: string[], documentInventory: object}} context - The context object containing the path and document
+ */
+export default (input, _, { path, documentInventory }) => {
+  const oas = documentInventory.unresolved;
+  const resourcePath = path[1];
+  const mediaType = input;
+
+  if (!mediaType.endsWith('json') || !isSingleResourceIdentifier(resourcePath)) {
+    return;
+  }
+
+  // Ignore if the Update method does not have a response schema
+  const updateMethodResponse = resolveObject(oas, path);
+
+  if (!updateMethodResponse || !updateMethodResponse.schema) {
+    return;
+  }
+
+  if (hasException(updateMethodResponse, RULE_NAME)) {
+    collectException(updateMethodResponse, RULE_NAME, path);
+    return;
+  }
+
+  // Ignore if there is no matching Get method
+  const getMethodResponseContentPerMediaType = getGETMethodResponseSchemaFromPathItem(
+    oas.paths[resourcePath],
+    mediaType
+  );
+  if (!getMethodResponseContentPerMediaType) {
+    return;
+  }
+
+  const errors = checkViolationsAndReturnErrors(path, updateMethodResponse, getMethodResponseContentPerMediaType);
+
+  if (errors.length !== 0) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+
+  collectAdoption(path, RULE_NAME);
+};
+
+function checkViolationsAndReturnErrors(path, updateMethodResponseContent, getMethodResponseContent) {
+  try {
+    // Error if the Get method does not have a schema
+    if (!getMethodResponseContent.schema) {
+      return [
+        {
+          path,
+          message: `Could not validate that the Update method returns the same resource object as the Get method. The Get method does not have a schema.`,
+        },
+      ];
+    }
+
+    const updateMethodSchemaRef = getSchemaRef(updateMethodResponseContent.schema);
+    const getMethodSchemaRef = getSchemaRef(getMethodResponseContent.schema);
+
+    // Error if the Get method does not have a schema ref
+    if (!getMethodSchemaRef) {
+      return [
+        {
+          path,
+          message: `Could not validate that the Update method returns the same resource object as the Get method. The Get method does not have a schema reference.`,
+        },
+      ];
+    }
+
+    // Error if the get method resource is not the same as the update method resource
+    if (getMethodSchemaRef !== updateMethodSchemaRef) {
+      return [{ path, message: ERROR_MESSAGE }];
+    }
+    return [];
+  } catch (e) {
+    handleInternalError(RULE_NAME, path, e);
+  }
+}

--- a/tools/spectral/ipa/rulesets/functions/utils/methodUtils.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/methodUtils.js
@@ -118,7 +118,7 @@ export function getResponseOfListMethodByMediaType(mediaType, pathForResourceCol
  * @param {string} mediaType The media type
  * @returns {Object|null} The schema object, or null if not found
  */
-function getGETMethodResponseSchemaFromPathItem(pathItem, mediaType) {
+export function getGETMethodResponseSchemaFromPathItem(pathItem, mediaType) {
   if (!hasGetMethod(pathItem)) {
     return null;
   }


### PR DESCRIPTION
## Proposed changes

Adds rule `xgen-IPA-107-update-method-response-is-get-method-response` and tests. Also drive-by to correct the test for `IPA106CreateMethodResponseIsGetMethodResponse.test.js` where there were request bodies validated instead of response contents.

_Jira ticket:_ [CLOUDP-304945](https://jira.mongodb.org/browse/CLOUDP-304945)

One violation currently. Will do combined follow-up PR to add exceptions for multiple "update method" related IPAs. 
