### PR TITLE
CLOUDP-306579: IPA-124: Repeated Fields (fix)

### DIFF
--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -61,8 +61,6 @@ jobs:
           env: ${{ inputs.env }}
           task_name: 'Optional Postman validation'
           team_id: ${{ vars.JIRA_TEAM_ID_APIX_1 }}
-        secrets:
-          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}
       - name: Create Issue - IPA validation Failed
         if: ${{ failure() && steps.ipa-spectral-validation.outcome == 'failure'}}
         uses: ./.github/workflows/task-failure-handler.yml
@@ -70,5 +68,3 @@ jobs:
           env: ${{ inputs.env }}
           task_name: 'Optional IPA validation'
           team_id: ${{ vars.JIRA_TEAM_ID_APIX_1 }}
-        secrets:
-          jira_api_token: ${{ secrets.JIRA_API_TOKEN }}

--- a/tools/spectral/ipa/__tests__/IPA124ArrayMaxItems.test.js
+++ b/tools/spectral/ipa/__tests__/IPA124ArrayMaxItems.test.js
@@ -57,6 +57,15 @@ testRule('xgen-IPA-124-array-max-items', [
                   type: 'object',
                 },
               },
+              mapProperty: {
+                type: 'object',
+                additionalProperties: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                },
+              },
             },
           },
         },

--- a/tools/spectral/ipa/rulesets/IPA-124.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-124.yaml
@@ -29,3 +29,4 @@ rules:
         ignore:
           - links
           - results
+          - additionalProperties


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-306579

Ignore additionalProperties in the xgen-IPA-124-array-max-items rule. AdditionalProperties property is used for map objects, and it is not possible to provide maxItems for them


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
