### PR TITLE
IPA-112 fix for incorrect paths in the error messages

### DIFF
--- a/tools/spectral/ipa/rulesets/IPA-112.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-112.yaml
@@ -20,6 +20,7 @@ rules:
         - Suggests using "group", "groups", or "groupId" as alternatives
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-112-avoid-project-field-names'
     severity: warn
+    resolved: false
     given:
       - '$.components.schemas..properties'
       - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties'
@@ -46,6 +47,7 @@ rules:
         - Reports any instances where these field names are not in camelCase format
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-112-field-names-are-camel-case'
     severity: warn
+    resolved: false
     given:
       - '$.components.schemas..properties'
       - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties'
@@ -64,6 +66,7 @@ rules:
         - Suggests using the direct adjective form instead (e.g., "disabled" instead of "isDisabled")
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-112-boolean-field-names-avoid-is-prefix'
     severity: warn
+    resolved: false
     given:
       - '$.components.schemas..properties'
       - '$.paths..requestBody.content[?(@property.match(/json$/i))].schema..properties'


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-271999
(affects other tickets CLOUDP-272000 and CLOUDP-272001)

Adds `resolved: false` to IPA-112 rule definitions to show the correct paths in the error messages

Example:
Before:
` 54973:27  warning  xgen-IPA-112-field-names-are-camel-case
Property "diskGB" must use camelCase format. https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-112-field-names-are-camel-case
components.schemas.DiskGBAutoScaling`
After:
`  32773:20  warning  xgen-IPA-112-field-names-are-camel-case
Property "diskGB" must use camelCase format. https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-112-field-names-are-camel-case 
components.schemas.AdvancedAutoScalingSettings.properties.diskGB`

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
