### PR TITLE
CLOUDP-307110: Combine separated put and patch IPA rules

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA107UpdateMethodMustNotHaveQueryParams.test.js
+++ b/tools/spectral/ipa/__tests__/IPA107UpdateMethodMustNotHaveQueryParams.test.js
@@ -40,7 +40,8 @@ const componentSchemas = {
   },
 };
 
-testRule('xgen-IPA-107-put-must-not-have-query-params', [
+// Put
+testRule('xgen-IPA-107-update-must-not-have-query-params', [
   {
     name: 'valid put',
     document: {
@@ -119,19 +120,19 @@ testRule('xgen-IPA-107-put-must-not-have-query-params', [
     },
     errors: [
       {
-        code: 'xgen-IPA-107-put-must-not-have-query-params',
+        code: 'xgen-IPA-107-update-must-not-have-query-params',
         message: 'Update operations must not have query parameters. Found [filter].',
         path: ['paths', '/resource/{id}', 'put'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-put-must-not-have-query-params',
+        code: 'xgen-IPA-107-update-must-not-have-query-params',
         message: 'Update operations must not have query parameters. Found [query-param].',
         path: ['paths', '/resource/{id}/singleton', 'put'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-put-must-not-have-query-params',
+        code: 'xgen-IPA-107-update-must-not-have-query-params',
         message: 'Update operations must not have query parameters. Found [query-param-2].',
         path: ['paths', '/resource/{id}/singleton', 'put'],
         severity: DiagnosticSeverity.Warning,
@@ -153,7 +154,7 @@ testRule('xgen-IPA-107-put-must-not-have-query-params', [
               },
             ],
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-put-must-not-have-query-params': 'Reason',
+              'xgen-IPA-107-update-must-not-have-query-params': 'Reason',
             },
           },
         },
@@ -165,7 +166,7 @@ testRule('xgen-IPA-107-put-must-not-have-query-params', [
               },
             ],
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-put-must-not-have-query-params': 'Reason',
+              'xgen-IPA-107-update-must-not-have-query-params': 'Reason',
             },
           },
         },
@@ -175,7 +176,8 @@ testRule('xgen-IPA-107-put-must-not-have-query-params', [
   },
 ]);
 
-testRule('xgen-IPA-107-patch-must-not-have-query-params', [
+// Patch
+testRule('xgen-IPA-107-update-must-not-have-query-params', [
   {
     name: 'valid patch',
     document: {
@@ -254,19 +256,19 @@ testRule('xgen-IPA-107-patch-must-not-have-query-params', [
     },
     errors: [
       {
-        code: 'xgen-IPA-107-patch-must-not-have-query-params',
+        code: 'xgen-IPA-107-update-must-not-have-query-params',
         message: 'Update operations must not have query parameters. Found [filter].',
         path: ['paths', '/resource/{id}', 'patch'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-patch-must-not-have-query-params',
+        code: 'xgen-IPA-107-update-must-not-have-query-params',
         message: 'Update operations must not have query parameters. Found [query-param].',
         path: ['paths', '/resource/{id}/singleton', 'patch'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-patch-must-not-have-query-params',
+        code: 'xgen-IPA-107-update-must-not-have-query-params',
         message: 'Update operations must not have query parameters. Found [query-param-2].',
         path: ['paths', '/resource/{id}/singleton', 'patch'],
         severity: DiagnosticSeverity.Warning,
@@ -288,7 +290,7 @@ testRule('xgen-IPA-107-patch-must-not-have-query-params', [
               },
             ],
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-patch-must-not-have-query-params': 'Reason',
+              'xgen-IPA-107-update-must-not-have-query-params': 'Reason',
             },
           },
         },
@@ -300,7 +302,7 @@ testRule('xgen-IPA-107-patch-must-not-have-query-params', [
               },
             ],
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-patch-must-not-have-query-params': 'Reason',
+              'xgen-IPA-107-update-must-not-have-query-params': 'Reason',
             },
           },
         },

--- a/tools/spectral/ipa/__tests__/IPA107UpdateResponseCodeShouldBe200OK.test.js
+++ b/tools/spectral/ipa/__tests__/IPA107UpdateResponseCodeShouldBe200OK.test.js
@@ -1,7 +1,8 @@
 import testRule from './__helpers__/testRule';
 import { DiagnosticSeverity } from '@stoplight/types';
 
-testRule('xgen-IPA-107-put-method-response-code-is-200', [
+// Put
+testRule('xgen-IPA-107-update-method-response-code-is-200', [
   {
     name: 'valid methods',
     document: {
@@ -72,28 +73,28 @@ testRule('xgen-IPA-107-put-method-response-code-is-200', [
     },
     errors: [
       {
-        code: 'xgen-IPA-107-put-method-response-code-is-200',
+        code: 'xgen-IPA-107-update-method-response-code-is-200',
         message:
           'The Update method response status code should be 200 OK. This method either lacks a 200 OK response or defines a different 2xx status code.',
         path: ['paths', '/resourceOne/{id}', 'put'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-put-method-response-code-is-200',
+        code: 'xgen-IPA-107-update-method-response-code-is-200',
         message:
           'The Update method response status code should be 200 OK. This method either lacks a 200 OK response or defines a different 2xx status code.',
         path: ['paths', '/resourceTwo/{id}', 'put'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-put-method-response-code-is-200',
+        code: 'xgen-IPA-107-update-method-response-code-is-200',
         message:
           'The Update method response status code should be 200 OK. This method either lacks a 200 OK response or defines a different 2xx status code.',
         path: ['paths', '/resourceThree/{id}', 'put'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-put-method-response-code-is-200',
+        code: 'xgen-IPA-107-update-method-response-code-is-200',
         message:
           'The Update method response status code should be 200 OK. This method either lacks a 200 OK response or defines a different 2xx status code.',
         path: ['paths', '/resource/{id}/singleton', 'put'],
@@ -113,7 +114,7 @@ testRule('xgen-IPA-107-put-method-response-code-is-200', [
               500: {},
             },
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-put-method-response-code-is-200': 'reason',
+              'xgen-IPA-107-update-method-response-code-is-200': 'reason',
             },
           },
         },
@@ -124,7 +125,7 @@ testRule('xgen-IPA-107-put-method-response-code-is-200', [
               500: {},
             },
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-put-method-response-code-is-200': 'reason',
+              'xgen-IPA-107-update-method-response-code-is-200': 'reason',
             },
           },
         },
@@ -136,7 +137,7 @@ testRule('xgen-IPA-107-put-method-response-code-is-200', [
               500: {},
             },
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-put-method-response-code-is-200': 'reason',
+              'xgen-IPA-107-update-method-response-code-is-200': 'reason',
             },
           },
         },
@@ -146,7 +147,8 @@ testRule('xgen-IPA-107-put-method-response-code-is-200', [
   },
 ]);
 
-testRule('xgen-IPA-107-patch-method-response-code-is-200', [
+// Patch
+testRule('xgen-IPA-107-update-method-response-code-is-200', [
   {
     name: 'valid methods',
     document: {
@@ -217,28 +219,28 @@ testRule('xgen-IPA-107-patch-method-response-code-is-200', [
     },
     errors: [
       {
-        code: 'xgen-IPA-107-patch-method-response-code-is-200',
+        code: 'xgen-IPA-107-update-method-response-code-is-200',
         message:
           'The Update method response status code should be 200 OK. This method either lacks a 200 OK response or defines a different 2xx status code.',
         path: ['paths', '/resourceOne/{id}', 'patch'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-patch-method-response-code-is-200',
+        code: 'xgen-IPA-107-update-method-response-code-is-200',
         message:
           'The Update method response status code should be 200 OK. This method either lacks a 200 OK response or defines a different 2xx status code.',
         path: ['paths', '/resourceTwo/{id}', 'patch'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-patch-method-response-code-is-200',
+        code: 'xgen-IPA-107-update-method-response-code-is-200',
         message:
           'The Update method response status code should be 200 OK. This method either lacks a 200 OK response or defines a different 2xx status code.',
         path: ['paths', '/resourceThree/{id}', 'patch'],
         severity: DiagnosticSeverity.Warning,
       },
       {
-        code: 'xgen-IPA-107-patch-method-response-code-is-200',
+        code: 'xgen-IPA-107-update-method-response-code-is-200',
         message:
           'The Update method response status code should be 200 OK. This method either lacks a 200 OK response or defines a different 2xx status code.',
         path: ['paths', '/resource/{id}/singleton', 'patch'],
@@ -258,7 +260,7 @@ testRule('xgen-IPA-107-patch-method-response-code-is-200', [
               500: {},
             },
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-patch-method-response-code-is-200': 'reason',
+              'xgen-IPA-107-update-method-response-code-is-200': 'reason',
             },
           },
         },
@@ -269,7 +271,7 @@ testRule('xgen-IPA-107-patch-method-response-code-is-200', [
               500: {},
             },
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-patch-method-response-code-is-200': 'reason',
+              'xgen-IPA-107-update-method-response-code-is-200': 'reason',
             },
           },
         },
@@ -281,7 +283,7 @@ testRule('xgen-IPA-107-patch-method-response-code-is-200', [
               500: {},
             },
             'x-xgen-IPA-exception': {
-              'xgen-IPA-107-patch-method-response-code-is-200': 'reason',
+              'xgen-IPA-107-update-method-response-code-is-200': 'reason',
             },
           },
         },

--- a/tools/spectral/ipa/rulesets/IPA-107.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-107.yaml
@@ -8,66 +8,35 @@ functions:
   - IPA107UpdateMethodRequestHasNoReadonlyFields
 
 rules:
-  xgen-IPA-107-put-must-not-have-query-params:
+  xgen-IPA-107-update-must-not-have-query-params:
     description: >-
       Update operations must not accept query parameters.
 
       ##### Implementation details
 
-      Validation checks the PUT method for single resource paths and singleton resources.
+      Validation checks the PATCH/PUT methods for single resource paths and singleton resources.
 
         - Query parameters `envelope` and `pretty` are exempt from this rule
         - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-put-must-not-have-query-params'
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-must-not-have-query-params'
     severity: warn
-    given: '$.paths[*].put'
+    given: '$.paths[*][put,patch]'
     then:
       function: 'IPA107UpdateMethodMustNotHaveQueryParams'
       functionOptions:
         ignoredValues: ['pretty', 'envelope']
-  xgen-IPA-107-patch-must-not-have-query-params:
-    description: >-
-      Update operations must not accept query parameters.
-
-      ##### Implementation details
-
-      Validation checks the PATCH method for single resource paths and singleton resources.
-
-        - Query parameters `envelope` and `pretty` are exempt from this rule
-        - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-patch-must-not-have-query-params'
-    severity: warn
-    given: '$.paths[*].patch'
-    then:
-      function: 'IPA107UpdateMethodMustNotHaveQueryParams'
-      functionOptions:
-        ignoredValues: ['pretty', 'envelope']
-  xgen-IPA-107-put-method-response-code-is-200:
+  xgen-IPA-107-update-method-response-code-is-200:
     description: >-
       The Update method response status code should be 200 OK.
 
       ##### Implementation details
 
-      Validation checks the PUT method for single resource paths and [singleton resources](https://go/ipa/113).
+      Validation checks the PATCH/PUT methods for single resource paths and [singleton resources](https://go/ipa/113).
 
         - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-put-method-response-code-is-200'
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-method-response-code-is-200'
     severity: warn
-    given: '$.paths[*].put'
-    then:
-      function: 'IPA107UpdateResponseCodeShouldBe200OK'
-  xgen-IPA-107-patch-method-response-code-is-200:
-    description: >-
-      The Update method response status code should be 200 OK.
-
-      ##### Implementation details
-
-      Validation checks the PATCH method for single resource paths and [singleton resources](https://go/ipa/113).
-
-        - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
-    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-patch-method-response-code-is-200'
-    severity: warn
-    given: '$.paths[*].patch'
+    given: '$.paths[*][put,patch]'
     then:
       function: 'IPA107UpdateResponseCodeShouldBe200OK'
   xgen-IPA-107-update-method-response-is-get-method-response:

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -279,38 +279,21 @@ Rule checks for the following conditions:
 
 Rules are based on [http://go/ipa/IPA-107](http://go/ipa/IPA-107).
 
-#### xgen-IPA-107-put-must-not-have-query-params
+#### xgen-IPA-107-update-must-not-have-query-params
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
 Update operations must not accept query parameters.
 ##### Implementation details
-Validation checks the PUT method for single resource paths and singleton resources.
+Validation checks the PATCH/PUT methods for single resource paths and singleton resources.
 
   - Query parameters `envelope` and `pretty` are exempt from this rule
   - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
-#### xgen-IPA-107-patch-must-not-have-query-params
-
- ![warn](https://img.shields.io/badge/warning-yellow) 
-Update operations must not accept query parameters.
-##### Implementation details
-Validation checks the PATCH method for single resource paths and singleton resources.
-
-  - Query parameters `envelope` and `pretty` are exempt from this rule
-  - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
-#### xgen-IPA-107-put-method-response-code-is-200
+#### xgen-IPA-107-update-method-response-code-is-200
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
 The Update method response status code should be 200 OK.
 ##### Implementation details
-Validation checks the PUT method for single resource paths and [singleton resources](https://go/ipa/113).
-
-  - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
-#### xgen-IPA-107-patch-method-response-code-is-200
-
- ![warn](https://img.shields.io/badge/warning-yellow) 
-The Update method response status code should be 200 OK.
-##### Implementation details
-Validation checks the PATCH method for single resource paths and [singleton resources](https://go/ipa/113).
+Validation checks the PATCH/PUT methods for single resource paths and [singleton resources](https://go/ipa/113).
 
   - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
 #### xgen-IPA-107-update-method-response-is-get-method-response


### PR DESCRIPTION
## Proposed changes

We have two rules for Update Method that are separated per PUT and PATCH, this PR combined them into one rule. Will update affected exceptions in follow-up.

_Jira ticket:_ [CLOUDP-307110](https://jira.mongodb.org/browse/CLOUDP-307110)
