### PR TITLE
CLOUDP-306573: Dont require gzip to have example

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA117PlaintextResponseMustHaveExample.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117PlaintextResponseMustHaveExample.test.js
@@ -34,7 +34,7 @@ testRule('xgen-IPA-117-plaintext-response-must-have-example', [
             },
           },
         },
-        // Ignores JSON/YAML
+        // Ignores JSON/YAML/gzip
         '/resourceTwo': {
           get: {
             responses: {
@@ -45,6 +45,9 @@ testRule('xgen-IPA-117-plaintext-response-must-have-example', [
                   },
                   'application/vnd.atlas.2024-08-05+yaml': {
                     type: 'string',
+                  },
+                  'application/vnd.atlas.2024-08-05+gzip': {
+                    type: 'binary',
                   },
                 },
               },

--- a/tools/spectral/ipa/__tests__/IPA117PlaintextResponseMustHaveExample.test.js
+++ b/tools/spectral/ipa/__tests__/IPA117PlaintextResponseMustHaveExample.test.js
@@ -47,7 +47,14 @@ testRule('xgen-IPA-117-plaintext-response-must-have-example', [
                     type: 'string',
                   },
                   'application/vnd.atlas.2024-08-05+gzip': {
-                    type: 'binary',
+                    type: 'string',
+                    format: 'binary',
+                  },
+                  'application/vnd.atlas.2023-08-05+gzip': {
+                    schema: {
+                      type: 'string',
+                      format: 'binary',
+                    },
                   },
                 },
               },

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -166,7 +166,7 @@ rules:
 
       ##### Implementation details
         - The rule only applies to 2xx responses
-        - The rule ignores JSON and YAML responses (passed as `allowedTypes`)
+        - The rule ignores JSON, YAML and GZIP responses (passed as `allowedTypes`)
         - The rule checks for the presence of the example property as a sibling to the `schema` property, or inside the `schema` object
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-plaintext-response-must-have-example'
     severity: warn
@@ -176,7 +176,7 @@ rules:
       field: '@key'
       function: 'IPA117PlaintextResponseMustHaveExample'
       functionOptions:
-        allowedTypes: ['json', 'yaml']
+        allowedTypes: ['json', 'yaml', 'gzip']
   xgen-IPA-117-objects-must-be-well-defined:
     description: |
       Components of type "object" must be well-defined, i.e. have of one of the properties:

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -166,7 +166,8 @@ rules:
 
       ##### Implementation details
         - The rule only applies to 2xx responses
-        - The rule ignores JSON, YAML and GZIP responses (passed as `allowedTypes`)
+        - The rule ignores JSON and YAML responses (passed as `allowedTypes`)
+        - The rule ignores responses with `format: 'binary'` (i.e. file types)
         - The rule checks for the presence of the example property as a sibling to the `schema` property, or inside the `schema` object
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-plaintext-response-must-have-example'
     severity: warn
@@ -176,7 +177,7 @@ rules:
       field: '@key'
       function: 'IPA117PlaintextResponseMustHaveExample'
       functionOptions:
-        allowedTypes: ['json', 'yaml', 'gzip']
+        allowedTypes: ['json', 'yaml']
   xgen-IPA-117-objects-must-be-well-defined:
     description: |
       Components of type "object" must be well-defined, i.e. have of one of the properties:

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -728,7 +728,7 @@ For APIs that respond with plain text, for example CSV, API producers must provi
 
 ##### Implementation details
   - The rule only applies to 2xx responses
-  - The rule ignores JSON and YAML responses (passed as `allowedTypes`)
+  - The rule ignores JSON, YAML and GZIP responses (passed as `allowedTypes`)
   - The rule checks for the presence of the example property as a sibling to the `schema` property, or inside the `schema` object
 
 #### xgen-IPA-117-objects-must-be-well-defined

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -728,7 +728,8 @@ For APIs that respond with plain text, for example CSV, API producers must provi
 
 ##### Implementation details
   - The rule only applies to 2xx responses
-  - The rule ignores JSON, YAML and GZIP responses (passed as `allowedTypes`)
+  - The rule ignores JSON and YAML responses (passed as `allowedTypes`)
+  - The rule ignores responses with `format: 'binary'` (i.e. file types)
   - The rule checks for the presence of the example property as a sibling to the `schema` property, or inside the `schema` object
 
 #### xgen-IPA-117-objects-must-be-well-defined

--- a/tools/spectral/ipa/rulesets/functions/IPA117PlaintextResponseMustHaveExample.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA117PlaintextResponseMustHaveExample.js
@@ -32,6 +32,14 @@ export default (input, { allowedTypes }, { documentInventory, path }) => {
 
   const response = resolveObject(documentInventory.resolved, path);
 
+  // Ignore binary formats, i.e. files
+  if (
+    (response['type'] && response['format'] === 'binary') ||
+    (response['schema'] && response['schema']['format'] === 'binary')
+  ) {
+    return;
+  }
+
   if (hasException(response, RULE_NAME)) {
     collectException(response, RULE_NAME, path);
     return;


### PR DESCRIPTION
## Proposed changes

Updates IPA rule `xgen-IPA-117-plaintext-response-must-have-example` to ignore file types. Added a test to cover case.

_Jira ticket:_ [CLOUDP-306573](https://jira.mongodb.org/browse/CLOUDP-306573)
