### PR TITLE
CLOUDP-306576: IPA-119: Multi-Cloud Support by Default

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA119NoDefaultForCloudProviders.test.js
+++ b/tools/spectral/ipa/__tests__/IPA119NoDefaultForCloudProviders.test.js
@@ -47,6 +47,32 @@ testRule('xgen-IPA-119-no-default-for-cloud-providers', [
     ],
   },
   {
+    name: 'invalid when cloud provider field has default value',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              provider: {
+                type: 'string',
+                enum: ['AWS', 'GCP', 'AZURE'],
+                default: 'AWS',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-119-no-default-for-cloud-providers',
+        message: 'When using a provider field or param, API producers should not define a default value.',
+        path: ['components', 'schemas', 'Schema', 'properties', 'provider'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
     name: 'valid when non-provider field has default value',
     document: {
       components: {
@@ -134,6 +160,22 @@ testRule('xgen-IPA-119-no-default-for-cloud-providers', [
                 },
               },
             ],
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              provider: {
+                type: 'string',
+                enum: ['AWS', 'GCP', 'AZURE'],
+                default: 'AWS',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-119-no-default-for-cloud-providers': 'Reason',
+                },
+              },
+            },
           },
         },
       },

--- a/tools/spectral/ipa/__tests__/IPA119NoDefaultForCloudProviders.test.js
+++ b/tools/spectral/ipa/__tests__/IPA119NoDefaultForCloudProviders.test.js
@@ -1,0 +1,143 @@
+import testRule from './__helpers__/testRule';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-119-no-default-for-cloud-providers', [
+  {
+    name: 'valid when no default in cloud provider field',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              cloudProvider: {
+                type: 'string',
+                enum: ['AWS', 'GCP', 'AZURE'],
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid when cloud provider field has default value',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              cloudProvider: {
+                type: 'string',
+                enum: ['AWS', 'GCP', 'AZURE'],
+                default: 'AWS',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-119-no-default-for-cloud-providers',
+        message: 'When using a provider field or param, API producers should not define a default value.',
+        path: ['components', 'schemas', 'Schema', 'properties', 'cloudProvider'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'valid when non-provider field has default value',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              region: {
+                type: 'string',
+                default: 'us-east-1',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'field with provider in name has exception',
+    document: {
+      components: {
+        schemas: {
+          Schema: {
+            properties: {
+              cloudProvider: {
+                type: 'string',
+                enum: ['AWS', 'GCP', 'AZURE'],
+                default: 'AWS',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-119-no-default-for-cloud-providers': 'Reason',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'parameters with provider in name',
+    document: {
+      paths: {
+        '/resources': {
+          get: {
+            parameters: [
+              {
+                name: 'cloudProvider',
+                in: 'query',
+                schema: {
+                  type: 'string',
+                  default: 'AWS',
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-119-no-default-for-cloud-providers',
+        message: 'When using a provider field or param, API producers should not define a default value.',
+        path: ['paths', '/resources', 'get', 'parameters', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'parameters with provider in name - exceptions',
+    document: {
+      paths: {
+        '/resources': {
+          get: {
+            parameters: [
+              {
+                name: 'cloudProvider',
+                in: 'query',
+                schema: {
+                  type: 'string',
+                  default: 'AWS',
+                },
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-119-no-default-for-cloud-providers': 'Reason',
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+]);

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -12,6 +12,7 @@ extends:
   - ./rulesets/IPA-113.yaml
   - ./rulesets/IPA-114.yaml
   - ./rulesets/IPA-117.yaml
+  - ./rulesets/IPA-119.yaml
   - ./rulesets/IPA-123.yaml
   - ./rulesets/IPA-125.yaml
 

--- a/tools/spectral/ipa/rulesets/IPA-119.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-119.yaml
@@ -1,0 +1,24 @@
+# IPA-119: Multi-Cloud Support by Default
+# http://go/ipa/119
+
+functions:
+  - IPA119NoDefaultForCloudProviders
+rules:
+  xgen-IPA-119-no-default-for-cloud-providers:
+    description: |
+      When using a provider field or parameter, API producers should not define a default value.
+      As providers are added, having a default value can impact usability.
+      This rule checks fields containing "provider" or "cloudProvider" and ensures they do not have a default value.
+      It also checks enum fields that might contain cloud provider values.
+    severity: warn
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-119-no-default-for-cloud-providers'
+    given:
+      # Target properties with "cloudProvider" in their name
+      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters'
+      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties'
+      - '$.components.schemas..properties'
+    then:
+      field: '@key'
+      function: IPA119NoDefaultForCloudProviders
+      functionOptions:
+        propertyNameToLookFor: 'cloudProvider'

--- a/tools/spectral/ipa/rulesets/IPA-119.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-119.yaml
@@ -7,9 +7,9 @@ rules:
   xgen-IPA-119-no-default-for-cloud-providers:
     description: |
       When using a provider field or parameter, API producers should not define a default value.
-      As providers are added, having a default value can impact usability.
-      This rule checks fields containing "provider" or "cloudProvider" and ensures they do not have a default value.
+      This rule checks fields and parameters named "cloudProvider" and ensures they do not have a default value.
       It also checks enum fields that might contain cloud provider values.
+      All cloudProviderEnumValues should be listed in the enum array.
     severity: warn
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-119-no-default-for-cloud-providers'
     given:
@@ -22,3 +22,7 @@ rules:
       function: IPA119NoDefaultForCloudProviders
       functionOptions:
         propertyNameToLookFor: 'cloudProvider'
+        cloudProviderEnumValues:
+          - 'AWS'
+          - 'GCP'
+          - 'AZURE'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -780,9 +780,9 @@ Rules are based on [http://go/ipa/IPA-119](http://go/ipa/IPA-119).
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
 When using a provider field or parameter, API producers should not define a default value.
-As providers are added, having a default value can impact usability.
-This rule checks fields containing "provider" or "cloudProvider" and ensures they do not have a default value.
+This rule checks fields and parameters named "cloudProvider" and ensures they do not have a default value.
 It also checks enum fields that might contain cloud provider values.
+All cloudProviderEnumValues should be listed in the enum array.
 
 
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -772,6 +772,20 @@ The rule checks for the presence of the `schema`, `examples` or `example` proper
 
 
 
+### IPA-119
+
+Rules are based on [http://go/ipa/IPA-119](http://go/ipa/IPA-119).
+
+#### xgen-IPA-119-no-default-for-cloud-providers
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+When using a provider field or parameter, API producers should not define a default value.
+As providers are added, having a default value can impact usability.
+This rule checks fields containing "provider" or "cloudProvider" and ensures they do not have a default value.
+It also checks enum fields that might contain cloud provider values.
+
+
+
 ### IPA-123
 
 Rules are based on [http://go/ipa/IPA-123](http://go/ipa/IPA-123).

--- a/tools/spectral/ipa/rulesets/functions/IPA119NoDefaultForCloudProviders.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA119NoDefaultForCloudProviders.js
@@ -14,6 +14,10 @@ export default (input, { propertyNameToLookFor, cloudProviderEnumValues }, { pat
   const propertyObject = resolveObject(oas, path);
   const fieldType = path[path.length - 2];
 
+  if(fieldType === 'parameters' && !propertyObject.schema) {
+    return;
+  }
+
   if (hasException(propertyObject, RULE_NAME)) {
     collectException(propertyObject, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/IPA119NoDefaultForCloudProviders.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA119NoDefaultForCloudProviders.js
@@ -9,7 +9,7 @@ import { resolveObject } from './utils/componentUtils.js';
 
 const RULE_NAME = 'xgen-IPA-119-no-default-for-cloud-providers';
 const ERROR_MESSAGE = 'When using a provider field or param, API producers should not define a default value.';
-export default (input, { propertyNameToLookFor }, { path, documentInventory }) => {
+export default (input, { propertyNameToLookFor, cloudProviderEnumValues }, { path, documentInventory }) => {
   const oas = documentInventory.resolved;
   const propertyObject = resolveObject(oas, path);
   const fieldType = path[path.length - 2];
@@ -19,14 +19,28 @@ export default (input, { propertyNameToLookFor }, { path, documentInventory }) =
     return;
   }
 
-  const errors = checkViolationsAndReturnErrors(input, propertyObject, path, propertyNameToLookFor, fieldType);
+  const errors = checkViolationsAndReturnErrors(
+    input,
+    propertyObject,
+    path,
+    propertyNameToLookFor,
+    fieldType,
+    cloudProviderEnumValues
+  );
   if (errors.length !== 0) {
     return collectAndReturnViolation(path, RULE_NAME, errors);
   }
   collectAdoption(path, RULE_NAME);
 };
 
-function checkViolationsAndReturnErrors(propertyName, propertyObject, path, propertyNameToLookFor, fieldType) {
+function checkViolationsAndReturnErrors(
+  propertyName,
+  propertyObject,
+  path,
+  propertyNameToLookFor,
+  fieldType,
+  cloudProviderEnumValues
+) {
   try {
     if (fieldType === 'properties') {
       if (propertyName === propertyNameToLookFor && propertyObject.default !== undefined) {
@@ -37,6 +51,21 @@ function checkViolationsAndReturnErrors(propertyName, propertyObject, path, prop
           },
         ];
       }
+
+      if (Array.isArray(propertyObject.enum) && propertyObject.enum.length > 0) {
+        const enumValues = propertyObject.enum;
+        const hasCloudProviderEnumValue = cloudProviderEnumValues.every((cloudProviderValue) =>
+          enumValues.includes(cloudProviderValue)
+        );
+        if (hasCloudProviderEnumValue && propertyObject.default !== undefined) {
+          return [
+            {
+              path,
+              message: ERROR_MESSAGE,
+            },
+          ];
+        }
+      }
     } else if (fieldType === 'parameters') {
       if (propertyObject.name === propertyNameToLookFor && propertyObject.schema.default !== undefined) {
         return [
@@ -45,6 +74,22 @@ function checkViolationsAndReturnErrors(propertyName, propertyObject, path, prop
             message: ERROR_MESSAGE,
           },
         ];
+      }
+
+      if (Array.isArray(propertyObject.schema.enum) && propertyObject.schema.enum.length > 0) {
+        const enumValues = propertyObject.schema.enum;
+        const hasCloudProviderEnumValue = cloudProviderEnumValues.every((cloudProviderValue) =>
+          enumValues.includes(cloudProviderValue)
+        );
+
+        if (hasCloudProviderEnumValue && propertyObject.schema.default !== undefined) {
+          return [
+            {
+              path,
+              message: ERROR_MESSAGE,
+            },
+          ];
+        }
       }
     }
 

--- a/tools/spectral/ipa/rulesets/functions/IPA119NoDefaultForCloudProviders.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA119NoDefaultForCloudProviders.js
@@ -14,7 +14,7 @@ export default (input, { propertyNameToLookFor, cloudProviderEnumValues }, { pat
   const propertyObject = resolveObject(oas, path);
   const fieldType = path[path.length - 2];
 
-  if(fieldType === 'parameters' && !propertyObject.schema) {
+  if (fieldType === 'parameters' && !propertyObject.schema) {
     return;
   }
 

--- a/tools/spectral/ipa/rulesets/functions/IPA119NoDefaultForCloudProviders.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA119NoDefaultForCloudProviders.js
@@ -1,0 +1,55 @@
+import { hasException } from './utils/exceptions.js';
+import {
+  collectAdoption,
+  collectAndReturnViolation,
+  collectException,
+  handleInternalError,
+} from './utils/collectionUtils.js';
+import { resolveObject } from './utils/componentUtils.js';
+
+const RULE_NAME = 'xgen-IPA-119-no-default-for-cloud-providers';
+const ERROR_MESSAGE = 'When using a provider field or param, API producers should not define a default value.';
+export default (input, { propertyNameToLookFor }, { path, documentInventory }) => {
+  const oas = documentInventory.resolved;
+  const propertyObject = resolveObject(oas, path);
+  const fieldType = path[path.length - 2];
+
+  if (hasException(propertyObject, RULE_NAME)) {
+    collectException(propertyObject, RULE_NAME, path);
+    return;
+  }
+
+  const errors = checkViolationsAndReturnErrors(input, propertyObject, path, propertyNameToLookFor, fieldType);
+  if (errors.length !== 0) {
+    return collectAndReturnViolation(path, RULE_NAME, errors);
+  }
+  collectAdoption(path, RULE_NAME);
+};
+
+function checkViolationsAndReturnErrors(propertyName, propertyObject, path, propertyNameToLookFor, fieldType) {
+  try {
+    if (fieldType === 'properties') {
+      if (propertyName === propertyNameToLookFor && propertyObject.default !== undefined) {
+        return [
+          {
+            path,
+            message: ERROR_MESSAGE,
+          },
+        ];
+      }
+    } else if (fieldType === 'parameters') {
+      if (propertyObject.name === propertyNameToLookFor && propertyObject.schema.default !== undefined) {
+        return [
+          {
+            path,
+            message: ERROR_MESSAGE,
+          },
+        ];
+      }
+    }
+
+    return [];
+  } catch (e) {
+    handleInternalError(RULE_NAME, path, e);
+  }
+}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-306576

```
  xgen-IPA-119-no-default-for-cloud-providers:
    description: |
      When using a provider field or parameter, API producers should not define a default value.
      This rule checks fields and parameters named "cloudProvider" and ensures they do not have a default value.
      It also checks enum fields that might contain cloud provider values.
      All cloudProviderEnumValues should be listed in the enum array.
```

Found 8 violations, all of them input parameters

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
