### PR TITLE
CLOUDP-304943: IPA rule for Update request schema suffix

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA104GetMethodReturnsResponseSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/IPA104GetMethodReturnsResponseSuffixedObject.test.js
@@ -152,7 +152,7 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
     errors: [
       {
         code: 'xgen-IPA-104-get-method-returns-response-suffixed-object',
-        message: 'The response body schema must reference a schema with a Response suffix.',
+        message: 'The schema must reference a schema with a Response suffix.',
         path: [
           'paths',
           '/resource/{id}',
@@ -166,7 +166,7 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
       },
       {
         code: 'xgen-IPA-104-get-method-returns-response-suffixed-object',
-        message: 'The response body schema must reference a schema with a Response suffix.',
+        message: 'The schema must reference a schema with a Response suffix.',
         path: [
           'paths',
           '/resource/{id}',
@@ -180,7 +180,7 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
       },
       {
         code: 'xgen-IPA-104-get-method-returns-response-suffixed-object',
-        message: 'The response body schema must reference a schema with a Response suffix.',
+        message: 'The schema must reference a schema with a Response suffix.',
         path: [
           'paths',
           '/resource/{id}',
@@ -194,7 +194,7 @@ testRule('xgen-IPA-104-get-method-returns-response-suffixed-object', [
       },
       {
         code: 'xgen-IPA-104-get-method-returns-response-suffixed-object',
-        message: 'The response body schema must reference a schema with a Response suffix.',
+        message: 'The schema must reference a schema with a Response suffix.',
         path: [
           'paths',
           '/resource/{id}/singleton',

--- a/tools/spectral/ipa/__tests__/IPA106CreateMethodRequestBodyIsRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/IPA106CreateMethodRequestBodyIsRequestSuffixedObject.test.js
@@ -154,31 +154,31 @@ testRule('xgen-IPA-106-create-method-request-body-is-request-suffixed-object', [
     errors: [
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. ',
+        message: 'The schema must reference a schema with a Request suffix.',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. ',
+        message: 'The schema must reference a schema with a Request suffix.',
         path: ['paths', '/resource', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. ',
+        message: 'The schema must reference a schema with a Request suffix.',
         path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema must reference a schema with a Request suffix. ',
+        message: 'The schema must reference a schema with a Request suffix.',
         path: ['paths', '/resourceTwo', 'post', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-106-create-method-request-body-is-request-suffixed-object',
-        message: 'The response body schema is defined inline and must reference a predefined schema. ',
+        message: 'The schema is defined inline and must reference a predefined schema.',
         path: ['paths', '/resourceThree', 'post', 'requestBody', 'content', 'application/vnd.atlas.2023-01-01+json'],
         severity: DiagnosticSeverity.Warning,
       },

--- a/tools/spectral/ipa/__tests__/IPA107UpdateMethodRequestBodyIsUpdateRequestSuffixedObject.test.js
+++ b/tools/spectral/ipa/__tests__/IPA107UpdateMethodRequestBodyIsUpdateRequestSuffixedObject.test.js
@@ -1,0 +1,300 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+const componentSchemas = {
+  schemas: {
+    SchemaUpdateRequest: {
+      type: 'object',
+    },
+    Schema: {
+      type: 'object',
+    },
+  },
+};
+
+testRule('xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object', [
+  {
+    name: 'valid schema names names',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/SchemaUpdateRequest',
+                  },
+                },
+                'application/vnd.atlas.2025-01-01+json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/SchemaUpdateRequest',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/SchemaUpdateRequest',
+                  },
+                },
+                'application/vnd.atlas.2025-01-01+json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/SchemaUpdateRequest',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resourceTwo/{id}': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-08-05+json': {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
+        '/resource/{id}/singleton': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-08-05+json': {
+                  schema: {
+                    $ref: '#/components/schemas/SchemaUpdateRequest',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: componentSchemas,
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid resources',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+                'application/vnd.atlas.2025-01-01+json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/Schema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-01-01+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+                'application/vnd.atlas.2025-01-01+json': {
+                  schema: {
+                    type: 'array',
+                    items: {
+                      $ref: '#/components/schemas/Schema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resource/{id}/singleton': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-08-05+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-08-05+json': {
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: componentSchemas,
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object',
+        message: 'The schema must reference a schema with a UpdateRequest suffix.',
+        path: ['paths', '/resource/{id}', 'patch', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object',
+        message: 'The schema must reference a schema with a UpdateRequest suffix.',
+        path: ['paths', '/resource/{id}', 'patch', 'requestBody', 'content', 'application/vnd.atlas.2025-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object',
+        message: 'The schema must reference a schema with a UpdateRequest suffix.',
+        path: ['paths', '/resource/{id}', 'put', 'requestBody', 'content', 'application/vnd.atlas.2024-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object',
+        message: 'The schema must reference a schema with a UpdateRequest suffix.',
+        path: ['paths', '/resource/{id}', 'put', 'requestBody', 'content', 'application/vnd.atlas.2025-01-01+json'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object',
+        message: 'The schema must reference a schema with a UpdateRequest suffix.',
+        path: [
+          'paths',
+          '/resource/{id}/singleton',
+          'patch',
+          'requestBody',
+          'content',
+          'application/vnd.atlas.2024-08-05+json',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object',
+        message: 'The schema must reference a schema with a UpdateRequest suffix.',
+        path: [
+          'paths',
+          '/resource/{id}/singleton',
+          'put',
+          'requestBody',
+          'content',
+          'application/vnd.atlas.2024-08-05+json',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid resources with exceptions',
+    document: {
+      paths: {
+        '/resource/{id}': {
+          patch: {
+            requestBody: {
+              'application/vnd.atlas.2024-01-01+json': {
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object': 'reason',
+                },
+                schema: {
+                  $ref: '#/components/schemas/Schema',
+                },
+              },
+              'application/vnd.atlas.2025-01-01+json': {
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object': 'reason',
+                },
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            requestBody: {
+              'application/vnd.atlas.2024-01-01+json': {
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object': 'reason',
+                },
+                schema: {
+                  $ref: '#/components/schemas/Schema',
+                },
+              },
+              'application/vnd.atlas.2025-01-01+json': {
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object': 'reason',
+                },
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/resource/{id}/singleton': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-08-05+json': {
+                  'x-xgen-IPA-exception': {
+                    'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object': 'reason',
+                  },
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+          put: {
+            requestBody: {
+              content: {
+                'application/vnd.atlas.2024-08-05+json': {
+                  'x-xgen-IPA-exception': {
+                    'xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object': 'reason',
+                  },
+                  schema: {
+                    $ref: '#/components/schemas/Schema',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: componentSchemas,
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/rulesets/IPA-107.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-107.yaml
@@ -7,6 +7,7 @@ functions:
   - IPA107UpdateMethodResponseIsGetMethodResponse
   - IPA107UpdateMethodRequestHasNoReadonlyFields
   - IPA107UpdateMethodRequestBodyIsGetResponse
+  - IPA107UpdateMethodRequestBodyIsUpdateRequestSuffixedObject
 
 rules:
   xgen-IPA-107-update-must-not-have-query-params:
@@ -81,7 +82,7 @@ rules:
 
       Validation checks the PATCH/PUT methods for single resource paths.
         - Validation ignores resources without a Get method.
-        - `readOnly:true` properties of Get method response will be ignored. 
+        - `readOnly:true` properties of Get method response will be ignored.
         - `writeOnly:true` properties of Update method request will be ignored.
         - Property comparison is based on `type` and `name` matching.
         - `oneOf` and `discriminator` definitions must match exactly.
@@ -91,3 +92,19 @@ rules:
     then:
       field: '@key'
       function: 'IPA107UpdateMethodRequestBodyIsGetResponse'
+  xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object:
+    description: |
+      The Update method request should be a `UpdateRequest` suffixed object.
+
+      ##### Implementation details
+      Rule checks for the following conditions:
+        - Applies to PUT/PATCH methods on single resource paths and singleton resources
+        - Applies only to JSON content types
+        - Validation only applies to schema references to a predefined schema (not inline)
+        - Confirms the referenced schema name ends with "Request" suffix
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object'
+    severity: warn
+    given: '$.paths[*][put,patch].requestBody.content'
+    then:
+      field: '@key'
+      function: 'IPA107UpdateMethodRequestBodyIsUpdateRequestSuffixedObject'

--- a/tools/spectral/ipa/rulesets/IPA-107.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-107.yaml
@@ -94,7 +94,7 @@ rules:
       function: 'IPA107UpdateMethodRequestBodyIsGetResponse'
   xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object:
     description: |
-      The Update method request should be a `UpdateRequest` suffixed object.
+      The Update method request schema should reference an `UpdateRequest` suffixed object.
 
       ##### Implementation details
       Rule checks for the following conditions:

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -327,10 +327,22 @@ The request body must contain the resource being updated, i.e. the resource or p
 
 Validation checks the PATCH/PUT methods for single resource paths.
   - Validation ignores resources without a Get method.
-  - `readOnly:true` properties of Get method response will be ignored. 
+  - `readOnly:true` properties of Get method response will be ignored.
   - `writeOnly:true` properties of Update method request will be ignored.
   - Property comparison is based on `type` and `name` matching.
   - `oneOf` and `discriminator` definitions must match exactly.
+
+#### xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+The Update method request should be a `UpdateRequest` suffixed object.
+
+##### Implementation details
+Rule checks for the following conditions:
+  - Applies to PUT/PATCH methods on single resource paths and singleton resources
+  - Applies only to JSON content types
+  - Validation only applies to schema references to a predefined schema (not inline)
+  - Confirms the referenced schema name ends with "Request" suffix
 
 
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -335,7 +335,7 @@ Validation checks the PATCH/PUT methods for single resource paths.
 #### xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-The Update method request should be a `UpdateRequest` suffixed object.
+The Update method request schema should reference an `UpdateRequest` suffixed object.
 
 ##### Implementation details
 Rule checks for the following conditions:

--- a/tools/spectral/ipa/rulesets/functions/utils/validations.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/validations.js
@@ -161,3 +161,41 @@ export function checkRequestResponseResourceEqualityAndReturnErrors(
 
   return errors;
 }
+
+/**
+ * Checks if a request or response content for a media type references a schema with a specific suffix.
+ * Returns errors if the schema doesn't reference a schema, or if the schema name does not end with the expected suffix.
+ * Ready to be used in a custom validation function.
+ *
+ * @param {string[]} path the path to the object being evaluated
+ * @param {object} contentPerMediaType the content to evaluate for a specific media type (unresolved)
+ * @param {string} expectedSuffix the expected suffix to evaluate the schema name for
+ * @param {string} ruleName the rule name
+ * @returns {[{path, message: string}]} the errors found, or an empty array in case of no errors
+ */
+export function checkSchemaRefSuffixAndReturnErrors(path, contentPerMediaType, expectedSuffix, ruleName) {
+  try {
+    const schema = contentPerMediaType.schema;
+    const schemaRef = getSchemaRef(schema);
+
+    if (!schemaRef) {
+      return [
+        {
+          path,
+          message: 'The schema is defined inline and must reference a predefined schema.',
+        },
+      ];
+    }
+    if (!schemaRef.endsWith(expectedSuffix)) {
+      return [
+        {
+          path,
+          message: `The schema must reference a schema with a ${expectedSuffix} suffix.`,
+        },
+      ];
+    }
+    return [];
+  } catch (e) {
+    handleInternalError(ruleName, path, e);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Adds rule `xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object` and also refactor to use a common validation function for all suffix related rules.

_Jira ticket:_ [CLOUDP-304943](https://jira.mongodb.org/browse/CLOUDP-304943)
