### PR TITLE
CLOUDP-306575: IPA-118: Extensible by Default

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA118NoAdditionalPropertiesFalse.test.js
+++ b/tools/spectral/ipa/__tests__/IPA118NoAdditionalPropertiesFalse.test.js
@@ -58,7 +58,6 @@ testRule('xgen-IPA-118-no-additional-properties-false', [
   {
     name: 'invalid with additionalProperties: false',
     document: {
-      openapi: '3.0.0',
       components: {
         schemas: {
           ExampleSchema: {
@@ -118,7 +117,45 @@ testRule('xgen-IPA-118-no-additional-properties-false', [
     ],
   },
   {
-    name: 'with exception tag',
+    name: 'invalid with multiple nested additionalProperties: false',
+    document: {
+      components: {
+        schemas: {
+          ParentSchema: {
+            type: 'object',
+            properties: {
+              child: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                },
+                additionalProperties: false,
+              },
+            },
+            additionalProperties: false,
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-118-no-additional-properties-false',
+        message:
+          "Schema must not use 'additionalProperties: false'. Consider using 'additionalProperties: true' or omitting the property.",
+        path: ['components', 'schemas', 'ParentSchema'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-118-no-additional-properties-false',
+        message:
+          "Schema must not use 'additionalProperties: false'. Consider using 'additionalProperties: true' or omitting the property.",
+        path: ['components', 'schemas', 'ParentSchema', 'properties', 'child'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'with exception',
     document: {
       components: {
         schemas: {
@@ -145,6 +182,32 @@ testRule('xgen-IPA-118-no-additional-properties-false', [
                 },
                 additionalProperties: false,
               },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid with multiple nested additionalProperties: false - exceptions',
+    document: {
+      components: {
+        schemas: {
+          ParentSchema: {
+            type: 'object',
+            properties: {
+              child: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                },
+                additionalProperties: false,
+              },
+            },
+            additionalProperties: false,
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-118-no-additional-properties-false': 'Exception reason',
             },
           },
         },

--- a/tools/spectral/ipa/__tests__/IPA118NoAdditionalPropertiesFalse.test.js
+++ b/tools/spectral/ipa/__tests__/IPA118NoAdditionalPropertiesFalse.test.js
@@ -1,0 +1,155 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-118-no-additional-properties-false', [
+  {
+    name: 'valid without additionalProperties',
+    document: {
+      components: {
+        schemas: {
+          ExampleSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              value: { type: 'integer' },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'valid with additionalProperties: true',
+    document: {
+      components: {
+        schemas: {
+          ExampleSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            additionalProperties: true,
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'valid with additionalProperties as schema',
+    document: {
+      components: {
+        schemas: {
+          ExampleSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            additionalProperties: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid with additionalProperties: false',
+    document: {
+      openapi: '3.0.0',
+      components: {
+        schemas: {
+          ExampleSchema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+            },
+            additionalProperties: false,
+          },
+          ReferencedSchema: {
+            type: 'object',
+            properties: {
+              property: { $ref: '#/components/schemas/ExampleSchema' },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-118-no-additional-properties-false',
+        message:
+          "Schema must not use 'additionalProperties: false'. Consider using 'additionalProperties: true' or omitting the property.",
+        path: ['components', 'schemas', 'ExampleSchema'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid with nested additionalProperties: false',
+    document: {
+      components: {
+        schemas: {
+          ParentSchema: {
+            type: 'object',
+            properties: {
+              child: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                },
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-118-no-additional-properties-false',
+        message:
+          "Schema must not use 'additionalProperties: false'. Consider using 'additionalProperties: true' or omitting the property.",
+        path: ['components', 'schemas', 'ParentSchema', 'properties', 'child'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'with exception tag',
+    document: {
+      components: {
+        schemas: {
+          ExampleSchema: {
+            type: 'object',
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-118-no-additional-properties-false': 'Exception reason',
+            },
+            properties: {
+              name: { type: 'string' },
+            },
+            additionalProperties: false,
+          },
+          ParentSchema: {
+            type: 'object',
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-118-no-additional-properties-false': 'Exception reason',
+            },
+            properties: {
+              child: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                },
+                additionalProperties: false,
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -12,6 +12,7 @@ extends:
   - ./rulesets/IPA-113.yaml
   - ./rulesets/IPA-114.yaml
   - ./rulesets/IPA-117.yaml
+  - ./rulesets/IPA-118.yaml
   - ./rulesets/IPA-123.yaml
   - ./rulesets/IPA-125.yaml
 
@@ -41,3 +42,15 @@ overrides:
       - '**#/components/schemas/UserSecurity/properties/customerX509' # unable to document exceptions, to be covered by CLOUDP-308286
     rules:
       xgen-IPA-112-field-names-are-camel-case: 'off'
+  - files:
+      - '**#/components/schemas/DataLakeS3StoreSettings/allOf/1/properties/additionalStorageClasses' # unable to document exceptions, to be covered by CLOUDP-293178
+      - '**#/components/schemas/DataLakeDatabaseDataSourceSettings/properties/databaseRegex' # unable to document exceptions, to be covered by CLOUDP-293178
+      - '**#/components/schemas/DataLakeDatabaseDataSourceSettings/properties/collectionRegex' # unable to document exceptions, to be covered by CLOUDP-293178
+    rules:
+      xgen-IPA-117-description-should-not-use-inline-links: 'off'
+  - files:
+      - '**#/paths/~1api~1atlas~1v2~1unauth~1openapi~1versions' # external reference, to be covered by CLOUDP-309694
+      - '**#/paths/~1api~1atlas~1v2~1openapi~1info' # external reference, to be covered by CLOUDP-309694
+      - '**#/paths/~1rest~1unauth~1version' # external reference, to be covered by CLOUDP-309694
+    rules:
+      xgen-IPA-114-error-responses-refer-to-api-error: 'off'

--- a/tools/spectral/ipa/rulesets/IPA-118.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-118.yaml
@@ -1,0 +1,20 @@
+# IPA-118: Extensible by Default
+# http://go/ipa/118
+
+functions:
+  - IPA118NoAdditionalPropertiesFalse
+
+rules:
+  xgen-IPA-118-no-additional-properties-false:
+    description: |
+      Schemas must not use `additionalProperties: false`
+
+      ##### Implementation details
+      This rule checks that schemas don't restrict additional properties by setting `additionalProperties: false`.
+      Schemas without explicit `additionalProperties` settings (which default to true) or with `additionalProperties` set to `true` are compliant.
+      This rule checks all nested schemas, but only parent schemas can be marked for exception.
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-118-no-additional-properties-false'
+    severity: warn
+    given: '$.components.schemas[*]'
+    then:
+      function: 'IPA118NoAdditionalPropertiesFalse'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -772,6 +772,22 @@ The rule checks for the presence of the `schema`, `examples` or `example` proper
 
 
 
+### IPA-118
+
+Rules are based on [http://go/ipa/IPA-118](http://go/ipa/IPA-118).
+
+#### xgen-IPA-118-no-additional-properties-false
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Schemas must not use `additionalProperties: false`
+
+##### Implementation details
+This rule checks that schemas don't restrict additional properties by setting `additionalProperties: false`.
+Schemas without explicit `additionalProperties` settings (which default to true) or with `additionalProperties` set to `true` are compliant.
+This rule checks all nested schemas, but only parent schemas can be marked for exception.
+
+
+
 ### IPA-123
 
 Rules are based on [http://go/ipa/IPA-123](http://go/ipa/IPA-123).

--- a/tools/spectral/ipa/rulesets/functions/IPA118NoAdditionalPropertiesFalse.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA118NoAdditionalPropertiesFalse.js
@@ -1,0 +1,53 @@
+import { hasException } from './utils/exceptions.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
+import { resolveObject } from './utils/componentUtils.js';
+import { findAdditionalPropertiesFalsePaths } from './utils/compareUtils.js';
+
+const RULE_NAME = 'xgen-IPA-118-no-additional-properties-false';
+const ERROR_MESSAGE = `Schema must not use 'additionalProperties: false'. Consider using 'additionalProperties: true' or omitting the property.`;
+/**
+ * Validates that schemas don't use additionalProperties: false
+ *
+ * @param {object} input - The schema object to check
+ * @param {object} _ - Rule options (unused)
+ * @param {object} context - The context object containing path and document information
+ */
+export default (input, _, { path, documentInventory }) => {
+  const oas = documentInventory.unresolved;
+  const schemaObject = resolveObject(oas, path);
+
+  if (hasException(input, RULE_NAME)) {
+    collectException(input, RULE_NAME, path);
+    return;
+  }
+
+  const errors = checkViolationsAndReturnErrors(schemaObject, path);
+  if (errors.length > 0) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+
+  collectAdoption(path, RULE_NAME);
+};
+
+function checkViolationsAndReturnErrors(schemaObject, path) {
+  try {
+    const errors = [];
+
+    const results = findAdditionalPropertiesFalsePaths(schemaObject, path);
+    for (const resultPath of results) {
+      errors.push({
+        message: ERROR_MESSAGE,
+        path: resultPath,
+      });
+    }
+
+    return errors;
+  } catch (e) {
+    handleInternalError(RULE_NAME, path, e);
+  }
+}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-306575

```
  xgen-IPA-118-no-additional-properties-false:
    description: |
      Schemas must not use `additionalProperties: false`

      ##### Implementation details
      This rule checks that schemas don't restrict additional properties by setting `additionalProperties: false`.
      Schemas without explicit `additionalProperties` settings (which default to true) or with `additionalProperties` set to `true` are compliant.
      This rule checks all nested schemas, but only parent schemas can be marked for exception.
```

No violations to fix

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
