### PR TITLE
chore: Upgrade golangci-lint to v2 

### DIFF
--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -67,7 +67,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd
         with:
-          version: v1.64.5
+          version: v2.0.1
           working-directory: tools/cli
       - name: Checkout GitHub actions
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/tools/cli/.golangci.bck.yml
+++ b/tools/cli/.golangci.bck.yml
@@ -1,0 +1,129 @@
+# TO BE REMOVED IN https://jira.mongodb.org/browse/CLOUDP-308470
+
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  govet:
+    enable:
+      - shadow
+
+  revive:
+    # see https://github.com/mgechev/revive#available-rules for details.
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: defer
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: early-return
+      - name: errorf
+      - name: exported
+      - name: import-shadowing
+      - name: indent-error-flow
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: struct-tag
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      - name: unused-receiver
+      - name: constant-logical-expr
+      - name: confusing-naming
+      - name: unnecessary-stmt
+      - name: use-any
+      - name: imports-blocklist
+        arguments:
+          - "github.com/pkg/errors"
+  misspell:
+    locale: US
+  lll:
+    line-length: 150
+  nestif:
+    # minimal complexity of if statements to report, 5 by default
+    min-complexity: 7
+  funlen:
+    lines: 360
+    statements: 120
+  gci:
+    sections:
+      - standard
+      - default
+linters:
+  disable-all: true
+  enable:
+    - copyloopvar # copyloopvar is a linter detects places where loop variables are copied
+    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
+    - errcheck # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases
+    - errorlint # Errorlint is a linter that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    - exhaustive # check exhaustiveness of enum switch statements
+    - copyloopvar # copyloopvar is a linter detects places where loop variables are copied. Replaces exportloopref since Go1.22
+    - funlen # Tool for detection of long functions
+    - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
+    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
+    - godot # Check if comments end in a period [fast: true, auto-fix: true]
+    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
+    - goimports # Check import statements are formatted according to the 'goimport' command. Reformat imports in autofix mode.
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end.
+    - gosec # Inspects source code for security problems
+    - gosimple # Linter for Go source code that specializes in simplifying code
+    - govet # Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes.
+    - ineffassign # Detects when assignments to existing variables are not used
+    - lll # Reports long lines
+    - makezero # Finds slice declarations with non-zero initial length
+    - misspell # Finds commonly misspelled English words
+    - nakedret # Checks that functions with naked returns are not longer than a maximum size (can be zero).
+    - noctx # Finds sending http request without context.Context
+    - nolintlint # Reports ill-formed or insufficient nolint directives
+    - perfsprint # Checks that fmt.Sprintf can be replaced with a faster alternative.
+    - prealloc # Finds slice declarations that could potentially be pre-allocated
+    - predeclared # find code that shadows one of Go's predeclared identifiers
+    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    - rowserrcheck # checks whether Rows.Err of rows is checked successfully
+    - staticcheck # It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
+    - stylecheck # Stylecheck is a replacement for golint
+    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
+    - testifylint # Checks usage of github.com/stretchr/testify.
+    - thelper # thelper detects tests helpers which is not start with t.Helper() method.
+    - unconvert # Remove unnecessary type conversions
+    - unused # Checks Go code for unused constants, variables, functions and types
+    - whitespace # Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.
+
+  # don't enable:
+  #   - deadcode
+  #   - varcheck
+  #   - structcheck
+  #   - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
+  #   - gocyclo # we already have funlen lint
+  #   - dupl  # we have a lot of duplicate test cases
+  #   - gochecknoinits # we need the init function for the provider
+  #   - gochecknoglobals # we need some global variables
+  #   - unparam # Forces to create global variables when one variable is repeated in different functions
+  #   - goerr113 # It does not allow you to return an error, you need to save the error in a variable to do it
+  #   - goconst
+  #   - gocognit
+
+run:
+  timeout: 10m
+  tests: true
+  modules-download-mode: readonly

--- a/tools/cli/.golangci.yml
+++ b/tools/cli/.golangci.yml
@@ -1,127 +1,137 @@
-linters-settings:
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  govet:
-    enable:
-      - shadow
-
-  revive:
-    # see https://github.com/mgechev/revive#available-rules for details.
-    ignore-generated-header: true
-    severity: warning
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: defer
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: early-return
-      - name: errorf
-      - name: exported
-      - name: import-shadowing
-      - name: indent-error-flow
-      - name: if-return
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: struct-tag
-      - name: unused-parameter
-      - name: unreachable-code
-      - name: redefines-builtin-id
-      - name: unused-receiver
-      - name: constant-logical-expr
-      - name: confusing-naming
-      - name: unnecessary-stmt
-      - name: use-any
-      - name: imports-blocklist
-        arguments:
-          - "github.com/pkg/errors"
-  misspell:
-    locale: US
-  lll:
-    line-length: 150
-  nestif:
-    # minimal complexity of if statements to report, 5 by default
-    min-complexity: 7
-  funlen:
-    lines: 360
-    statements: 120
-  gci:
-    sections:
-      - standard
-      - default
-linters:
-  disable-all: true
-  enable:
-    - copyloopvar # copyloopvar is a linter detects places where loop variables are copied
-    - dogsled # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
-    - errcheck # errcheck is a program for checking for unchecked errors in Go code. These unchecked errors can be critical bugs in some cases
-    - errorlint # Errorlint is a linter that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
-    - exhaustive # check exhaustiveness of enum switch statements
-    - copyloopvar # copyloopvar is a linter detects places where loop variables are copied. Replaces exportloopref since Go1.22
-    - funlen # Tool for detection of long functions
-    - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
-    - gocritic # Provides diagnostics that check for bugs, performance and style issues.
-    - godot # Check if comments end in a period [fast: true, auto-fix: true]
-    - gofmt # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
-    - goimports # Check import statements are formatted according to the 'goimport' command. Reformat imports in autofix mode.
-    - goprintffuncname # Checks that printf-like functions are named with `f` at the end.
-    - gosec # Inspects source code for security problems
-    - gosimple # Linter for Go source code that specializes in simplifying code
-    - govet # Vet examines Go source code and reports suspicious constructs. It is roughly the same as 'go vet' and uses its passes.
-    - ineffassign # Detects when assignments to existing variables are not used
-    - lll # Reports long lines
-    - makezero # Finds slice declarations with non-zero initial length
-    - misspell # Finds commonly misspelled English words
-    - nakedret # Checks that functions with naked returns are not longer than a maximum size (can be zero).
-    - noctx # Finds sending http request without context.Context
-    - nolintlint # Reports ill-formed or insufficient nolint directives
-    - perfsprint # Checks that fmt.Sprintf can be replaced with a faster alternative.
-    - prealloc # Finds slice declarations that could potentially be pre-allocated
-    - predeclared # find code that shadows one of Go's predeclared identifiers
-    - revive # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
-    - rowserrcheck # checks whether Rows.Err of rows is checked successfully
-    - staticcheck # It's a set of rules from staticcheck. It's not the same thing as the staticcheck binary. The author of staticcheck doesn't support or approve the use of staticcheck as a library inside golangci-lint.
-    - stylecheck # Stylecheck is a replacement for golint
-    - tenv # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
-    - testifylint # Checks usage of github.com/stretchr/testify.
-    - thelper # thelper detects tests helpers which is not start with t.Helper() method.
-    - unconvert # Remove unnecessary type conversions
-    - unused # Checks Go code for unused constants, variables, functions and types
-    - whitespace # Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc.
-
-  # don't enable:
-  #   - deadcode
-  #   - varcheck
-  #   - structcheck
-  #   - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
-  #   - gocyclo # we already have funlen lint
-  #   - dupl  # we have a lot of duplicate test cases
-  #   - gochecknoinits # we need the init function for the provider
-  #   - gochecknoglobals # we need some global variables
-  #   - unparam # Forces to create global variables when one variable is repeated in different functions
-  #   - goerr113 # It does not allow you to return an error, you need to save the error in a variable to do it
-  #   - goconst
-  #   - gocognit
-
+version: "2"
 run:
-  timeout: 10m
-  tests: true
   modules-download-mode: readonly
+  tests: true
+linters:
+  default: none
+  enable:
+    - copyloopvar
+    - dogsled
+    - errcheck
+    - errorlint
+    - exhaustive
+    - funlen
+    - gocritic
+    - godot
+    - goprintffuncname
+    - gosec
+    - govet
+    - ineffassign
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - perfsprint
+    - prealloc
+    - predeclared
+    - revive
+    - rowserrcheck
+    - staticcheck
+    - testifylint
+    - thelper
+    - unconvert
+    - unused
+    - whitespace
+    # don't enable:
+    #   - deadcode
+    #   - varcheck
+    #   - structcheck
+    #   - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
+    #   - gocyclo # we already have funlen lint
+    #   - dupl  # we have a lot of duplicate test cases
+    #   - gochecknoinits # we need the init function for the provider
+    #   - gochecknoglobals # we need some global variables
+    #   - unparam # Forces to create global variables when one variable is repeated in different functions
+    #   - goerr113 # It does not allow you to return an error, you need to save the error in a variable to do it
+    #   - goconst
+    #   - gocognit
+  settings:
+    funlen:
+      lines: 360
+      statements: 120
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    govet:
+      enable:
+        - shadow
+    lll:
+      line-length: 150
+    misspell:
+      locale: US
+    nestif:
+      min-complexity: 7
+    revive:
+      severity: warning
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: defer
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: early-return
+        - name: errorf
+        - name: exported
+        - name: import-shadowing
+        - name: indent-error-flow
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: struct-tag
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
+        - name: unused-receiver
+        - name: constant-logical-expr
+        - name: confusing-naming
+        - name: unnecessary-stmt
+        - name: use-any
+        - name: imports-blocklist
+          arguments:
+            - github.com/pkg/errors
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/tools/cli/Makefile
+++ b/tools/cli/Makefile
@@ -1,6 +1,6 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
-GOLANGCI_VERSION=v1.64.5
+GOLANGCI_VERSION=v2.0.1
 SOURCE_FILES?=./cmd
 BINARY_NAME=foascli
 VERSION=v0.0.1

--- a/tools/cli/internal/breakingchanges/exemptions_test.go
+++ b/tools/cli/internal/breakingchanges/exemptions_test.go
@@ -38,7 +38,7 @@ func TestGenerateExemptionsFileWithFs(t *testing.T) {
 
 		data, err := os.ReadFile(outputPath)
 		require.NoError(t, err)
-		assert.Equal(t, "", string(data))
+		assert.Empty(t, string(data))
 	})
 
 	t.Run("test_generate_exemptions_expired_entries_ignore_set", func(t *testing.T) {

--- a/tools/cli/internal/openapi/filter/schemas_test.go
+++ b/tools/cli/internal/openapi/filter/schemas_test.go
@@ -36,7 +36,7 @@ func TestSchemasFilter_Apply(t *testing.T) {
 			}
 
 			require.NoError(t, f.Apply())
-			require.EqualValues(t, tc.wantedSpec, f.oas)
+			require.Equal(t, tc.wantedSpec, f.oas)
 		})
 	}
 }

--- a/tools/cli/internal/openapi/filter/sunset_test.go
+++ b/tools/cli/internal/openapi/filter/sunset_test.go
@@ -332,7 +332,7 @@ func TestSunsetFilter_Apply(t *testing.T) {
 			}
 
 			require.NoError(t, f.Apply())
-			require.EqualValues(t, tc.wantedSpec, f.oas)
+			require.Equal(t, tc.wantedSpec, f.oas)
 		})
 	}
 }

--- a/tools/cli/internal/openapi/oasdiff_test.go
+++ b/tools/cli/internal/openapi/oasdiff_test.go
@@ -337,7 +337,7 @@ func TestOasDiff_mergeTags(t *testing.T) {
 			}
 			tc.wantErr(t, o.mergeTags())
 			if tc.expectedTags != nil {
-				assert.Equal(t, len(o.base.Spec.Tags), len(tc.expectedTags))
+				assert.Len(t, len(o.base.Spec.Tags), len(tc.expectedTags))
 				// check tag names are the same
 				for i := range o.base.Spec.Tags {
 					assert.Equal(t, o.base.Spec.Tags[i].Name, tc.expectedTags[i].Name)

--- a/tools/cli/internal/openapi/oasdiff_test.go
+++ b/tools/cli/internal/openapi/oasdiff_test.go
@@ -337,7 +337,7 @@ func TestOasDiff_mergeTags(t *testing.T) {
 			}
 			tc.wantErr(t, o.mergeTags())
 			if tc.expectedTags != nil {
-				assert.Len(t, len(o.base.Spec.Tags), len(tc.expectedTags))
+				assert.Len(t, o.base.Spec.Tags, len(tc.expectedTags))
 				// check tag names are the same
 				for i := range o.base.Spec.Tags {
 					assert.Equal(t, o.base.Spec.Tags[i].Name, tc.expectedTags[i].Name)

--- a/tools/cli/test/data/exemptions/exemptions.txt
+++ b/tools/cli/test/data/exemptions/exemptions.txt
@@ -1,0 +1,5 @@
+in components removed the schema 'GroupName' [api-schema-removed]
+GET /api/atlas/v2/groups/{groupId}/clusters/provider/regions removed the 'GSP' enum value from the 'results/items/provider' response property for the response status '200' [response-property-enum-value-removed].
+GET /api/atlas/v1.0/groups/{groupId}/clusters/provider/regions removed the 'GSP' enum value from the 'results/items/provider' response property for the response status '200' [response-property-enum-value-removed].
+GET /api/atlas/v1.5/groups/{groupId}/clusters/provider/regions removed the 'GSP' enum value from the 'results/items/provider' response property for the response status '200' [response-property-enum-value-removed].
+GET /api/atlas/v1.0/groups/{groupId}/clusters/provider/regions removed the 'GSP' enum value from the 'results/items/provider' response property for the response status '200' [response-property-enum-value-removed].

--- a/tools/cli/test/data/exemptions/exemptions.txt
+++ b/tools/cli/test/data/exemptions/exemptions.txt
@@ -1,5 +1,0 @@
-in components removed the schema 'GroupName' [api-schema-removed]
-GET /api/atlas/v2/groups/{groupId}/clusters/provider/regions removed the 'GSP' enum value from the 'results/items/provider' response property for the response status '200' [response-property-enum-value-removed].
-GET /api/atlas/v1.0/groups/{groupId}/clusters/provider/regions removed the 'GSP' enum value from the 'results/items/provider' response property for the response status '200' [response-property-enum-value-removed].
-GET /api/atlas/v1.5/groups/{groupId}/clusters/provider/regions removed the 'GSP' enum value from the 'results/items/provider' response property for the response status '200' [response-property-enum-value-removed].
-GET /api/atlas/v1.0/groups/{groupId}/clusters/provider/regions removed the 'GSP' enum value from the 'results/items/provider' response property for the response status '200' [response-property-enum-value-removed].

--- a/tools/cli/test/e2e/cli/changelog_test.go
+++ b/tools/cli/test/e2e/cli/changelog_test.go
@@ -139,13 +139,13 @@ func compareVersions(t *testing.T, cmdOutput, testOutput string) {
 
 func areEntriesTheSame(t *testing.T, cmdEntries, testEntries []*changelog.Entry) {
 	t.Helper()
-	require.Equal(t, len(cmdEntries), len(testEntries))
+	require.Len(t, len(cmdEntries), len(testEntries))
 	arePathsTheSame(t, cmdEntries[0].Paths, testEntries[0].Paths)
 }
 
 func arePathsTheSame(t *testing.T, cmdPaths, testPaths []*changelog.Path) {
 	t.Helper()
-	require.Equal(t, len(cmdPaths), len(testPaths))
+	require.Len(t, len(cmdPaths), len(testPaths))
 	for i, cmdPath := range cmdPaths {
 		assert.Equal(t, cmdPath.OperationID, testPaths[i].OperationID)
 		assert.Equal(t, cmdPath.HTTPMethod, testPaths[i].HTTPMethod)

--- a/tools/cli/test/e2e/cli/changelog_test.go
+++ b/tools/cli/test/e2e/cli/changelog_test.go
@@ -139,13 +139,13 @@ func compareVersions(t *testing.T, cmdOutput, testOutput string) {
 
 func areEntriesTheSame(t *testing.T, cmdEntries, testEntries []*changelog.Entry) {
 	t.Helper()
-	require.Len(t, len(cmdEntries), len(testEntries))
+	require.Len(t, cmdEntries, len(testEntries))
 	arePathsTheSame(t, cmdEntries[0].Paths, testEntries[0].Paths)
 }
 
 func arePathsTheSame(t *testing.T, cmdPaths, testPaths []*changelog.Path) {
 	t.Helper()
-	require.Len(t, len(cmdPaths), len(testPaths))
+	require.Len(t, cmdPaths, len(testPaths))
 	for i, cmdPath := range cmdPaths {
 		assert.Equal(t, cmdPath.OperationID, testPaths[i].OperationID)
 		assert.Equal(t, cmdPath.HTTPMethod, testPaths[i].HTTPMethod)


### PR DESCRIPTION
## Proposed changes
This PR upgrade golangci-lint to v2 and fixes linting errors. I followed the migration guide: https://golangci-lint.run/product/migration-guide/
