### PR TITLE
CLOUDP-272001: Disallow usages of project in the api (fix)

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA112AvoidProjectFieldNames.test.js
+++ b/tools/spectral/ipa/__tests__/IPA112AvoidProjectFieldNames.test.js
@@ -11,7 +11,7 @@ testRule('xgen-IPA-112-avoid-project-field-names', [
             properties: {
               group: { type: 'string' },
               groupId: { type: 'string' },
-              otherField: { type: 'number' },
+              projection: { type: 'number' },
             },
           },
         },
@@ -57,7 +57,7 @@ testRule('xgen-IPA-112-avoid-project-field-names', [
     errors: [
       {
         code: 'xgen-IPA-112-avoid-project-field-names',
-        message: 'Field name "projects" should be avoided. Consider using "group" instead.',
+        message: 'Field name "projects" should be avoided. Consider using "groups" instead.',
         path: ['components', 'schemas', 'SchemaName', 'properties', 'projects'],
         severity: DiagnosticSeverity.Warning,
       },
@@ -81,35 +81,6 @@ testRule('xgen-IPA-112-avoid-project-field-names', [
         code: 'xgen-IPA-112-avoid-project-field-names',
         message: 'Field name "projectId" should be avoided. Consider using "group" instead.',
         path: ['components', 'schemas', 'SchemaName', 'properties', 'projectId'],
-        severity: DiagnosticSeverity.Warning,
-      },
-    ],
-  },
-  {
-    name: 'invalid schema - with different case variants',
-    document: {
-      components: {
-        schemas: {
-          SchemaName: {
-            properties: {
-              Project: { type: 'string' },
-              PROJECTID: { type: 'string' },
-            },
-          },
-        },
-      },
-    },
-    errors: [
-      {
-        code: 'xgen-IPA-112-avoid-project-field-names',
-        message: 'Field name "Project" should be avoided. Consider using "group" instead.',
-        path: ['components', 'schemas', 'SchemaName', 'properties', 'Project'],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        code: 'xgen-IPA-112-avoid-project-field-names',
-        message: 'Field name "PROJECTID" should be avoided. Consider using "group" instead.',
-        path: ['components', 'schemas', 'SchemaName', 'properties', 'PROJECTID'],
         severity: DiagnosticSeverity.Warning,
       },
     ],

--- a/tools/spectral/ipa/__tests__/utils/schemaUtils.test.js
+++ b/tools/spectral/ipa/__tests__/utils/schemaUtils.test.js
@@ -1,0 +1,30 @@
+import { splitCamelCase } from '../../rulesets/functions/utils/schemaUtils.js';
+import { describe, expect, it } from '@jest/globals';
+
+describe('splitCamelCase', () => {
+  it('should split basic camelCase strings', () => {
+    expect(splitCamelCase('camelCase')).toEqual(['camel', 'case']);
+    expect(splitCamelCase('thisIsCamelCase')).toEqual(['this', 'is', 'camel', 'case']);
+  });
+
+  it('should handle single-word strings', () => {
+    expect(splitCamelCase('word')).toEqual(['word']);
+    expect(splitCamelCase('Word')).toEqual(['word']);
+  });
+
+  it('should handle strings with numbers', () => {
+    expect(splitCamelCase('user123Name')).toEqual(['user123', 'name']);
+    expect(splitCamelCase('user123name')).toEqual(['user123name']);
+  });
+
+  it('should handle empty strings', () => {
+    expect(splitCamelCase('')).toEqual(['']);
+  });
+
+  it('should handle edge cases from the project', () => {
+    expect(splitCamelCase('project')).toEqual(['project']);
+    expect(splitCamelCase('projectId')).toEqual(['project', 'id']);
+    expect(splitCamelCase('myProjectDetails')).toEqual(['my', 'project', 'details']);
+    expect(splitCamelCase('projection')).toEqual(['projection']);
+  });
+});

--- a/tools/spectral/ipa/rulesets/IPA-112.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-112.yaml
@@ -24,3 +24,5 @@ rules:
         prohibitedFieldNames:
           - name: 'project'
             alternative: ['group']
+          - name: 'projects'
+            alternative: ['groups']

--- a/tools/spectral/ipa/rulesets/functions/IPA112AvoidProjectFieldNames.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA112AvoidProjectFieldNames.js
@@ -6,6 +6,7 @@ import {
   handleInternalError,
 } from './utils/collectionUtils.js';
 import { resolveObject } from './utils/componentUtils.js';
+import { splitCamelCase } from './utils/schemaUtils.js';
 
 const RULE_NAME = 'xgen-IPA-112-avoid-project-field-names';
 
@@ -28,18 +29,20 @@ export default (input, options, { path, documentInventory }) => {
 function checkViolationsAndReturnErrors(input, options, path) {
   try {
     const prohibitedFieldNames = options?.prohibitedFieldNames || [];
-    const lowerPropertyName = input.toLowerCase();
+
+    // Split the field name into words assuming camelCase
+    const words = splitCamelCase(input);
 
     // Check if the property name includes any of the prohibited terms
     for (const prohibitedItem of prohibitedFieldNames) {
       const prohibitedName = prohibitedItem.name || '';
       const alternative = prohibitedItem.alternative || '';
 
-      if (lowerPropertyName.includes(prohibitedName.toLowerCase())) {
+      if (words.some((word) => word.toLowerCase() === prohibitedName)) {
         return [
           {
             path,
-            message: `Field name "${input}" should be avoided. Consider using ${alternative.map((alt) => `"${alt}"`)} instead.`,
+            message: `Field name "${input}" should be avoided. Consider using "${alternative}" instead.`,
           },
         ];
       }

--- a/tools/spectral/ipa/rulesets/functions/IPA112AvoidProjectFieldNames.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA112AvoidProjectFieldNames.js
@@ -38,7 +38,7 @@ function checkViolationsAndReturnErrors(input, options, path) {
       const prohibitedName = prohibitedItem.name || '';
       const alternative = prohibitedItem.alternative || '';
 
-      if (words.some((word) => word.toLowerCase() === prohibitedName)) {
+      if (words.some((word) => word === prohibitedName)) {
         return [
           {
             path,

--- a/tools/spectral/ipa/rulesets/functions/utils/schemaUtils.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/schemaUtils.js
@@ -38,5 +38,10 @@ export function getSchemaPathFromEnumPath(path) {
  * @returns {*}
  */
 export function splitCamelCase(str) {
-  return str.split(/(?=[A-Z])/);
+  if (!str) return [''];
+
+  // Special handling for single words
+  if (!/[A-Z]/.test(str)) return [str];
+
+  return str.split(/(?=[A-Z])/).map((word) => word.toLowerCase());
 }

--- a/tools/spectral/ipa/rulesets/functions/utils/schemaUtils.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/schemaUtils.js
@@ -35,7 +35,7 @@ export function getSchemaPathFromEnumPath(path) {
  * Split camelCase string into words
  * Example: "myProjectId" becomes ["my", "Project", "Id"]
  * @param str {string} camelCase string
- * @returns {*}
+ * @returns {string[]}
  */
 export function splitCamelCase(str) {
   if (!str) return [''];

--- a/tools/spectral/ipa/rulesets/functions/utils/schemaUtils.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/schemaUtils.js
@@ -30,3 +30,13 @@ export function getSchemaPathFromEnumPath(path) {
   }
   return path.slice(0, enumIndex);
 }
+
+/**
+ * Split camelCase string into words
+ * Example: "myProjectId" becomes ["my", "Project", "Id"]
+ * @param str {string} camelCase string
+ * @returns {*}
+ */
+export function splitCamelCase(str) {
+  return str.split(/(?=[A-Z])/);
+}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-272001

Fix: Split the field name into words, assuming it follows camelCase. If any of the split words match a prohibited word, it is considered a violation.


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
