### PR TITLE
Fix on IPA-112 rule implementation

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA112BooleanFieldNamesAvoidIsPrefix.test.js
+++ b/tools/spectral/ipa/__tests__/IPA112BooleanFieldNamesAvoidIsPrefix.test.js
@@ -177,4 +177,147 @@ testRule('xgen-IPA-112-boolean-field-names-avoid-is-prefix', [
     },
     errors: [],
   },
+  {
+    name: 'schema with referenced property types',
+    document: {
+      components: {
+        schemas: {
+          BooleanProperties: {
+            type: 'object',
+            properties: {
+              active: { type: 'boolean' },
+              isEnabled: { type: 'boolean' },
+              disabled: { type: 'boolean' },
+            },
+          },
+          User: {
+            type: 'object',
+            properties: {
+              userId: { type: 'string' },
+              name: { type: 'string' },
+              status: { $ref: '#/components/schemas/BooleanProperties' },
+              isAdmin: { type: 'boolean' },
+              preferences: {
+                type: 'object',
+                properties: {
+                  isEmailNotificationsEnabled: { type: 'boolean' },
+                  darkMode: { type: 'boolean' },
+                },
+              },
+            },
+          },
+        },
+      },
+      paths: {
+        '/users/{userId}': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-01-01+json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        user: { $ref: '#/components/schemas/User' },
+                        isCached: { type: 'boolean' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-112-boolean-field-names-avoid-is-prefix',
+        message: 'Boolean field "isEnabled" should not use the "is" prefix. Use "enabled" instead.',
+        path: ['components', 'schemas', 'BooleanProperties', 'properties', 'isEnabled'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-112-boolean-field-names-avoid-is-prefix',
+        message: 'Boolean field "isAdmin" should not use the "is" prefix. Use "admin" instead.',
+        path: ['components', 'schemas', 'User', 'properties', 'isAdmin'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-112-boolean-field-names-avoid-is-prefix',
+        message:
+          'Boolean field "isEmailNotificationsEnabled" should not use the "is" prefix. Use "emailNotificationsEnabled" instead.',
+        path: [
+          'components',
+          'schemas',
+          'User',
+          'properties',
+          'preferences',
+          'properties',
+          'isEmailNotificationsEnabled',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-112-boolean-field-names-avoid-is-prefix',
+        message: 'Boolean field "isCached" should not use the "is" prefix. Use "cached" instead.',
+        path: [
+          'paths',
+          '/users/{userId}',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.atlas.2024-01-01+json',
+          'schema',
+          'properties',
+          'isCached',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'schema with referenced property and exceptions',
+    document: {
+      components: {
+        schemas: {
+          UserSettings: {
+            type: 'object',
+            properties: {
+              isVerified: {
+                type: 'boolean',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-112-boolean-field-names-avoid-is-prefix': 'Reason',
+                },
+              },
+              isMfaEnabled: { type: 'boolean' },
+            },
+          },
+          UserProfile: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              email: { type: 'string' },
+              settings: { $ref: '#/components/schemas/UserSettings' },
+              isPremiumUser: {
+                type: 'boolean',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-112-boolean-field-names-avoid-is-prefix': 'Reason',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-112-boolean-field-names-avoid-is-prefix',
+        message: 'Boolean field "isMfaEnabled" should not use the "is" prefix. Use "mfaEnabled" instead.',
+        path: ['components', 'schemas', 'UserSettings', 'properties', 'isMfaEnabled'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
 ]);

--- a/tools/spectral/ipa/__tests__/IPA112FieldNamesAreCamelCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA112FieldNamesAreCamelCase.test.js
@@ -479,7 +479,7 @@ testRule('xgen-IPA-112-field-names-are-camel-case', [
               userId: { type: 'string' },
               firstName: { type: 'string' },
               Last_Name: { type: 'string' },
-              primaryAddress: { $ref: '#/components/schemas/Address' },
+              primary_address: { $ref: '#/components/schemas/Address' },
               contactInfo: {
                 type: 'object',
                 properties: {
@@ -501,7 +501,7 @@ testRule('xgen-IPA-112-field-names-are-camel-case', [
                     schema: {
                       type: 'object',
                       properties: {
-                        user: { $ref: '#/components/schemas/User' },
+                        primary_user: { $ref: '#/components/schemas/User' },
                         REQUEST_ID: { type: 'string' },
                       },
                     },
@@ -528,8 +528,31 @@ testRule('xgen-IPA-112-field-names-are-camel-case', [
       },
       {
         code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "primary_address" must use camelCase format.',
+        path: ['components', 'schemas', 'User', 'properties', 'primary_address'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
         message: 'Property "email_address" must use camelCase format.',
         path: ['components', 'schemas', 'User', 'properties', 'contactInfo', 'properties', 'email_address'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "primary_user" must use camelCase format.',
+        path: [
+          'paths',
+          '/users/{userId}',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.atlas.2024-01-01+json',
+          'schema',
+          'properties',
+          'primary_user',
+        ],
         severity: DiagnosticSeverity.Warning,
       },
       {

--- a/tools/spectral/ipa/__tests__/IPA112FieldNamesAreCamelCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA112FieldNamesAreCamelCase.test.js
@@ -461,4 +461,129 @@ testRule('xgen-IPA-112-field-names-are-camel-case', [
     },
     errors: [],
   },
+  {
+    name: 'schema with referenced property and nested objects',
+    document: {
+      components: {
+        schemas: {
+          Address: {
+            type: 'object',
+            properties: {
+              State_Name: { type: 'string' },
+              zipCode: { type: 'string' },
+            },
+          },
+          User: {
+            type: 'object',
+            properties: {
+              userId: { type: 'string' },
+              firstName: { type: 'string' },
+              Last_Name: { type: 'string' },
+              primaryAddress: { $ref: '#/components/schemas/Address' },
+              contactInfo: {
+                type: 'object',
+                properties: {
+                  email_address: { type: 'string' },
+                  phoneNumber: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+      paths: {
+        '/users/{userId}': {
+          get: {
+            responses: {
+              200: {
+                content: {
+                  'application/vnd.atlas.2024-01-01+json': {
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        user: { $ref: '#/components/schemas/User' },
+                        REQUEST_ID: { type: 'string' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "State_Name" must use camelCase format.',
+        path: ['components', 'schemas', 'Address', 'properties', 'State_Name'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "Last_Name" must use camelCase format.',
+        path: ['components', 'schemas', 'User', 'properties', 'Last_Name'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "email_address" must use camelCase format.',
+        path: ['components', 'schemas', 'User', 'properties', 'contactInfo', 'properties', 'email_address'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-112-field-names-are-camel-case',
+        message: 'Property "REQUEST_ID" must use camelCase format.',
+        path: [
+          'paths',
+          '/users/{userId}',
+          'get',
+          'responses',
+          '200',
+          'content',
+          'application/vnd.atlas.2024-01-01+json',
+          'schema',
+          'properties',
+          'REQUEST_ID',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'schema with referenced property and exceptions',
+    document: {
+      components: {
+        schemas: {
+          ApiSettings: {
+            type: 'object',
+            properties: {
+              API_KEY: {
+                type: 'string',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-112-field-names-are-camel-case': 'Reason',
+                },
+              },
+            },
+          },
+          UserProfile: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              email: { type: 'string' },
+              apiSettings: { $ref: '#/components/schemas/ApiSettings' },
+              User_Status: {
+                type: 'string',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-112-field-names-are-camel-case': 'Reason',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
 ]);

--- a/tools/spectral/ipa/rulesets/IPA-112.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-112.yaml
@@ -21,10 +21,11 @@ rules:
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-112-avoid-project-field-names'
     severity: warn
     given:
-      - '$.components.schemas..properties[*]~'
-      - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties[*]~'
-      - '$.paths..responses..content[?(@property.match(/json$/i))].schema..properties[*]~'
+      - '$.components.schemas..properties'
+      - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties'
+      - '$.paths..responses..content[?(@property.match(/json$/i))].schema..properties'
     then:
+      field: '@key'
       function: 'IPA112AvoidProjectFieldNames'
       functionOptions:
         prohibitedFieldNames:
@@ -46,10 +47,11 @@ rules:
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-112-field-names-are-camel-case'
     severity: warn
     given:
-      - '$.components.schemas..properties[*]~'
-      - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties[*]~'
-      - '$.paths..responses..content[?(@property.match(/json$/i))].schema..properties[*]~'
+      - '$.components.schemas..properties'
+      - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties'
+      - '$.paths..responses..content[?(@property.match(/json$/i))].schema..properties'
     then:
+      field: '@key'
       function: 'IPA112FieldNamesAreCamelCase'
   xgen-IPA-112-boolean-field-names-avoid-is-prefix:
     description: |
@@ -63,8 +65,9 @@ rules:
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-112-boolean-field-names-avoid-is-prefix'
     severity: warn
     given:
-      - '$.components.schemas..properties[*]~'
-      - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties[*]~'
-      - '$.paths..responses..content[?(@property.match(/json$/i))].schema..properties[*]~'
+      - '$.components.schemas..properties'
+      - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties'
+      - '$.paths..responses..content[?(@property.match(/json$/i))].schema..properties'
     then:
+      field: '@key'
       function: 'IPA112BooleanFieldNamesAvoidIsPrefix'

--- a/tools/spectral/ipa/rulesets/functions/IPA112AvoidProjectFieldNames.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA112AvoidProjectFieldNames.js
@@ -11,8 +11,14 @@ import { splitCamelCase } from './utils/schemaUtils.js';
 const RULE_NAME = 'xgen-IPA-112-avoid-project-field-names';
 
 export default (input, options, { path, documentInventory }) => {
-  const oas = documentInventory.resolved;
+  const oas = documentInventory.unresolved;
   const property = resolveObject(oas, path);
+
+  // Skip schema references ($ref):
+  // Referenced schemas are validated separately to prevent duplicate violations
+  if (!property) {
+    return;
+  }
 
   const ignoreList = options?.ignore || [];
   if (ignoreList.some((ignoreTerm) => input.toLowerCase().includes(ignoreTerm))) {

--- a/tools/spectral/ipa/rulesets/functions/IPA112BooleanFieldNamesAvoidIsPrefix.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA112BooleanFieldNamesAvoidIsPrefix.js
@@ -6,15 +6,17 @@ const RULE_NAME = 'xgen-IPA-112-boolean-field-names-avoid-is-prefix';
 const IS_PREFIX_REGEX = /^is[A-Z]/;
 
 export default (input, options, { path, documentInventory }) => {
-  const oas = documentInventory.resolved;
+  const oas = documentInventory.unresolved;
   const property = resolveObject(oas, path);
 
-  if (hasException(property, RULE_NAME)) {
-    collectException(property, RULE_NAME, path);
+  // Skip schema references ($ref) and non-boolean fields:
+  // Referenced schemas are validated separately to prevent duplicate violations
+  if (!property || property.type !== 'boolean') {
     return;
   }
 
-  if (property.type !== 'boolean') {
+  if (hasException(property, RULE_NAME)) {
+    collectException(property, RULE_NAME, path);
     return;
   }
 

--- a/tools/spectral/ipa/rulesets/functions/IPA112BooleanFieldNamesAvoidIsPrefix.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA112BooleanFieldNamesAvoidIsPrefix.js
@@ -1,4 +1,9 @@
-import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
 import { hasException } from './utils/exceptions.js';
 import { resolveObject } from './utils/componentUtils.js';
 
@@ -20,11 +25,22 @@ export default (input, options, { path, documentInventory }) => {
     return;
   }
 
-  if (IS_PREFIX_REGEX.test(input)) {
-    const suggestedName = input.charAt(2).toLowerCase() + input.slice(3);
-    const errorMessage = `Boolean field "${input}" should not use the "is" prefix. Use "${suggestedName}" instead.`;
-    return collectAndReturnViolation(path, RULE_NAME, errorMessage);
+  const errors = checkViolationsAndReturnErrors(input, path);
+  if (errors.length !== 0) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
   }
-
   collectAdoption(path, RULE_NAME);
 };
+
+function checkViolationsAndReturnErrors(input, path) {
+  try {
+    if (IS_PREFIX_REGEX.test(input)) {
+      const suggestedName = input.charAt(2).toLowerCase() + input.slice(3);
+      const errorMessage = `Boolean field "${input}" should not use the "is" prefix. Use "${suggestedName}" instead.`;
+      return [{ path, message: errorMessage }];
+    }
+    return [];
+  } catch (e) {
+    handleInternalError(RULE_NAME, path, e);
+  }
+}

--- a/tools/spectral/ipa/rulesets/functions/IPA112FieldNamesAreCamelCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA112FieldNamesAreCamelCase.js
@@ -6,8 +6,14 @@ import { resolveObject } from './utils/componentUtils.js';
 const RULE_NAME = 'xgen-IPA-112-field-names-are-camel-case';
 
 export default (input, options, { path, documentInventory }) => {
-  const oas = documentInventory.resolved;
+  const oas = documentInventory.unresolved;
   const property = resolveObject(oas, path);
+
+  // Skip schema references ($ref):
+  // Referenced schemas are validated separately to prevent duplicate violations
+  if (!property) {
+    return;
+  }
 
   if (hasException(property, RULE_NAME)) {
     collectException(property, RULE_NAME, path);

--- a/tools/spectral/ipa/rulesets/functions/IPA112FieldNamesAreCamelCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA112FieldNamesAreCamelCase.js
@@ -20,11 +20,6 @@ export default (input, options, { path, documentInventory }) => {
     return;
   }
 
-  if (input === 'mongoDBEmployeeAccessGrant') {
-    console.log(property);
-    console.log(path);
-  }
-
   if (hasException(property, RULE_NAME)) {
     collectException(property, RULE_NAME, path);
     return;


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-271999
(and other tickets CLOUDP-272000 and CLOUDP-272001)

Fix on the IPA-112 rule implementations:
If the path to property is a resolved version of a schema reference, skip it to prevent duplicate violations. The referenced schemas will be validated separately

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
