### PR TITLE
CLOUDP-306570: Rule xgen-IPA-117-description-must-not-use-html

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA117DescriptionEndsWithPeriod.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117DescriptionEndsWithPeriod.test.js
@@ -61,7 +61,7 @@ testRule('xgen-IPA-117-description-ends-with-period', [
     errors: [],
   },
   {
-    name: 'invalid components with exceptions',
+    name: 'invalid description with exceptions',
     document: {
       components: {
         schemas: {

--- a/tools/spectral/ipa/__tests__/IPA117DescriptionMustNotUseHtml.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117DescriptionMustNotUseHtml.test.js
@@ -1,0 +1,112 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-117-description-must-not-use-html', [
+  {
+    name: 'valid description',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              valid: {
+                description: 'Description.',
+              },
+              validWithAngleBracket: {
+                description: 'Must be < 250 characters.',
+              },
+              validWithAngleBrackets: {
+                description: 'For example <username>:<password>',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid descriptions',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              html: {
+                description: '<a>Description</a>',
+              },
+              link: {
+                description: 'To learn more, see <a href="https://www.mongodb.com/">MongoDB</a>',
+              },
+              inlineHtml: {
+                description: 'This is something. <a>Description</a>',
+              },
+              selfClosingHtml: {
+                description: 'This is something.<br/>With a line break.',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-117-description-must-not-use-html',
+        message: 'Descriptions must not use raw HTML.',
+        path: ['components', 'schemas', 'Schema', 'properties', 'html'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-117-description-must-not-use-html',
+        message:
+          'Descriptions must not use raw HTML. If you want to link to additional documentation, please use the externalDocumentation property (https://swagger.io/specification/#external-documentation-object).',
+        path: ['components', 'schemas', 'Schema', 'properties', 'link'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-117-description-must-not-use-html',
+        message: 'Descriptions must not use raw HTML.',
+        path: ['components', 'schemas', 'Schema', 'properties', 'inlineHtml'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-117-description-must-not-use-html',
+        message: 'Descriptions must not use raw HTML.',
+        path: ['components', 'schemas', 'Schema', 'properties', 'selfClosingHtml'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid descriptions with exceptions',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              html: {
+                description: '<a>Description</a>',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-117-description-must-not-use-html': 'reason',
+                },
+              },
+              inlineHtml: {
+                description: 'This is something. <a>Description</a>',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-117-description-must-not-use-html': 'reason',
+                },
+              },
+              selfClosingHtml: {
+                description: 'This is something.</br>With a line break.',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-117-description-must-not-use-html': 'reason',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/IPA117DescriptionStartsWithUpperCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117DescriptionStartsWithUpperCase.test.js
@@ -44,7 +44,7 @@ testRule('xgen-IPA-117-description-starts-with-uppercase', [
     ],
   },
   {
-    name: 'invalid components with exceptions',
+    name: 'invalid description with exceptions',
     document: {
       components: {
         schemas: {

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -5,6 +5,7 @@ functions:
   - IPA117HasDescription
   - IPA117DescriptionStartsWithUpperCase
   - IPA117DescriptionEndsWithPeriod
+  - IPA117DescriptionMustNotUseHtml
 
 rules:
   xgen-IPA-117-description:
@@ -81,3 +82,28 @@ rules:
       - '$.components.parameters[*]'
     then:
       function: 'IPA117DescriptionEndsWithPeriod'
+  xgen-IPA-117-description-must-not-use-html:
+    description: |
+      Descriptions must not use raw HTML.
+
+      ##### Implementation details
+      Rule checks the format of the descriptions for components:
+        - Info object
+        - Tags
+        - Operation objects
+        - Inline schema properties for operation object requests and responses
+        - Parameter objects (in operations and components)
+        - Schema properties
+      The rule validates that the description content does not include opening and/or closing HTML tags.
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-description-must-not-use-html'
+    severity: warn
+    given:
+      - '$.info'
+      - '$.tags[*]'
+      - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
+      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
+      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
+      - '$.components.schemas..properties[*]'
+      - '$.components.parameters[*]'
+    then:
+      function: 'IPA117DescriptionMustNotUseHtml'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -575,6 +575,21 @@ Rule checks the format of the description property in the following components:
   - Schema properties
 The rule ignores descriptions that end with `|`, i.e. inline markdown tables
 
+#### xgen-IPA-117-description-must-not-use-html
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Descriptions must not use raw HTML.
+
+##### Implementation details
+Rule checks the format of the descriptions for components:
+  - Info object
+  - Tags
+  - Operation objects
+  - Inline schema properties for operation object requests and responses
+  - Parameter objects (in operations and components)
+  - Schema properties
+The rule validates that the description content does not include opening and/or closing HTML tags.
+
 
 
 ### IPA-123

--- a/tools/spectral/ipa/rulesets/functions/IPA117DescriptionMustNotUseHtml.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117DescriptionMustNotUseHtml.js
@@ -1,0 +1,51 @@
+import { hasException } from './utils/exceptions.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
+
+const RULE_NAME = 'xgen-IPA-117-description-must-not-use-html';
+const ERROR_MESSAGE = 'Descriptions must not use raw HTML.';
+
+export default (input, opts, { path }) => {
+  // Ignore missing descriptions
+  if (!input['description']) {
+    return;
+  }
+
+  if (hasException(input, RULE_NAME)) {
+    collectException(input, RULE_NAME, path);
+    return;
+  }
+
+  const errors = checkViolationsAndReturnErrors(input['description'], path);
+  if (errors.length !== 0) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+  collectAdoption(path, RULE_NAME);
+};
+
+function checkViolationsAndReturnErrors(description, path) {
+  const htmlTagPattern = new RegExp(`<.*>.*</.*>`);
+  const htmlTagSelfClosingPattern = new RegExp(`<.*/>`);
+  const linkHtmlPattern = new RegExp(`<a.*>.*</a>`);
+
+  try {
+    if (htmlTagPattern.test(description) || htmlTagSelfClosingPattern.test(description)) {
+      if (linkHtmlPattern.test(description)) {
+        return [
+          {
+            path,
+            message: `${ERROR_MESSAGE} If you want to link to additional documentation, please use the externalDocumentation property (https://swagger.io/specification/#external-documentation-object).`,
+          },
+        ];
+      }
+      return [{ path, message: ERROR_MESSAGE }];
+    }
+    return [];
+  } catch (e) {
+    handleInternalError(RULE_NAME, path, e);
+  }
+}


### PR DESCRIPTION
## Proposed changes

Adds rule `xgen-IPA-117-description-must-not-use-html` which checks for HTML tags in the descriptions. It will fail if
- There is an opening and closing HTML tag
- There is a self closing HTML tag, for example `<br/>` is a common one

Additionally, if there is an `<a>` tag, the error message with give a recommendation to use `externalDocumentation` property instead (see [Swagger docs](https://swagger.io/specification/#external-documentation-object))

12 violations currently, checked them to ensure there are no false positives.

_Jira ticket:_ [CLOUDP-306570](https://jira.mongodb.org/browse/CLOUDP-306570)
