### PR TITLE
DOP-5448: Re-add automated Bump triggers

### DIFF
--- a/.github/workflows/generate-bump-pages.yml
+++ b/.github/workflows/generate-bump-pages.yml
@@ -1,7 +1,20 @@
 name: Check & deploy API documentation
 
 on:
+  # For deployments
   workflow_dispatch: # Allow manual trigger in case of quick fix
+  push:
+    branches:
+      - main
+    paths:
+      - 'openapi/**.json'
+
+  # For previews
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'openapi/**.json'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket: DOP-5448

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

This is a follow-up to #530. It was previously discussed that we'd remove automated triggers for now and add them when repo secrets/variables were configured. A commit within the previous PR preemptively removed them. This PR just adds them back since the secrets/variables have already been configured.

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

