### PR TITLE
CLOUDP-309577: Update `curl` Parameters for Improved Reliability

### DIFF
--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -64,9 +64,9 @@ if [  "$collection_exists" = "false" ]; then
      --header 'X-API-Key: **********'
      --data ${collection_transformed_path}"
   curl --show-error \
-          --retry 10 \
+          --retry 7 \
           --retry-delay 30  \
-          --retry-max-time 300 \
+          --retry-max-time 1200 \
           --retry-all-errors \
           --fail  \
           --silent \
@@ -87,9 +87,9 @@ else
      --data ${collection_transformed_path}"
 
   curl --show-error \
-       --retry 10 \
+       --retry 7 \
        --retry-delay 30  \
-       --retry-max-time 300 \
+       --retry-max-time 1200 \
        --retry-all-errors \
        --fail  \
        --silent \


### PR DESCRIPTION
 ## Overview

This PR updates the `curl` command parameters used in our Postman calls, based on the observations from our CI/CD pipeline from the last failure.

## Background

During our evaluation of last failure based on tracing we added, we discovered that postman in fact was overwhelmed and took entire 2 minutes to get error. I could not reproduce this locally :(

This resulted in only two requests being made due to the previous `--retry-max-time` limit of 300 seconds.

## Changes

To enhance the robustness and reliability of our calls, we have decided to adjust the parameters as follows:

- **Retry Attempts**: Changing the `--retry` option to retry up to **7 times** to finetune between instant failures and each request taking max 2 minutes.
  
  
- **Updated Maximum Retry Time**: increased it to `--retry-max-time 1200` to allow more retries within the 20-minute window (1200 seconds).

These changes lead to a potential maximum execution time of **7 attempts * 2 minutes per attempt + 7 * 30 seconds delay**, which totals less than 1200 seconds.

## Note

IMHO change is only temporary to help us with stability of OpenAPI job, while we are waiting for Postman support.
