### PR TITLE
CLOUDP-306571: Add rule xgen-IPA-117-description-should-not-use-inline-links

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA117DescriptionShouldNotUseLinks.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117DescriptionShouldNotUseLinks.test.js
@@ -1,0 +1,95 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-117-description-should-not-use-inline-links', [
+  {
+    name: 'valid description',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              valid: {
+                description: 'Description.',
+              },
+              validWithParentheses: {
+                description: 'Description (with parentheses).',
+              },
+              validWithBrackets: {
+                description: 'Description [with brackets].',
+              },
+              validMixed: {
+                description: 'Something [with brackets]. Description (with parentheses).',
+              },
+              validChars: {
+                description: 'Something can only be "a-zA-Z[]():,".',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid descriptions',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              invalidLink: {
+                description: 'Hello [world](https://www.mongodb.com).',
+              },
+              invalidMultipleLinks: {
+                description: 'Hello [world](https://www.mongodb.com). And [MongoDB website](https://www.mongodb.com)',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-117-description-should-not-use-inline-links',
+        message:
+          'Descriptions should not include inline links. Use the externalDocumentation property instead, see https://swagger.io/specification/#external-documentation-object.',
+        path: ['components', 'schemas', 'Schema', 'properties', 'invalidLink'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-117-description-should-not-use-inline-links',
+        message:
+          'Descriptions should not include inline links. Use the externalDocumentation property instead, see https://swagger.io/specification/#external-documentation-object.',
+        path: ['components', 'schemas', 'Schema', 'properties', 'invalidMultipleLinks'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid descriptions with exceptions',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              invalidLink: {
+                description: 'Hello [world](https://www.mongodb.com).',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-117-description-should-not-use-inline-links': 'reason',
+                },
+              },
+              invalidMultipleLinks: {
+                description: 'Hello [world](https://www.mongodb.com). And [MongoDB website](https://www.mongodb.com)',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-117-description-should-not-use-inline-links': 'reason',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -145,7 +145,7 @@ rules:
         - Inline schema properties for operation object requests and responses
         - Parameter objects (in operations and components)
         - Schema properties
-      The rule validates that the description content does not include inline markdown links. The ignores HTML `a` links, this is covered by `xgen-IPA-117-description-must-not-use-html`.
+      The rule validates that the description content does not include inline markdown links. The rule ignores HTML `<a>` links - this is covered by `xgen-IPA-117-description-must-not-use-html`.
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-description-should-not-use-inline-links'
     severity: warn
     given:

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -7,6 +7,7 @@ functions:
   - IPA117DescriptionEndsWithPeriod
   - IPA117DescriptionMustNotUseHtml
   - IPA117DescriptionShouldNotUseTables
+  - IPA117DescriptionShouldNotUseLinks
 
 rules:
   xgen-IPA-117-description:
@@ -133,3 +134,26 @@ rules:
       - '$.components.parameters[*]'
     then:
       function: 'IPA117DescriptionShouldNotUseTables'
+  xgen-IPA-117-description-should-not-use-inline-links:
+    description: |
+      Descriptions should not include inline links.
+
+      ##### Implementation details
+      Rule checks the format of the descriptions for components:
+        - Tags
+        - Operation objects
+        - Inline schema properties for operation object requests and responses
+        - Parameter objects (in operations and components)
+        - Schema properties
+      The rule validates that the description content does not include inline markdown links. The ignores HTML `a` links, this is covered by `xgen-IPA-117-description-must-not-use-html`.
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-description-should-not-use-inline-links'
+    severity: warn
+    given:
+      - '$.tags[*]'
+      - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
+      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
+      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
+      - '$.components.schemas..properties[*]'
+      - '$.components.parameters[*]'
+    then:
+      function: 'IPA117DescriptionShouldNotUseLinks'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -672,7 +672,7 @@ Rule checks the format of the descriptions for components:
   - Inline schema properties for operation object requests and responses
   - Parameter objects (in operations and components)
   - Schema properties
-The rule validates that the description content does not include inline markdown links. The ignores HTML `a` links, this is covered by `xgen-IPA-117-description-must-not-use-html`.
+The rule validates that the description content does not include inline markdown links. The rule ignores HTML `<a>` links - this is covered by `xgen-IPA-117-description-must-not-use-html`.
 
 
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -660,6 +660,20 @@ Rule checks the format of the descriptions for components:
   - Schema properties
 The rule validates that the description content does not include inline markdown tables.
 
+#### xgen-IPA-117-description-should-not-use-inline-links
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Descriptions should not include inline links.
+
+##### Implementation details
+Rule checks the format of the descriptions for components:
+  - Tags
+  - Operation objects
+  - Inline schema properties for operation object requests and responses
+  - Parameter objects (in operations and components)
+  - Schema properties
+The rule validates that the description content does not include inline markdown links. The ignores HTML `a` links, this is covered by `xgen-IPA-117-description-must-not-use-html`.
+
 
 
 ### IPA-123

--- a/tools/spectral/ipa/rulesets/functions/IPA117DescriptionShouldNotUseLinks.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117DescriptionShouldNotUseLinks.js
@@ -33,7 +33,6 @@ function checkViolationsAndReturnErrors(description, path) {
 
   try {
     if (markdownLinkPattern.test(description)) {
-      console.log(description, '\n\n');
       return [{ path, message: ERROR_MESSAGE }];
     }
     return [];

--- a/tools/spectral/ipa/rulesets/functions/IPA117DescriptionShouldNotUseLinks.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117DescriptionShouldNotUseLinks.js
@@ -1,0 +1,43 @@
+import { hasException } from './utils/exceptions.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
+
+const RULE_NAME = 'xgen-IPA-117-description-should-not-use-inline-links';
+const ERROR_MESSAGE =
+  'Descriptions should not include inline links. Use the externalDocumentation property instead, see https://swagger.io/specification/#external-documentation-object.';
+
+export default (input, opts, { path }) => {
+  // Ignore missing descriptions
+  if (!input['description']) {
+    return;
+  }
+
+  if (hasException(input, RULE_NAME)) {
+    collectException(input, RULE_NAME, path);
+    return;
+  }
+
+  const errors = checkViolationsAndReturnErrors(input['description'], path);
+  if (errors.length !== 0) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+  collectAdoption(path, RULE_NAME);
+};
+
+function checkViolationsAndReturnErrors(description, path) {
+  const markdownLinkPattern = new RegExp(`\\[.+]\\(.+\\)`);
+
+  try {
+    if (markdownLinkPattern.test(description)) {
+      console.log(description, '\n\n');
+      return [{ path, message: ERROR_MESSAGE }];
+    }
+    return [];
+  } catch (e) {
+    handleInternalError(RULE_NAME, path, e);
+  }
+}


### PR DESCRIPTION
## Proposed changes

New rule `xgen-IPA-117-description-should-not-use-inline-links` checks for inline MD links in the descriptions. It does not check for HTML links since this is covered by `xgen-IPA-117-description-must-not-use-html`.

_Jira ticket:_ [CLOUDP-306571](https://jira.mongodb.org/browse/CLOUDP-306571)
