### PR TITLE
fix: update the sunset filter to remove the `9999-12-01` also from the operation extension.

### DIFF
--- a/tools/cli/internal/openapi/filter/sunset.go
+++ b/tools/cli/internal/openapi/filter/sunset.go
@@ -50,9 +50,9 @@ func (f *SunsetFilter) Apply() error {
 }
 
 // applyOnOperation removes the "sunset" extension if its value is set to "sunsetToBeDecided".
-// The "sunset" extension can be located in two places:
-// 1) Within the 20X response
-// 2) As part of the operation itself
+// The "sunset" extension can be located in two places.
+// 1) Within the 20X response.
+// 2) As part of the operation itself.
 func applyOnOperation(op *openapi3.Operation) {
 	// 1) Check the "sunset" extension in the response
 	for key, response := range op.Responses.Map() {

--- a/tools/cli/internal/openapi/filter/sunset.go
+++ b/tools/cli/internal/openapi/filter/sunset.go
@@ -49,7 +49,12 @@ func (f *SunsetFilter) Apply() error {
 	return nil
 }
 
+// applyOnOperation removes the "sunset" extension if its value is set to "sunsetToBeDecided".
+// The "sunset" extension can be located in two places:
+// 1) Within the 20X response
+// 2) As part of the operation itself
 func applyOnOperation(op *openapi3.Operation) {
+	// 1) Check the "sunset" extension in the response
 	for key, response := range op.Responses.Map() {
 		if !strings.HasPrefix(key, "20") {
 			continue
@@ -61,4 +66,9 @@ func applyOnOperation(op *openapi3.Operation) {
 			})
 		}
 	}
+
+	// 2) Check the "sunset" extension as part of the operation
+	maps.DeleteFunc(op.Extensions, func(_ string, v any) bool {
+		return v == sunsetToBeDecided
+	})
 }

--- a/tools/cli/internal/openapi/filter/sunset_test.go
+++ b/tools/cli/internal/openapi/filter/sunset_test.go
@@ -21,389 +21,11 @@ import (
 )
 
 func TestSunsetFilter_Apply(t *testing.T) {
-	testCases := []struct {
-		name       string
-		initSpec   *openapi3.T
-		wantedSpec *openapi3.T
-	}{
-		{
-			name: "Remove x-sunset when value is 9999-12-31",
-			initSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-								"application/vnd.atlas.2023-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2023-01-01",
-										"x-sunset":      "9999-12-31",
-									},
-								},
-							},
-						})),
-					},
-				})),
-			},
-			wantedSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-								"application/vnd.atlas.2023-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2023-01-01",
-									},
-								},
-							},
-						})),
-					},
-				})),
-			},
-		},
-		{
-			name: "Remove x-sunset when value is 9999-12-31 for a 204",
-			initSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("204", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-								"application/vnd.atlas.2023-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2023-01-01",
-										"x-sunset":      "9999-12-31",
-									},
-								},
-							},
-						})),
-					},
-				})),
-			},
-			wantedSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("204", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-								"application/vnd.atlas.2023-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2023-01-01",
-									},
-								},
-							},
-						})),
-					},
-				})),
-			},
-		},
-		{
-			name: "Keep x-sunset when value is different",
-			initSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-							},
-						})),
-					},
-				})),
-			},
-			wantedSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-							},
-						})),
-					},
-				})),
-			},
-		},
-		{
-			name: "Ignore non-2xx responses",
-			initSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("404", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-								"application/vnd.atlas.2023-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2023-01-01",
-										"x-sunset":      "9999-12-31",
-									},
-								},
-							},
-						})),
-					},
-				})),
-			},
-			wantedSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("404", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-								"application/vnd.atlas.2023-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2023-01-01",
-										"x-sunset":      "9999-12-31",
-									},
-								},
-							},
-						})),
-					},
-				})),
-			},
-		},
-		{
-			name: "Remove x-sunset when value is 9999-12-31 and extension is in the operation",
-			initSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-								"application/vnd.atlas.2023-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2023-01-01",
-									},
-								},
-							},
-						})),
-						Extensions: map[string]any{
-							"x-sunset": "9999-12-31",
-						},
-					},
-				})),
-			},
-			wantedSpec: &openapi3.T{
-				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
-					Get: &openapi3.Operation{
-						OperationID: "testOperationID",
-						Summary:     "testSummary",
-						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
-							Content: openapi3.Content{
-								"application/vnd.atlas.2025-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2025-01-01",
-									},
-								},
-								"application/vnd.atlas.2024-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2024-01-01",
-										"x-sunset":      "2024-12-31",
-									},
-								},
-								"application/vnd.atlas.2023-01-01+json": {
-									Schema: &openapi3.SchemaRef{
-										Ref: "#/components/schemas/PaginatedAppUserView",
-									},
-									Extensions: map[string]any{
-										"x-gen-version": "2023-01-01",
-									},
-								},
-							},
-						})),
-						Extensions: map[string]any{},
-					},
-				})),
-			},
-		},
-	}
+	testCases := []testCase{removeSunsetFromOperation(),
+		ignoreNot20XResponse(),
+		doNotRemoveSunset(),
+		removeSunsetToDecideFromResponse204(),
+		removeSunsetToDecideFromResponse()}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -415,5 +37,393 @@ func TestSunsetFilter_Apply(t *testing.T) {
 			require.NoError(t, f.Apply())
 			require.Equal(t, tc.wantedSpec, f.oas)
 		})
+	}
+}
+
+func removeSunsetFromOperation() testCase {
+	return testCase{
+		name: "Remove x-sunset when value is 9999-12-31 and extension is in the operation",
+		initSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+							"application/vnd.atlas.2023-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2023-01-01",
+								},
+							},
+						},
+					})),
+					Extensions: map[string]any{
+						"x-sunset": "9999-12-31",
+					},
+				},
+			})),
+		},
+		wantedSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+							"application/vnd.atlas.2023-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2023-01-01",
+								},
+							},
+						},
+					})),
+					Extensions: map[string]any{},
+				},
+			})),
+		},
+	}
+}
+func ignoreNot20XResponse() testCase {
+	return testCase{
+		name: "Ignore non-2xx responses",
+		initSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("404", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+							"application/vnd.atlas.2023-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2023-01-01",
+									"x-sunset":      "9999-12-31",
+								},
+							},
+						},
+					})),
+				},
+			})),
+		},
+		wantedSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("404", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+							"application/vnd.atlas.2023-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2023-01-01",
+									"x-sunset":      "9999-12-31",
+								},
+							},
+						},
+					})),
+				},
+			})),
+		},
+	}
+}
+func doNotRemoveSunset() testCase {
+	return testCase{
+		name: "Keep x-sunset when value is different",
+		initSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+						},
+					})),
+				},
+			})),
+		},
+		wantedSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+						},
+					})),
+				},
+			})),
+		},
+	}
+}
+func removeSunsetToDecideFromResponse204() testCase {
+	return testCase{
+		name: "Remove x-sunset when value is 9999-12-31 for a 204",
+		initSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("204", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+							"application/vnd.atlas.2023-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2023-01-01",
+									"x-sunset":      "9999-12-31",
+								},
+							},
+						},
+					})),
+				},
+			})),
+		},
+		wantedSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("204", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+							"application/vnd.atlas.2023-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2023-01-01",
+								},
+							},
+						},
+					})),
+				},
+			})),
+		},
+	}
+}
+func removeSunsetToDecideFromResponse() testCase {
+	return testCase{
+		name: "Remove x-sunset when value is 9999-12-31",
+		initSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+							"application/vnd.atlas.2023-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2023-01-01",
+									"x-sunset":      "9999-12-31",
+								},
+							},
+						},
+					})),
+				},
+			})),
+		},
+		wantedSpec: &openapi3.T{
+			Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					OperationID: "testOperationID",
+					Summary:     "testSummary",
+					Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+						Content: openapi3.Content{
+							"application/vnd.atlas.2025-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2025-01-01",
+								},
+							},
+							"application/vnd.atlas.2024-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2024-01-01",
+									"x-sunset":      "2024-12-31",
+								},
+							},
+							"application/vnd.atlas.2023-01-01+json": {
+								Schema: &openapi3.SchemaRef{
+									Ref: "#/components/schemas/PaginatedAppUserView",
+								},
+								Extensions: map[string]any{
+									"x-gen-version": "2023-01-01",
+								},
+							},
+						},
+					})),
+				},
+			})),
+		},
 	}
 }

--- a/tools/cli/internal/openapi/filter/sunset_test.go
+++ b/tools/cli/internal/openapi/filter/sunset_test.go
@@ -322,6 +322,87 @@ func TestSunsetFilter_Apply(t *testing.T) {
 				})),
 			},
 		},
+		{
+			name: "Remove x-sunset when value is 9999-12-31 and extension is in the operation",
+			initSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+								"application/vnd.atlas.2023-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2023-01-01",
+									},
+								},
+							},
+						})),
+						Extensions: map[string]any{
+							"x-sunset": "9999-12-31",
+						},
+					},
+				})),
+			},
+			wantedSpec: &openapi3.T{
+				Paths: openapi3.NewPaths(openapi3.WithPath("test", &openapi3.PathItem{
+					Get: &openapi3.Operation{
+						OperationID: "testOperationID",
+						Summary:     "testSummary",
+						Responses: openapi3.NewResponses(openapi3.WithName("200", &openapi3.Response{
+							Content: openapi3.Content{
+								"application/vnd.atlas.2025-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2025-01-01",
+									},
+								},
+								"application/vnd.atlas.2024-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2024-01-01",
+										"x-sunset":      "2024-12-31",
+									},
+								},
+								"application/vnd.atlas.2023-01-01+json": {
+									Schema: &openapi3.SchemaRef{
+										Ref: "#/components/schemas/PaginatedAppUserView",
+									},
+									Extensions: map[string]any{
+										"x-gen-version": "2023-01-01",
+									},
+								},
+							},
+						})),
+						Extensions: map[string]any{},
+					},
+				})),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This pull request introduces changes to the `SunsetFilter` functionality in the `tools/cli/internal/openapi/filter` package. The main goal is to enhance the handling of the "sunset" extension within OpenAPI operations and their responses. Additionally, new test cases are added to ensure the correctness of these changes.

Enhancements to `SunsetFilter`:

* [`tools/cli/internal/openapi/filter/sunset.go`](diffhunk://#diff-4402820713197db547cf70d716c84bc59371389eb0158f53a52c06dbd93f4422R52-R57): Added logic to remove the "sunset" extension if its value is set to "sunsetToBeDecided". This check is performed both within the 20X response and as part of the operation itself. [[1]](diffhunk://#diff-4402820713197db547cf70d716c84bc59371389eb0158f53a52c06dbd93f4422R52-R57) [[2]](diffhunk://#diff-4402820713197db547cf70d716c84bc59371389eb0158f53a52c06dbd93f4422R69-R73)

New test cases:

* [`tools/cli/internal/openapi/filter/sunset_test.go`](diffhunk://#diff-5f179b353f24fedacee2b3d627adbd5f26d6a618f0abce205cb0668a7dd2a796R325-R405): Added a new test case to verify the removal of the "x-sunset" extension when its value is "9999-12-31" and the extension is part of the operation.