### PR TITLE
CLOUDP-304958: IPA rule singleton must not have delete

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA113SingletonHasNoDeleteMethod.test.js
+++ b/tools/spectral/ipa/__tests__/IPA113SingletonHasNoDeleteMethod.test.js
@@ -1,0 +1,59 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-113-singleton-must-not-have-delete-method', [
+  {
+    name: 'valid resources',
+    document: {
+      paths: {
+        '/resource': {
+          post: {},
+          get: {},
+        },
+        '/resource/{exampleId}': {
+          get: {},
+          patch: {},
+          delete: {},
+        },
+        '/resource/{exampleId}/singleton': {
+          get: {},
+          patch: {},
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid resource',
+    document: {
+      paths: {
+        '/resource/{exampleId}/singleton': {
+          delete: {},
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-113-singleton-must-not-have-delete-method',
+        message:
+          'Singleton resources must not define the Delete standard method. If this is not a singleton resource, please implement all CRUDL methods.',
+        path: ['paths', '/resource/{exampleId}/singleton'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid resources with exceptions',
+    document: {
+      paths: {
+        '/resource/{exampleId}/singleton': {
+          delete: {},
+          'x-xgen-IPA-exception': {
+            'xgen-IPA-113-singleton-must-not-have-delete-method': 'reason',
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/IPA113SingletonHasUpdateMethod.test.js
+++ b/tools/spectral/ipa/__tests__/IPA113SingletonHasUpdateMethod.test.js
@@ -1,0 +1,69 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-113-singleton-should-have-update-method', [
+  {
+    name: 'valid resources',
+    document: {
+      paths: {
+        '/resource/{exampleId}/singletonOne': {
+          patch: {},
+        },
+        '/resource/{exampleId}/singletonTwo': {
+          put: {},
+        },
+        '/resource/{exampleId}/singletonThree': {
+          patch: {},
+          put: {},
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid resource',
+    document: {
+      paths: {
+        '/resource/{exampleId}/singletonOne': {
+          get: {},
+        },
+        '/resource/{exampleId}/singletonTwo': {},
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-113-singleton-should-have-update-method',
+        message:
+          'Singleton resources should define the Update method. If this is not a singleton resource, please implement all CRUDL methods.',
+        path: ['paths', '/resource/{exampleId}/singletonOne'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-113-singleton-should-have-update-method',
+        message:
+          'Singleton resources should define the Update method. If this is not a singleton resource, please implement all CRUDL methods.',
+        path: ['paths', '/resource/{exampleId}/singletonTwo'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid resources with exceptions',
+    document: {
+      paths: {
+        '/resource/{exampleId}/singletonOne': {
+          get: {},
+          'x-xgen-IPA-exception': {
+            'xgen-IPA-113-singleton-should-have-update-method': 'reason',
+          },
+        },
+        '/resource/{exampleId}/singletonTwo': {
+          'x-xgen-IPA-exception': {
+            'xgen-IPA-113-singleton-should-have-update-method': 'reason',
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/rulesets/IPA-113.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-113.yaml
@@ -4,6 +4,7 @@
 functions:
   - IPA113SingletonHasNoId
   - IPA113SingletonHasNoDeleteMethod
+  - IPA113SingletonHasUpdateMethod
 
 rules:
   xgen-IPA-113-singleton-must-not-have-id:
@@ -24,7 +25,7 @@ rules:
       function: 'IPA113SingletonHasNoId'
   xgen-IPA-113-singleton-must-not-have-delete-method:
     description: |
-      Singleton resources must not define the Delete standard method
+      Singleton resources must not define the Delete standard method.
 
       ##### Implementation details
       Rule checks for the following conditions:
@@ -35,3 +36,16 @@ rules:
     given: '$.paths[*]'
     then:
       function: 'IPA113SingletonHasNoDeleteMethod'
+  xgen-IPA-113-singleton-should-have-update-method:
+    description: |
+      Singleton resources should define the Update method. Validation for the presence of Get method is covered by IPA-104 (see [xgen-IPA-104-resource-has-GET](https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-resource-has-GET)).
+
+      ##### Implementation details
+      Rule checks for the following conditions:
+        - Applies only to singleton resources
+        - Checks that the resource has the PUT and/or PATCH methods defined
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-113-singleton-should-have-update-method'
+    severity: warn
+    given: '$.paths[*]'
+    then:
+      function: 'IPA113SingletonHasUpdateMethod'

--- a/tools/spectral/ipa/rulesets/IPA-113.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-113.yaml
@@ -3,6 +3,7 @@
 
 functions:
   - IPA113SingletonHasNoId
+  - IPA113SingletonHasNoDeleteMethod
 
 rules:
   xgen-IPA-113-singleton-must-not-have-id:
@@ -21,3 +22,16 @@ rules:
     given: '$.paths[*]'
     then:
       function: 'IPA113SingletonHasNoId'
+  xgen-IPA-113-singleton-must-not-have-delete-method:
+    description: |
+      Singleton resources must not define the Delete standard method
+
+      ##### Implementation details
+      Rule checks for the following conditions:
+        - Applies only to singleton resources
+        - Checks that the resource does not have a DELETE method defined
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-113-singleton-must-not-have-delete-method'
+    severity: warn
+    given: '$.paths[*]'
+    then:
+      function: 'IPA113SingletonHasNoDeleteMethod'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -485,12 +485,22 @@ Rule checks for the following conditions:
 #### xgen-IPA-113-singleton-must-not-have-delete-method
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Singleton resources must not define the Delete standard method
+Singleton resources must not define the Delete standard method.
 
 ##### Implementation details
 Rule checks for the following conditions:
   - Applies only to singleton resources
   - Checks that the resource does not have a DELETE method defined
+
+#### xgen-IPA-113-singleton-should-have-update-method
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Singleton resources should define the Update method. Validation for the presence of Get method is covered by IPA-104 (see [xgen-IPA-104-resource-has-GET](https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-resource-has-GET)).
+
+##### Implementation details
+Rule checks for the following conditions:
+  - Applies only to singleton resources
+  - Checks that the resource has the PUT and/or PATCH methods defined
 
 
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -482,6 +482,16 @@ Rule checks for the following conditions:
   - Verifies that no schema contains 'id' or '_id' properties in their object definitions
   - Fails if any response schema contains these identifier properties
 
+#### xgen-IPA-113-singleton-must-not-have-delete-method
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Singleton resources must not define the Delete standard method
+
+##### Implementation details
+Rule checks for the following conditions:
+  - Applies only to singleton resources
+  - Checks that the resource does not have a DELETE method defined
+
 
 
 ### IPA-123

--- a/tools/spectral/ipa/rulesets/functions/IPA113SingletonHasNoDeleteMethod.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA113SingletonHasNoDeleteMethod.js
@@ -1,0 +1,49 @@
+import {
+  getResourcePathItems,
+  isSingletonResource,
+  isResourceCollectionIdentifier,
+  hasDeleteMethod,
+} from './utils/resourceEvaluation.js';
+import { hasException } from './utils/exceptions.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
+
+const RULE_NAME = 'xgen-IPA-113-singleton-must-not-have-delete-method';
+const ERROR_MESSAGE =
+  'Singleton resources must not define the Delete standard method. If this is not a singleton resource, please implement all CRUDL methods.';
+
+export default (input, opts, { path, documentInventory }) => {
+  const oas = documentInventory.resolved;
+  const resourcePath = path[1];
+  const resourcePathItems = getResourcePathItems(resourcePath, oas.paths);
+
+  if (!(isResourceCollectionIdentifier(resourcePath) && isSingletonResource(resourcePathItems))) {
+    return;
+  }
+
+  if (hasException(input, RULE_NAME)) {
+    collectException(input, RULE_NAME, path);
+    return;
+  }
+
+  const errors = checkViolationsAndReturnErrors(input, path);
+  if (errors.length !== 0) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+  collectAdoption(path, RULE_NAME);
+};
+
+function checkViolationsAndReturnErrors(input, path) {
+  try {
+    if (hasDeleteMethod(input)) {
+      return [{ path, message: ERROR_MESSAGE }];
+    }
+    return [];
+  } catch (e) {
+    handleInternalError(RULE_NAME, path, e);
+  }
+}

--- a/tools/spectral/ipa/rulesets/functions/IPA113SingletonHasUpdateMethod.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA113SingletonHasUpdateMethod.js
@@ -1,0 +1,50 @@
+import {
+  getResourcePathItems,
+  isSingletonResource,
+  isResourceCollectionIdentifier,
+  hasPutMethod,
+  hasPatchMethod,
+} from './utils/resourceEvaluation.js';
+import { hasException } from './utils/exceptions.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
+
+const RULE_NAME = 'xgen-IPA-113-singleton-should-have-update-method';
+const ERROR_MESSAGE =
+  'Singleton resources should define the Update method. If this is not a singleton resource, please implement all CRUDL methods.';
+
+export default (input, opts, { path, documentInventory }) => {
+  const oas = documentInventory.resolved;
+  const resourcePath = path[1];
+  const resourcePathItems = getResourcePathItems(resourcePath, oas.paths);
+
+  if (!(isResourceCollectionIdentifier(resourcePath) && isSingletonResource(resourcePathItems))) {
+    return;
+  }
+
+  if (hasException(input, RULE_NAME)) {
+    collectException(input, RULE_NAME, path);
+    return;
+  }
+
+  const errors = checkViolationsAndReturnErrors(input, path);
+  if (errors.length !== 0) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+  collectAdoption(path, RULE_NAME);
+};
+
+function checkViolationsAndReturnErrors(input, path) {
+  try {
+    if (!(hasPutMethod(input) || hasPatchMethod(input))) {
+      return [{ path, message: ERROR_MESSAGE }];
+    }
+    return [];
+  } catch (e) {
+    handleInternalError(RULE_NAME, path, e);
+  }
+}

--- a/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
@@ -103,6 +103,16 @@ export function hasPostMethod(pathObject) {
 }
 
 /**
+ * Checks if a path object has a DELETE method
+ *
+ * @param pathObject the path object to evaluate
+ * @returns {boolean}
+ */
+export function hasDeleteMethod(pathObject) {
+  return Object.keys(pathObject).includes('delete');
+}
+
+/**
  * Get all path items for a resource based on the path for the resource collection
  * For example, resource collection path '/resource' may return path items for ['/resource', '/resource{id}', '/resource{id}:customMethod']
  *

--- a/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
+++ b/tools/spectral/ipa/rulesets/functions/utils/resourceEvaluation.js
@@ -113,6 +113,26 @@ export function hasDeleteMethod(pathObject) {
 }
 
 /**
+ * Checks if a path object has a PUT method
+ *
+ * @param pathObject the path object to evaluate
+ * @returns {boolean}
+ */
+export function hasPutMethod(pathObject) {
+  return Object.keys(pathObject).includes('put');
+}
+
+/**
+ * Checks if a path object has a PATCH method
+ *
+ * @param pathObject the path object to evaluate
+ * @returns {boolean}
+ */
+export function hasPatchMethod(pathObject) {
+  return Object.keys(pathObject).includes('patch');
+}
+
+/**
  * Get all path items for a resource based on the path for the resource collection
  * For example, resource collection path '/resource' may return path items for ['/resource', '/resource{id}', '/resource{id}:customMethod']
  *


### PR DESCRIPTION
## Proposed changes

Adds IPA 113 rules:

- `xgen-IPA-113-singleton-must-not-have-delete-method`
- `xgen-IPA-113-singleton-should-have-update-method`

**Note:** `xgen-IPA-113-singleton-must-not-have-delete-method` is covering the statement "Singleton resources must not define the Create or Delete standard methods" however I only implemented the check for DELETE since we use the absence of POST to determine if a resource is a singleton resource.

**Note:** `xgen-IPA-113-singleton-should-have-update-method` in the guidelines mentions GET as well, but this is already covered by a rule for 104, so didn't include this validation here.

## Testing

- Added unit tests
- Ran validation, currently:
  - 3 violations for `xgen-IPA-113-singleton-must-not-have-delete-method`
  - 24 violations for `xgen-IPA-113-singleton-should-have-update-method`

_Jira ticket:_ [CLOUDP-304958](https://jira.mongodb.org/browse/CLOUDP-304958)
