### PR TITLE
Fix on xgen-IPA-110-collections-response-define-results-array

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA110CollectionsResponseDefineResultsArray.test.js
+++ b/tools/spectral/ipa/__tests__/IPA110CollectionsResponseDefineResultsArray.test.js
@@ -230,13 +230,6 @@ testRule('xgen-IPA-110-collections-response-define-results-array', [
         },
       },
     },
-    errors: [
-      {
-        code: 'xgen-IPA-110-collections-response-define-results-array',
-        message: 'The response for collections must define an array of results containing the paginated resource.',
-        path: ['paths', '/resources', 'get', 'responses', '200', 'content', 'application/json'],
-        severity: DiagnosticSeverity.Warning,
-      },
-    ],
+    errors: [],
   },
 ]);

--- a/tools/spectral/ipa/rulesets/functions/IPA110CollectionsResponseDefineResultsArray.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA110CollectionsResponseDefineResultsArray.js
@@ -13,7 +13,7 @@ import {
 import { resolveObject } from './utils/componentUtils.js';
 import { schemaIsPaginated } from './utils/schemaUtils.js';
 
-const RULE_NAME = 'xgen-IPA-110-collections-use-paginated-schema';
+const RULE_NAME = 'xgen-IPA-110-collections-response-define-results-array';
 const ERROR_MESSAGE = 'The response for collections must define an array of results containing the paginated resource.';
 
 export default (input, _, { path, documentInventory }) => {


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-304955

Small fixes around the exception mechanism of `xgen-IPA-110-collections-response-define-results-array` rule

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
