### PR TITLE
CLOUDP-309394 - Increase postman upload timelines

### DIFF
--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -80,13 +80,18 @@ else
      --header 'X-API-Key: **********'
      --data ${collection_transformed_path}"
 
-  curl --show-error --fail --retry 10 --retry-all-errors --silent --request PUT \
+  curl --show-error \
+       --retry 10 \
+       --retry-delay 30  \
+       --retry-max-time 300 \
+       --fail  \
+       --retry-all-errors \
+       --silent \
+       --request PUT \
        --location "https://api.getpostman.com/collections/${collection_id}" \
        --header "Content-Type: application/json" \
        --header "X-API-Key: ${POSTMAN_API_KEY}" \
-       --data "@${collection_transformed_path}"  \
-       --retry-delay 30 \
-       --retry-max-time 300
+       --data "@${collection_transformed_path}"
 fi
 
 popd -0

--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -63,7 +63,13 @@ if [  "$collection_exists" = "false" ]; then
      --header 'Content-Type: application/json'
      --header 'X-API-Key: **********'
      --data ${collection_transformed_path}"
-  curl --show-error --fail --retry 5 --retry-all-errors --silent \
+  curl --show-error \
+          --retry 10 \
+          --retry-delay 30  \
+          --retry-max-time 300 \
+          --retry-all-errors \
+          --fail  \
+          --silent \
        --location "https://api.getpostman.com/collections?workspace=${WORKSPACE_ID}" \
        --header "Content-Type: application/json" \
        --header "X-API-Key: ${POSTMAN_API_KEY}" \
@@ -84,8 +90,8 @@ else
        --retry 10 \
        --retry-delay 30  \
        --retry-max-time 300 \
-       --fail  \
        --retry-all-errors \
+       --fail  \
        --silent \
        --request PUT \
        --location "https://api.getpostman.com/collections/${collection_id}" \

--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -80,7 +80,7 @@ else
      --header 'X-API-Key: **********'
      --data ${collection_transformed_path}"
 
-  curl --show-error --fail --retry 10 --retry-all-errors --silent --request PUT \
+  curl --show-error --fail --retry 10 --retry-all-errors -v --request PUT \
        --location "https://api.getpostman.com/collections/${collection_id}" \
        --header "Content-Type: application/json" \
        --header "X-API-Key: ${POSTMAN_API_KEY}" \

--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -80,11 +80,13 @@ else
      --header 'X-API-Key: **********'
      --data ${collection_transformed_path}"
 
-  curl --show-error --fail --retry 5 --retry-all-errors --silent --request PUT \
+  curl --show-error --fail --retry 10 --retry-all-errors --silent --request PUT \
        --location "https://api.getpostman.com/collections/${collection_id}" \
        --header "Content-Type: application/json" \
        --header "X-API-Key: ${POSTMAN_API_KEY}" \
-       --data "@${collection_transformed_path}"
+       --data "@${collection_transformed_path}"  \
+       --retry-delay 30 \
+       --retry-max-time 300
 fi
 
 popd -0

--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -80,7 +80,7 @@ else
      --header 'X-API-Key: **********'
      --data ${collection_transformed_path}"
 
-  curl --show-error --fail --retry 10 --retry-all-errors -v --request PUT \
+  curl --show-error --fail --retry 10 --retry-all-errors --silent --request PUT \
        --location "https://api.getpostman.com/collections/${collection_id}" \
        --header "Content-Type: application/json" \
        --header "X-API-Key: ${POSTMAN_API_KEY}" \


### PR DESCRIPTION
## Proposed changes

Done research and it looks like postman API gets overwhelmed sometimes over period of 1-2 minutes.
Current retry mechanism uses backoff mechanism that reattempt next request in double time of the previous one starting from 1s.
This PR extends retries to be attempted every 30 seconds and increases the amount of retries to 10. 

## Explanations
```
--retry 10: This sets the number of retries to 10.
--retry-delay 30: Adds a delay of 30 seconds between retry attempts. This helps increase the time between retries.
--retry-max-time 300: Specifies the maximum time for all retry operations to occur, which is set to 300 seconds (5 minutes).
```

