### PR TITLE
CLOUDP-306577: IPA-121: Datetime

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA121DateTimeFieldsMentionISO8601.test.js
+++ b/tools/spectral/ipa/__tests__/IPA121DateTimeFieldsMentionISO8601.test.js
@@ -1,0 +1,261 @@
+import testRule from './__helpers__/testRule.js';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
+  {
+    name: 'valid when date-time format mentions ISO 8601 in description',
+    document: {
+      components: {
+        schemas: {
+          TestSchema: {
+            properties: {
+              createdAt: {
+                type: 'string',
+                format: 'date-time',
+                description: 'The creation timestamp in ISO 8601 format.',
+              },
+              updatedOn: {
+                type: 'string',
+                format: 'date-time',
+                description: 'When the resource was last updated. Uses ISO 8601 datetime format.',
+              },
+            },
+          },
+        },
+        parameters: {
+          TestParameter: {
+            name: 'createdAt',
+            in: 'query',
+            schema: {
+              type: 'string',
+              format: 'date-time',
+              description: 'The creation timestamp in ISO 8601 format.',
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'valid with non-date-time format',
+    document: {
+      components: {
+        schemas: {
+          TestSchema: {
+            properties: {
+              username: {
+                type: 'string',
+                description: 'The username for login.',
+              },
+              age: {
+                type: 'integer',
+                description: 'Age in years.',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid when date-time format has no description',
+    document: {
+      components: {
+        schemas: {
+          TestSchema: {
+            properties: {
+              createdAt: {
+                type: 'string',
+                format: 'date-time',
+              },
+              modifiedAt: {
+                type: 'string',
+                format: 'date-time',
+                description: 'The modification timestamp.',
+              },
+            },
+          },
+        },
+        parameters: {
+          TestParameter: {
+            name: 'createdAt',
+            in: 'query',
+            schema: {
+              type: 'string',
+              format: 'date-time',
+              description: 'The creation timestamp',
+            },
+          },
+        },
+      },
+      paths: {
+        '/resources': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    properties: {
+                      $ref: '#/components/schemas/TestSchema',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
+        message:
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+        path: ['components', 'schemas', 'TestSchema', 'properties', 'createdAt'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
+        message:
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+        path: ['components', 'schemas', 'TestSchema', 'properties', 'modifiedAt'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
+        message:
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+        path: ['components', 'parameters', 'TestParameter', 'schema'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'exception',
+    document: {
+      components: {
+        schemas: {
+          TestSchema: {
+            properties: {
+              createdAt: {
+                type: 'string',
+                format: 'date-time',
+                description: 'The creation timestamp.',
+                'x-xgen-IPA-exception': {
+                  'xgen-IPA-121-date-time-fields-mention-iso-8601': 'Legacy field format',
+                },
+              },
+            },
+          },
+        },
+        parameters: {
+          TestParameter: {
+            name: 'createdAt',
+            in: 'query',
+            schema: {
+              type: 'string',
+              format: 'date-time',
+              description: 'The creation timestamp',
+              'x-xgen-IPA-exception': {
+                'xgen-IPA-121-date-time-fields-mention-iso-8601': 'Legacy field format',
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+  {
+    name: 'test with parameters in path operation',
+    document: {
+      paths: {
+        '/resources': {
+          get: {
+            parameters: [
+              {
+                name: 'since',
+                in: 'query',
+                schema: {
+                  type: 'string',
+                  format: 'date-time',
+                  description: 'Filter resources created since this ISO 8601 timestamp',
+                },
+              },
+              {
+                name: 'until',
+                in: 'query',
+                schema: {
+                  type: 'string',
+                  format: 'date-time',
+                  description: 'Filter resources created until this timestamp', // Missing ISO 8601
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
+        message:
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+        path: ['paths', '/resources', 'get', 'parameters', '1', 'schema'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'test with requestBody properties',
+    document: {
+      paths: {
+        '/resources': {
+          post: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    properties: {
+                      scheduledFor: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'When to schedule the job using ISO 8601 format.',
+                      },
+                      expiresAt: {
+                        type: 'string',
+                        format: 'date-time',
+                        description: 'When this resource expires.', // Missing ISO 8601
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
+        message:
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+        path: [
+          'paths',
+          '/resources',
+          'post',
+          'requestBody',
+          'content',
+          'application/json',
+          'schema',
+          'properties',
+          'expiresAt',
+        ],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/IPA121DateTimeFieldsMentionISO8601.test.js
+++ b/tools/spectral/ipa/__tests__/IPA121DateTimeFieldsMentionISO8601.test.js
@@ -112,21 +112,21 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
       {
         code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
         message:
-          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 and UTC in their description.',
         path: ['components', 'schemas', 'TestSchema', 'properties', 'createdAt'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
         message:
-          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 and UTC in their description.',
         path: ['components', 'schemas', 'TestSchema', 'properties', 'modifiedAt'],
         severity: DiagnosticSeverity.Warning,
       },
       {
         code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
         message:
-          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 and UTC in their description.',
         path: ['components', 'parameters', 'TestParameter'],
         severity: DiagnosticSeverity.Warning,
       },
@@ -202,7 +202,7 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
       {
         code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
         message:
-          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 and UTC in their description.',
         path: ['paths', '/resources', 'get', 'parameters', '1'],
         severity: DiagnosticSeverity.Warning,
       },
@@ -242,7 +242,7 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
       {
         code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
         message:
-          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
+          'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 and UTC in their description.',
         path: [
           'paths',
           '/resources',

--- a/tools/spectral/ipa/__tests__/IPA121DateTimeFieldsMentionISO8601.test.js
+++ b/tools/spectral/ipa/__tests__/IPA121DateTimeFieldsMentionISO8601.test.js
@@ -26,10 +26,10 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
           TestParameter: {
             name: 'createdAt',
             in: 'query',
+            description: 'The creation timestamp in ISO 8601 format in UTC.',
             schema: {
               type: 'string',
               format: 'date-time',
-              description: 'The creation timestamp in ISO 8601 format in UTC.',
             },
           },
         },
@@ -82,10 +82,10 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
           TestParameter: {
             name: 'createdAt',
             in: 'query',
+            description: 'The creation timestamp',
             schema: {
               type: 'string',
               format: 'date-time',
-              description: 'The creation timestamp',
             },
           },
         },
@@ -127,7 +127,7 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
         code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
         message:
           'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
-        path: ['components', 'parameters', 'TestParameter', 'schema'],
+        path: ['components', 'parameters', 'TestParameter'],
         severity: DiagnosticSeverity.Warning,
       },
     ],
@@ -154,13 +154,13 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
           TestParameter: {
             name: 'createdAt',
             in: 'query',
+            description: 'The creation timestamp',
             schema: {
               type: 'string',
               format: 'date-time',
-              description: 'The creation timestamp',
-              'x-xgen-IPA-exception': {
-                'xgen-IPA-121-date-time-fields-mention-iso-8601': 'Legacy field format',
-              },
+            },
+            'x-xgen-IPA-exception': {
+              'xgen-IPA-121-date-time-fields-mention-iso-8601': 'Legacy field format',
             },
           },
         },
@@ -178,19 +178,19 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
               {
                 name: 'since',
                 in: 'query',
+                description: 'Filter resources created since this ISO 8601 timestamp in UTC',
                 schema: {
                   type: 'string',
                   format: 'date-time',
-                  description: 'Filter resources created since this ISO 8601 timestamp in UTC',
                 },
               },
               {
                 name: 'until',
                 in: 'query',
+                description: 'Filter resources created until this timestamp', // Missing ISO 8601 and UTC
                 schema: {
                   type: 'string',
                   format: 'date-time',
-                  description: 'Filter resources created until this timestamp', // Missing ISO 8601 and UTC
                 },
               },
             ],
@@ -203,7 +203,7 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
         code: 'xgen-IPA-121-date-time-fields-mention-iso-8601',
         message:
           'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.',
-        path: ['paths', '/resources', 'get', 'parameters', '1', 'schema'],
+        path: ['paths', '/resources', 'get', 'parameters', '1'],
         severity: DiagnosticSeverity.Warning,
       },
     ],

--- a/tools/spectral/ipa/__tests__/IPA121DateTimeFieldsMentionISO8601.test.js
+++ b/tools/spectral/ipa/__tests__/IPA121DateTimeFieldsMentionISO8601.test.js
@@ -12,12 +12,12 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
               createdAt: {
                 type: 'string',
                 format: 'date-time',
-                description: 'The creation timestamp in ISO 8601 format.',
+                description: 'The creation timestamp in ISO 8601 format in UTC.',
               },
               updatedOn: {
                 type: 'string',
                 format: 'date-time',
-                description: 'When the resource was last updated. Uses ISO 8601 datetime format.',
+                description: 'When the resource was last updated. Uses ISO 8601 datetime format in UTC.',
               },
             },
           },
@@ -29,7 +29,7 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
             schema: {
               type: 'string',
               format: 'date-time',
-              description: 'The creation timestamp in ISO 8601 format.',
+              description: 'The creation timestamp in ISO 8601 format in UTC.',
             },
           },
         },
@@ -181,7 +181,7 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
                 schema: {
                   type: 'string',
                   format: 'date-time',
-                  description: 'Filter resources created since this ISO 8601 timestamp',
+                  description: 'Filter resources created since this ISO 8601 timestamp in UTC',
                 },
               },
               {
@@ -190,7 +190,7 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
                 schema: {
                   type: 'string',
                   format: 'date-time',
-                  description: 'Filter resources created until this timestamp', // Missing ISO 8601
+                  description: 'Filter resources created until this timestamp', // Missing ISO 8601 and UTC
                 },
               },
             ],
@@ -222,12 +222,12 @@ testRule('xgen-IPA-121-date-time-fields-mention-iso-8601', [
                       scheduledFor: {
                         type: 'string',
                         format: 'date-time',
-                        description: 'When to schedule the job using ISO 8601 format.',
+                        description: 'When to schedule the job using ISO 8601 format in UTC.',
                       },
                       expiresAt: {
                         type: 'string',
                         format: 'date-time',
-                        description: 'When this resource expires.', // Missing ISO 8601
+                        description: 'When this resource expires.', // Missing ISO 8601 and UTC
                       },
                     },
                   },

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -14,6 +14,7 @@ extends:
   - ./rulesets/IPA-117.yaml
   - ./rulesets/IPA-118.yaml
   - ./rulesets/IPA-119.yaml
+  - ./rulesets/IPA-121.yaml
   - ./rulesets/IPA-123.yaml
   - ./rulesets/IPA-125.yaml
 

--- a/tools/spectral/ipa/rulesets/IPA-121.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-121.yaml
@@ -16,6 +16,7 @@ rules:
       - $.components.schemas..properties[*]
       - $.paths..requestBody..schema..properties[*]
       - $.paths..responses..schema..properties[*]
+    resolved: false
     severity: warn
     then:
       function: IPA121DateTimeFieldsMentionISO8601

--- a/tools/spectral/ipa/rulesets/IPA-121.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-121.yaml
@@ -8,10 +8,11 @@ rules:
   xgen-IPA-121-date-time-fields-mention-iso-8601:
     description: |
       Fields with format="date-time" should mention ISO 8601 and UTC in their description.
+      It collects adoption metrics at schema property level and parameter level
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-121-date-time-fields-mention-iso-8601'
     given:
-      - $.paths..parameters[*].schema
-      - $.components.parameters.*.schema
+      - $.paths..parameters[*]
+      - $.components.parameters[*]
       - $.components.schemas..properties[*]
       - $.paths..requestBody..schema..properties[*]
       - $.paths..responses..schema..properties[*]

--- a/tools/spectral/ipa/rulesets/IPA-121.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-121.yaml
@@ -1,0 +1,20 @@
+# IPA-121: Datetime
+# http://go/ipa/121
+
+functions:
+  - IPA121DateTimeFieldsMentionISO8601
+
+rules:
+  xgen-IPA-121-date-time-fields-mention-iso-8601:
+    description: |
+      Fields with format="date-time" should mention ISO 8601 in their description.
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-121-date-time-fields-mention-iso-8601'
+    given:
+      - $.paths..parameters[*].schema
+      - $.components.parameters.*.schema
+      - $.components.schemas..properties[*]
+      - $.paths..requestBody..schema..properties[*]
+      - $.paths..responses..schema..properties[*]
+    severity: warn
+    then:
+      function: IPA121DateTimeFieldsMentionISO8601

--- a/tools/spectral/ipa/rulesets/IPA-121.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-121.yaml
@@ -7,7 +7,7 @@ functions:
 rules:
   xgen-IPA-121-date-time-fields-mention-iso-8601:
     description: |
-      Fields with format="date-time" should mention ISO 8601 in their description.
+      Fields with format="date-time" should mention ISO 8601 and UTC in their description.
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-121-date-time-fields-mention-iso-8601'
     given:
       - $.paths..parameters[*].schema

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -810,6 +810,7 @@ Rules are based on [http://go/ipa/IPA-121](http://go/ipa/IPA-121).
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
 Fields with format="date-time" should mention ISO 8601 and UTC in their description.
+It collects adoption metrics at schema property level and parameter level
 
 
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -809,7 +809,7 @@ Rules are based on [http://go/ipa/IPA-121](http://go/ipa/IPA-121).
 #### xgen-IPA-121-date-time-fields-mention-iso-8601
 
  ![warn](https://img.shields.io/badge/warning-yellow) 
-Fields with format="date-time" should mention ISO 8601 in their description.
+Fields with format="date-time" should mention ISO 8601 and UTC in their description.
 
 
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -802,6 +802,17 @@ All cloudProviderEnumValues should be listed in the enum array.
 
 
 
+### IPA-121
+
+Rules are based on [http://go/ipa/IPA-121](http://go/ipa/IPA-121).
+
+#### xgen-IPA-121-date-time-fields-mention-iso-8601
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Fields with format="date-time" should mention ISO 8601 in their description.
+
+
+
 ### IPA-123
 
 Rules are based on [http://go/ipa/IPA-123](http://go/ipa/IPA-123).

--- a/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
@@ -21,7 +21,7 @@ export default (input, options, { path, documentInventory }) => {
   }
 
   if (input.format === 'date-time') {
-    if (!input.description?.includes('ISO 8601')) {
+    if (!input.description?.includes('ISO 8601') && !input.description?.includes('UTC')) {
       return collectAndReturnViolation(path, RULE_NAME, [
         {
           path,

--- a/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
@@ -1,0 +1,35 @@
+import { hasException } from './utils/exceptions.js';
+import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { resolveObject } from './utils/componentUtils.js';
+
+const RULE_NAME = 'xgen-IPA-121-date-time-fields-mention-iso-8601';
+const ERROR_MESSAGE =
+  'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.';
+
+export default (input, options, { path, documentInventory }) => {
+  const oas = documentInventory.unresolved;
+  const propertyObject = resolveObject(oas, path);
+
+  // Not to duplicate the check for referenced schemas
+  if (!propertyObject) {
+    return;
+  }
+
+  if (hasException(input, RULE_NAME)) {
+    collectException(input, RULE_NAME, path);
+    return;
+  }
+
+  if (input.format === 'date-time') {
+    if (!input.description?.includes('ISO 8601')) {
+      return collectAndReturnViolation(path, RULE_NAME, [
+        {
+          path,
+          message: ERROR_MESSAGE,
+        },
+      ]);
+    }
+
+    collectAdoption(path, RULE_NAME);
+  }
+};

--- a/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
@@ -9,7 +9,7 @@ const ERROR_MESSAGE =
 export default (input, options, { path, documentInventory }) => {
   const oas = documentInventory.unresolved;
   const propertyObject = resolveObject(oas, path);
-
+  const fieldType = path[path.length - 2];
   // Not to duplicate the check for referenced schemas
   if (!propertyObject) {
     return;
@@ -20,8 +20,16 @@ export default (input, options, { path, documentInventory }) => {
     return;
   }
 
-  if (input.format === 'date-time') {
-    if (!input.description?.includes('ISO 8601') && !input.description?.includes('UTC')) {
+  let format;
+  let description = input.description;
+  if (fieldType === 'parameters') {
+    format = input.schema?.format;
+  } else if (fieldType === 'properties') {
+    format = input.format;
+  }
+
+  if (format === 'date-time') {
+    if (!description?.includes('ISO 8601') && !description?.includes('UTC')) {
       return collectAndReturnViolation(path, RULE_NAME, [
         {
           path,

--- a/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
@@ -1,19 +1,12 @@
 import { hasException } from './utils/exceptions.js';
 import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
-import { resolveObject } from './utils/componentUtils.js';
 
 const RULE_NAME = 'xgen-IPA-121-date-time-fields-mention-iso-8601';
 const ERROR_MESSAGE =
   'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 and UTC in their description.';
 
-export default (input, options, { path, documentInventory }) => {
-  const oas = documentInventory.unresolved;
-  const propertyObject = resolveObject(oas, path);
+export default (input, options, { path }) => {
   const fieldType = path[path.length - 2];
-  // Not to duplicate the check for referenced schemas
-  if (!propertyObject) {
-    return;
-  }
 
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);

--- a/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA121DateTimeFieldsMentionISO8601.js
@@ -4,7 +4,7 @@ import { resolveObject } from './utils/componentUtils.js';
 
 const RULE_NAME = 'xgen-IPA-121-date-time-fields-mention-iso-8601';
 const ERROR_MESSAGE =
-  'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 in their description.';
+  'API producers must use ISO 8601 date-time format in UTC for all timestamps. Fields must note ISO 8601 and UTC in their description.';
 
 export default (input, options, { path, documentInventory }) => {
   const oas = documentInventory.unresolved;


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-306577
```

  xgen-IPA-121-date-time-fields-mention-iso-8601:
    description: |
      Fields with format="date-time" should mention ISO 8601 and UTC in their description.
```
Found 48 violations to fix

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
