### PR TITLE
Fix: Remove permissions from Spectral Lint workflow

### DIFF
--- a/.github/workflows/spectral-lint.yml
+++ b/.github/workflows/spectral-lint.yml
@@ -14,9 +14,6 @@ on:
       - 'tools/spectral/**'
       - 'openapi/**.yaml'
       - 'package.json'
-permissions:
-  issues: write
-  contents: write
 
 jobs:
   spectral-lint:
@@ -49,5 +46,5 @@ jobs:
       - name: IPA validation action
         uses: stoplightio/spectral-action@2ad0b9302e32a77c1caccf474a9b2191a8060d83
         with:
-          file_glob: ${{ github.workspace }}//v2.yaml
+          file_glob: v2.yaml
           spectral_ruleset: tools/spectral/ipa/ipa-spectral.yaml


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Removes permissions from Spectral Lint workflow to keep the default permissions

Modify `file_glob` to `v2.yaml` only, because it already points to `github/workspace`

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
