### PR TITLE
Fix: List method checks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,6 +32,7 @@ export default [
           enforceForLogicalOperands: true,
         },
       ],
+      'no-mixed-operators': 'warn'
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,7 +32,7 @@ export default [
           enforceForLogicalOperands: true,
         },
       ],
-      'no-mixed-operators': 'warn'
+      'no-mixed-operators': 'warn',
     },
   },
   {

--- a/tools/spectral/ipa/rulesets/functions/IPA105ListMethodHasNoRequestBody.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA105ListMethodHasNoRequestBody.js
@@ -15,7 +15,7 @@ export default (input, _, { path, documentInventory }) => {
 
   if (
     !isResourceCollectionIdentifier(resourcePath) ||
-    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
+    isSingletonResource(getResourcePathItems(resourcePath, oas.paths))
   ) {
     return;
   }

--- a/tools/spectral/ipa/rulesets/functions/IPA105ListMethodResponseIsGetMethodResponse.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA105ListMethodResponseIsGetMethodResponse.js
@@ -26,7 +26,7 @@ export default (input, _, { path, documentInventory }) => {
   if (
     !mediaType.endsWith('json') ||
     !isResourceCollectionIdentifier(resourcePath) ||
-    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
+    isSingletonResource(getResourcePathItems(resourcePath, oas.paths))
   ) {
     return;
   }

--- a/tools/spectral/ipa/rulesets/functions/IPA105ListResponseCodeShouldBe200OK.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA105ListResponseCodeShouldBe200OK.js
@@ -17,7 +17,7 @@ export default (input, _, { path, documentInventory }) => {
 
   if (
     !isResourceCollectionIdentifier(resourcePath) ||
-    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
+    isSingletonResource(getResourcePathItems(resourcePath, oas.paths))
   ) {
     return;
   }

--- a/tools/spectral/ipa/rulesets/functions/IPA106CreateMethodResponseIsGetMethodResponse.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA106CreateMethodResponseIsGetMethodResponse.js
@@ -25,7 +25,7 @@ export default (input, _, { path, documentInventory }) => {
   if (
     !mediaType.endsWith('json') ||
     !isResourceCollectionIdentifier(resourcePath) ||
-    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
+    isSingletonResource(getResourcePathItems(resourcePath, oas.paths))
   ) {
     return;
   }

--- a/tools/spectral/ipa/rulesets/functions/IPA110CollectionsRequestHasItemsPerPageQueryParam.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA110CollectionsRequestHasItemsPerPageQueryParam.js
@@ -15,7 +15,7 @@ export default (input, _, { path, documentInventory }) => {
 
   if (
     !isResourceCollectionIdentifier(resourcePath) ||
-    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
+    isSingletonResource(getResourcePathItems(resourcePath, oas.paths))
   ) {
     return;
   }

--- a/tools/spectral/ipa/rulesets/functions/IPA110CollectionsRequestHasPageNumQueryParam.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA110CollectionsRequestHasPageNumQueryParam.js
@@ -15,7 +15,7 @@ export default (input, _, { path, documentInventory }) => {
 
   if (
     !isResourceCollectionIdentifier(resourcePath) ||
-    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
+    isSingletonResource(getResourcePathItems(resourcePath, oas.paths))
   ) {
     return;
   }

--- a/tools/spectral/ipa/rulesets/functions/IPA110CollectionsResponseDefineResultsArray.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA110CollectionsResponseDefineResultsArray.js
@@ -24,7 +24,7 @@ export default (input, _, { path, documentInventory }) => {
   if (
     !mediaType.endsWith('json') ||
     !isResourceCollectionIdentifier(resourcePath) ||
-    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
+    isSingletonResource(getResourcePathItems(resourcePath, oas.paths))
   ) {
     return;
   }

--- a/tools/spectral/ipa/rulesets/functions/IPA110CollectionsUsePaginatedPrefix.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA110CollectionsUsePaginatedPrefix.js
@@ -24,7 +24,7 @@ export default (input, _, { path, documentInventory }) => {
   if (
     !mediaType.endsWith('json') ||
     !isResourceCollectionIdentifier(resourcePath) ||
-    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
+    isSingletonResource(getResourcePathItems(resourcePath, oas.paths))
   ) {
     return;
   }


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

Replaces the check if a path belongs to a List method 
```
!isResourceCollectionIdentifier(resourcePath) ||
    (isResourceCollectionIdentifier(resourcePath) && isSingletonResource(getResourcePathItems(resourcePath, oas.paths)))
```
with
`!isResourceCollectionIdentifier(resourcePath) || isSingletonResource(getResourcePathItems(resourcePath, oas.paths)
`

Related discussion: https://github.com/mongodb/openapi/pull/622#discussion_r2016194427

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
