### PR TITLE
CLOUDP-297946:  removes the `x-sunset=9999-12-31` from the openapi spec

### DIFF
--- a/tools/cli/internal/openapi/filter/filter.go
+++ b/tools/cli/internal/openapi/filter/filter.go
@@ -77,6 +77,7 @@ func DefaultFilters(oas *openapi3.T, metadata *Metadata) []Filter {
 		&HiddenEnvsFilter{oas: oas, metadata: metadata},
 		&TagsFilter{oas: oas},
 		&OperationsFilter{oas: oas},
+		&SunsetFilter{oas: oas},
 	}
 }
 

--- a/tools/cli/internal/openapi/filter/sunset.go
+++ b/tools/cli/internal/openapi/filter/sunset.go
@@ -1,4 +1,4 @@
-// Copyright 2024 MongoDB Inc
+// Copyright 2025 MongoDB Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,28 +16,53 @@ package filter
 
 import (
 	"github.com/getkin/kin-openapi/openapi3"
+	"strings"
 )
 
-// OperationsFilter: is a filter that removes the x-xgen-owner-team extension from operations.
-type OperationsFilter struct {
+const sunsetToBeDecided = "9999-12-31"
+
+// SunsetFilter removes the sunsetToBeDecided from the openapi specification
+type SunsetFilter struct {
 	oas *openapi3.T
 }
 
-func (*OperationsFilter) ValidateMetadata() error {
+func (f *SunsetFilter) ValidateMetadata() error {
 	return nil
 }
 
-func (f *OperationsFilter) Apply() error {
+func (f *SunsetFilter) Apply() error {
 	if f.oas.Paths == nil {
 		return nil
 	}
 
 	for _, pathItem := range f.oas.Paths.Map() {
 		for _, operation := range pathItem.Operations() {
-			if operation.Extensions != nil {
-				delete(operation.Extensions, "x-xgen-owner-team")
+			if operation.Responses == nil {
+				continue
 			}
+
+			applyOnOperation(operation)
 		}
 	}
 	return nil
+}
+
+func applyOnOperation(op *openapi3.Operation) {
+	//newResponses := make(map[string]*openapi3.ResponseRef, 1)
+	for key, response := range op.Responses.Map() {
+		if !strings.HasPrefix(key, "20") {
+			continue
+		}
+
+		for _, content := range response.Value.Content {
+			if v, ok := content.Extensions["x-sunset"]; ok {
+				if v != sunsetToBeDecided {
+					continue
+				}
+
+				delete(content.Extensions, "x-sunset")
+				//newResponses[key] = response
+			}
+		}
+	}
 }

--- a/tools/cli/internal/openapi/filter/sunset_test.go
+++ b/tools/cli/internal/openapi/filter/sunset_test.go
@@ -1,0 +1,336 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package filter
+
+import (
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSunsetFilter_Apply(t *testing.T) {
+	testCases := []struct {
+		name       string
+		initSpec   *openapi3.T
+		wantedSpec *openapi3.T
+	}{
+		{
+			name: "Remove x-sunset when value is 9999-12-31",
+			initSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+								"application/vnd.atlas.2023-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2023-01-01",
+										"x-sunset":      "9999-12-31",
+									},
+								},
+							},
+						})),
+					},
+				})),
+			},
+			wantedSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+								"application/vnd.atlas.2023-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2023-01-01",
+									},
+								},
+							},
+						})),
+					},
+				})),
+			},
+		},
+		{
+			name: "Remove x-sunset when value is 9999-12-31 for a 204",
+			initSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("204", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+								"application/vnd.atlas.2023-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2023-01-01",
+										"x-sunset":      "9999-12-31",
+									},
+								},
+							},
+						})),
+					},
+				})),
+			},
+			wantedSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("204", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+								"application/vnd.atlas.2023-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2023-01-01",
+									},
+								},
+							},
+						})),
+					},
+				})),
+			},
+		},
+		{
+			name: "Keep x-sunset when value is different",
+			initSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+							},
+						})),
+					},
+				})),
+			},
+			wantedSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+							},
+						})),
+					},
+				})),
+			},
+		},
+		{
+			name: "Ignore non-2xx responses",
+			initSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("404", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+								"application/vnd.atlas.2023-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2023-01-01",
+										"x-sunset":      "9999-12-31",
+									},
+								},
+							},
+						})),
+					},
+				})),
+			},
+			wantedSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("404", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+								"application/vnd.atlas.2023-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2023-01-01",
+										"x-sunset":      "9999-12-31",
+									},
+								},
+							},
+						})),
+					},
+				})),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &SunsetFilter{
+				oas: tc.initSpec,
+			}
+
+			require.NoError(t, f.Apply())
+			require.EqualValues(t, f.oas, tc.wantedSpec)
+		})
+	}
+}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-297946


This PR removes the `x-sunset=9999-12-31` from the openapi spec by creating a new filter.