### PR TITLE
CLOUDP-308303: remove whitespaces to reduce collection size

### DIFF
--- a/tools/postman/scripts/transform-for-api.sh
+++ b/tools/postman/scripts/transform-for-api.sh
@@ -125,17 +125,21 @@ else
   cp intermediateCollectionPostBody.json "$COLLECTION_TRANSFORMED_FILE_NAME"
 fi
 
+# Remove trailing whitespaces by reformatting the JSON
+echo "Removing all whitespaces from the final JSON file"
+jq -c '.' "$COLLECTION_TRANSFORMED_FILE_NAME" > tmpnowhitespaces.json && mv tmpnowhitespaces.json "$COLLECTION_TRANSFORMED_FILE_NAME"
+
 # Clean up temporary files
 echo "Removing temporary files"
 rm intermediateCollectionWrapped.json \
-   intermediateCollectionDisableQueryParam.json \
-   intermediateCollectionNoPostmanID.json \
-   intermediateCollectionNoCircular.json \
-   intermediateCollectionWithName.json \
-   intermediateCollectionWithDescription.json \
-   intermediateCollectionWithBaseURL.json \
-   intermediateCollectionWithLinks.json \
-   intermediateCollectionPostBody.json \
-   intermediateCollectionWithNoVar.json
+  intermediateCollectionDisableQueryParam.json \
+  intermediateCollectionNoPostmanID.json \
+  intermediateCollectionNoCircular.json \
+  intermediateCollectionWithName.json \
+  intermediateCollectionWithDescription.json \
+  intermediateCollectionWithBaseURL.json \
+  intermediateCollectionWithLinks.json \
+  intermediateCollectionPostBody.json \
+  intermediateCollectionWithNoVar.json
 
 popd -0

--- a/tools/postman/scripts/transform-postman.js
+++ b/tools/postman/scripts/transform-postman.js
@@ -119,7 +119,7 @@ function loadJsonFile(filePath) {
 }
 
 function saveJsonFile(filePath, json) {
-  fs.writeFileSync(filePath, JSON.stringify(json, null, 2), 'utf8');
+  fs.writeFileSync(filePath, JSON.stringify(json, null, 0), 'utf8');
 }
 
 // hack


### PR DESCRIPTION
## Description

Fix in the postman transformation to reduce size of the generated file. It reduces filesize by 50% 
Applied to both transformations. Tested by uploading file to my private postman.

## Context

In previous PR #600  I used to take approach where we removed all possible fields and seek for possible redundancies.
During the process I have logged difference and created table covering the biggest wins we can get for the size compared to the experience we loose. AI analised size redundancies and different use cases and found that we can get 50% efficiency on removing whitespaces from json. All other improvements did not had the same impact to the file so I did not included them in the process.

## Before

![Screenshot 2025-03-25 at 14 30 42](https://github.com/user-attachments/assets/4cb0962a-fd43-4616-b7aa-a23d3c3cbf13)

## After

 
![Screenshot 2025-03-25 at 15 24 07](https://github.com/user-attachments/assets/a84bbb42-9382-4c63-8223-f5e4346e672b)


