### PR TITLE
CLOUDP-306582: IPA-126: Top-Level API Names

### DIFF
--- a/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
@@ -1,0 +1,169 @@
+import testRule from './__helpers__/testRule.js';
+import { DiagnosticSeverity } from '@stoplight/types';
+
+testRule('xgen-IPA-126-tag-names-should-use-title-case', [
+  {
+    name: 'valid Title Case tag names',
+    document: {
+      tags: [
+        { name: 'User Management' },
+        { name: 'Resource Groups' },
+        { name: 'Atlas' },
+        { name: 'User Profiles' },
+        { name: 'Api' },
+        { name: 'Users' },
+        { name: 'Resources' },
+        { name: 'Projects' },
+      ],
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid camelCase instead of Title Case',
+    document: {
+      tags: [{ name: 'userManagement' }],
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "userManagement".',
+        path: ['tags', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid kebab-case instead of Title Case',
+    document: {
+      tags: [{ name: 'user-management' }],
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "user-management".',
+        path: ['tags', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid snake_case instead of Title Case',
+    document: {
+      tags: [{ name: 'user_management' }],
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "user_management".',
+        path: ['tags', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid all lowercase instead of Title Case',
+    document: {
+      tags: [{ name: 'user management' }],
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "user management".',
+        path: ['tags', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'invalid ALL UPPERCASE instead of Title Case',
+    document: {
+      tags: [{ name: 'USER MANAGEMENT' }],
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "USER MANAGEMENT".',
+        path: ['tags', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'mixed cases in multiple tags',
+    document: {
+      tags: [{ name: 'User Management' }, { name: 'resourceGroups' }, { name: 'API ENDPOINTS' }],
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "resourceGroups".',
+        path: ['tags', '1'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "API ENDPOINTS".',
+        path: ['tags', '2'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+  {
+    name: 'valid with exception',
+    document: {
+      tags: [
+        {
+          name: 'legacy_tag',
+          'x-xgen-IPA-exception': {
+            'xgen-IPA-126-tag-names-should-use-title-case': 'Legacy tag that cannot be changed',
+          },
+        },
+      ],
+    },
+    errors: [],
+  },
+  {
+    name: 'invalid tag names',
+    document: {
+      tags: [
+        { name: 'Api V1' },
+        { name: 'Version 2 Resources' },
+        { name: 'Push-Based Log Export' },
+        { name: 'AWS Clusters DNS' },
+        { name: 'Encryption at Rest using Customer Key Management' },
+      ],
+    },
+    errors: [
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "Api V1".',
+        path: ['tags', '0'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "Version 2 Resources".',
+        path: ['tags', '1'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "Push-Based Log Export".',
+        path: ['tags', '2'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "AWS Clusters DNS".',
+        path: ['tags', '3'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "Encryption at Rest using Customer Key Management".',
+        path: ['tags', '4'],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+]);

--- a/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
@@ -135,6 +135,7 @@ testRule('xgen-IPA-126-tag-names-should-use-title-case', [
         { name: 'Test Tag-' },
         { name: 'Test Tag -Name' },
         { name: 'the Test Tag' },
+        { name: 'A Test Tag' },
       ],
     },
     errors: [

--- a/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
@@ -134,6 +134,7 @@ testRule('xgen-IPA-126-tag-names-should-use-title-case', [
         { name: '-Test Tag' },
         { name: 'Test Tag-' },
         { name: 'Test Tag -Name' },
+        { name: 'the Test Tag' },
       ],
     },
     errors: [
@@ -171,6 +172,12 @@ testRule('xgen-IPA-126-tag-names-should-use-title-case', [
         code: 'xgen-IPA-126-tag-names-should-use-title-case',
         message: 'Tag name should use Title Case, found: "Test Tag -Name".',
         path: ['tags', '7'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "the Test Tag".',
+        path: ['tags', '8'],
         severity: DiagnosticSeverity.Warning,
       },
     ],

--- a/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
@@ -128,8 +128,8 @@ testRule('xgen-IPA-126-tag-names-should-use-title-case', [
       tags: [
         { name: 'Api V1' },
         { name: 'Version 2 Resources' },
-        { name: 'Push-Based Log Export' },
-        { name: 'AWS Clusters DNS' },
+        { name: 'Push-Based Log Export' }, //valid
+        { name: 'AWS Clusters DNS' }, // valid
         { name: 'Encryption at Rest using Customer Key Management' },
       ],
     },
@@ -144,18 +144,6 @@ testRule('xgen-IPA-126-tag-names-should-use-title-case', [
         code: 'xgen-IPA-126-tag-names-should-use-title-case',
         message: 'Tag name should use Title Case, found: "Version 2 Resources".',
         path: ['tags', '1'],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        code: 'xgen-IPA-126-tag-names-should-use-title-case',
-        message: 'Tag name should use Title Case, found: "Push-Based Log Export".',
-        path: ['tags', '2'],
-        severity: DiagnosticSeverity.Warning,
-      },
-      {
-        code: 'xgen-IPA-126-tag-names-should-use-title-case',
-        message: 'Tag name should use Title Case, found: "AWS Clusters DNS".',
-        path: ['tags', '3'],
         severity: DiagnosticSeverity.Warning,
       },
       {

--- a/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
+++ b/tools/spectral/ipa/__tests__/IPA126TagNamesShouldUseTitleCase.test.js
@@ -131,6 +131,9 @@ testRule('xgen-IPA-126-tag-names-should-use-title-case', [
         { name: 'Push-Based Log Export' }, //valid
         { name: 'AWS Clusters DNS' }, // valid
         { name: 'Encryption at Rest using Customer Key Management' },
+        { name: '-Test Tag' },
+        { name: 'Test Tag-' },
+        { name: 'Test Tag -Name' },
       ],
     },
     errors: [
@@ -150,6 +153,24 @@ testRule('xgen-IPA-126-tag-names-should-use-title-case', [
         code: 'xgen-IPA-126-tag-names-should-use-title-case',
         message: 'Tag name should use Title Case, found: "Encryption at Rest using Customer Key Management".',
         path: ['tags', '4'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "-Test Tag".',
+        path: ['tags', '5'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "Test Tag-".',
+        path: ['tags', '6'],
+        severity: DiagnosticSeverity.Warning,
+      },
+      {
+        code: 'xgen-IPA-126-tag-names-should-use-title-case',
+        message: 'Tag name should use Title Case, found: "Test Tag -Name".',
+        path: ['tags', '7'],
         severity: DiagnosticSeverity.Warning,
       },
     ],

--- a/tools/spectral/ipa/ipa-spectral.yaml
+++ b/tools/spectral/ipa/ipa-spectral.yaml
@@ -18,6 +18,7 @@ extends:
   - ./rulesets/IPA-123.yaml
   - ./rulesets/IPA-124.yaml
   - ./rulesets/IPA-125.yaml
+  - ./rulesets/IPA-126.yaml
 
 overrides:
   - files:

--- a/tools/spectral/ipa/rulesets/IPA-126.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-126.yaml
@@ -1,0 +1,19 @@
+# IPA-126: Top-Level API Names
+# http://go/ipa/126
+
+functions:
+  - IPA126TagNamesShouldUseTitleCase
+rules:
+  xgen-IPA-126-tag-names-should-use-title-case:
+    description: |
+      Tag names in the OpenAPI specification should use Title Case.
+
+      ##### Implementation details
+      Rule checks for the following conditions:
+        - All tag names defined in the OpenAPI tags object should use Title Case 
+        - Title Case means each word starts with an uppercase letter, and the rest are lowercase
+    message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-126-tag-names-should-use-title-case'
+    severity: warn
+    given: $.tags[*]
+    then:
+      function: 'IPA126TagNamesShouldUseTitleCase'

--- a/tools/spectral/ipa/rulesets/IPA-126.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-126.yaml
@@ -12,6 +12,13 @@ rules:
       Rule checks for the following conditions:
         - All tag names defined in the OpenAPI tags object should use Title Case 
         - Title Case means each word starts with an uppercase letter, and the rest are lowercase
+        - Certain abbreviations (like "API", "AWS", etc.) in the ignoreList are allowed to maintain their casing
+        - Grammatical words (like "and", "or", "the", etc.) are allowed to be all lowercase
+
+      ##### Configuration
+      This rule includes two configuration options:
+        - `ignoreList`: Words that are allowed to maintain their specific casing (e.g., "API", "AWS", "DNS")
+        - `grammaticalWords`: Common words that can remain lowercase in titles (e.g., "and", "or", "the")
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-126-tag-names-should-use-title-case'
     severity: warn
     given: $.tags[?(@.name && @.name.length > 0)]
@@ -26,3 +33,17 @@ rules:
           - 'MongoDB'
           - 'LDAP'
           - 'GCP'
+        grammaticalWords:
+          - 'and'
+          - 'or'
+          - 'to'
+          - 'in'
+          - 'as'
+          - 'for'
+          - 'of'
+          - 'with'
+          - 'by'
+          - 'but'
+          - 'the'
+          - 'a'
+          - 'an'

--- a/tools/spectral/ipa/rulesets/IPA-126.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-126.yaml
@@ -14,6 +14,6 @@ rules:
         - Title Case means each word starts with an uppercase letter, and the rest are lowercase
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-126-tag-names-should-use-title-case'
     severity: warn
-    given: $.tags[*]
+    given: $.tags[?(@.name && @.name.length > 0)]
     then:
       function: 'IPA126TagNamesShouldUseTitleCase'

--- a/tools/spectral/ipa/rulesets/IPA-126.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-126.yaml
@@ -17,3 +17,12 @@ rules:
     given: $.tags[?(@.name && @.name.length > 0)]
     then:
       function: 'IPA126TagNamesShouldUseTitleCase'
+      functionOptions:
+        ignoreList:
+          - 'AWS'
+          - 'DNS'
+          - 'API'
+          - 'IP'
+          - 'MongoDB'
+          - 'LDAP'
+          - 'GCP'

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -920,4 +920,20 @@ object types with clear discriminators.
 
 
 
+### IPA-126
+
+Rules are based on [http://go/ipa/IPA-126](http://go/ipa/IPA-126).
+
+#### xgen-IPA-126-tag-names-should-use-title-case
+
+ ![warn](https://img.shields.io/badge/warning-yellow) 
+Tag names in the OpenAPI specification should use Title Case.
+
+##### Implementation details
+Rule checks for the following conditions:
+  - All tag names defined in the OpenAPI tags object should use Title Case 
+  - Title Case means each word starts with an uppercase letter, and the rest are lowercase
+
+
+
 

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -933,6 +933,13 @@ Tag names in the OpenAPI specification should use Title Case.
 Rule checks for the following conditions:
   - All tag names defined in the OpenAPI tags object should use Title Case 
   - Title Case means each word starts with an uppercase letter, and the rest are lowercase
+  - Certain abbreviations (like "API", "AWS", etc.) in the ignoreList are allowed to maintain their casing
+  - Grammatical words (like "and", "or", "the", etc.) are allowed to be all lowercase
+
+##### Configuration
+This rule includes two configuration options:
+  - `ignoreList`: Words that are allowed to maintain their specific casing (e.g., "API", "AWS", "DNS")
+  - `grammaticalWords`: Common words that can remain lowercase in titles (e.g., "and", "or", "the")
 
 
 

--- a/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
@@ -33,7 +33,6 @@ function isTitleCase(str, ignoreList, grammaticalWords) {
     if (wordGroup.includes('-')) {
       const hyphenatedParts = wordGroup.split('-');
       return hyphenatedParts.every((part) => {
-        if (part === '') return true; // Skip empty parts
         if (ignoreList.includes(part)) return true;
         if (grammaticalWords.includes(part)) return true;
         // First character should be uppercase, rest lowercase, all alphabetical
@@ -42,7 +41,6 @@ function isTitleCase(str, ignoreList, grammaticalWords) {
     }
 
     // For regular words
-    if (wordGroup === '') return true;
     if (ignoreList.includes(wordGroup)) return true;
     if (grammaticalWords.includes(wordGroup)) return true;
     return /^[A-Z][a-z]*$/.test(wordGroup);

--- a/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
@@ -6,10 +6,6 @@ const RULE_NAME = 'xgen-IPA-126-tag-names-should-use-title-case';
 
 export default (input, options, { path }) => {
   const tagName = input.name;
-  if (!tagName || tagName.trim().length === 0) {
-    return;
-  }
-
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
     return;

--- a/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
@@ -1,0 +1,30 @@
+import { hasException } from './utils/exceptions.js';
+import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
+import { casing } from '@stoplight/spectral-functions';
+
+const RULE_NAME = 'xgen-IPA-126-tag-names-should-use-title-case';
+
+export default (input, options, { path }) => {
+  const tagName = input.name;
+  if (!tagName || tagName.trim().length === 0) {
+    return;
+  }
+
+  if (hasException(input, RULE_NAME)) {
+    collectException(input, RULE_NAME, path);
+    return;
+  }
+
+  // Check if the tag name uses Title Case
+  if (casing(tagName, { type: 'pascal', disallowDigits: true, separator: { char: ' ' } })) {
+    return collectAndReturnViolation(path, RULE_NAME, [
+      {
+        path,
+        message: `Tag name should use Title Case, found: "${tagName}".`,
+      },
+    ]);
+  }
+
+  // Tag name uses Title Case
+  collectAdoption(path, RULE_NAME);
+};

--- a/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
@@ -26,23 +26,22 @@ export default (input, { ignoreList, grammaticalWords }, { path }) => {
 
 function isTitleCase(str, ignoreList, grammaticalWords) {
   // Split by spaces to check each word/word-group
+  // First character should be uppercase, rest lowercase, all alphabetical
   const words = str.split(' ');
 
-  return words.every((wordGroup) => {
+  return words.every((wordGroup, index) => {
     // For hyphenated words, check each part
     if (wordGroup.includes('-')) {
       const hyphenatedParts = wordGroup.split('-');
       return hyphenatedParts.every((part) => {
         if (ignoreList.includes(part)) return true;
-        if (grammaticalWords.includes(part)) return true;
-        // First character should be uppercase, rest lowercase, all alphabetical
         return /^[A-Z][a-z]*$/.test(part);
       });
     }
 
     // For regular words
     if (ignoreList.includes(wordGroup)) return true;
-    if (grammaticalWords.includes(wordGroup)) return true;
+    if (index !== 0 && grammaticalWords.includes(wordGroup)) return true;
     return /^[A-Z][a-z]*$/.test(wordGroup);
   });
 }

--- a/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
@@ -3,7 +3,7 @@ import { collectAdoption, collectAndReturnViolation, collectException } from './
 
 const RULE_NAME = 'xgen-IPA-126-tag-names-should-use-title-case';
 
-export default (input, { ignoreList }, { path }) => {
+export default (input, { ignoreList, grammaticalWords }, { path }) => {
   const tagName = input.name;
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
@@ -11,7 +11,7 @@ export default (input, { ignoreList }, { path }) => {
   }
 
   // Check if the tag name uses Title Case
-  if (!isTitleCase(tagName, ignoreList)) {
+  if (!isTitleCase(tagName, ignoreList, grammaticalWords)) {
     return collectAndReturnViolation(path, RULE_NAME, [
       {
         path,
@@ -24,7 +24,7 @@ export default (input, { ignoreList }, { path }) => {
   collectAdoption(path, RULE_NAME);
 };
 
-function isTitleCase(str, ignoreList) {
+function isTitleCase(str, ignoreList, grammaticalWords) {
   // Split by spaces to check each word/word-group
   const words = str.split(' ');
 
@@ -35,6 +35,7 @@ function isTitleCase(str, ignoreList) {
       return hyphenatedParts.every((part) => {
         if (part === '') return true; // Skip empty parts
         if (ignoreList.includes(part)) return true;
+        if (grammaticalWords.includes(part)) return true;
         // First character should be uppercase, rest lowercase, all alphabetical
         return /^[A-Z][a-z]*$/.test(part);
       });
@@ -43,6 +44,7 @@ function isTitleCase(str, ignoreList) {
     // For regular words
     if (wordGroup === '') return true;
     if (ignoreList.includes(wordGroup)) return true;
+    if (grammaticalWords.includes(wordGroup)) return true;
     return /^[A-Z][a-z]*$/.test(wordGroup);
   });
 }

--- a/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA126TagNamesShouldUseTitleCase.js
@@ -1,10 +1,9 @@
 import { hasException } from './utils/exceptions.js';
 import { collectAdoption, collectAndReturnViolation, collectException } from './utils/collectionUtils.js';
-import { casing } from '@stoplight/spectral-functions';
 
 const RULE_NAME = 'xgen-IPA-126-tag-names-should-use-title-case';
 
-export default (input, options, { path }) => {
+export default (input, { ignoreList }, { path }) => {
   const tagName = input.name;
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
@@ -12,7 +11,7 @@ export default (input, options, { path }) => {
   }
 
   // Check if the tag name uses Title Case
-  if (casing(tagName, { type: 'pascal', disallowDigits: true, separator: { char: ' ' } })) {
+  if (!isTitleCase(tagName, ignoreList)) {
     return collectAndReturnViolation(path, RULE_NAME, [
       {
         path,
@@ -24,3 +23,26 @@ export default (input, options, { path }) => {
   // Tag name uses Title Case
   collectAdoption(path, RULE_NAME);
 };
+
+function isTitleCase(str, ignoreList) {
+  // Split by spaces to check each word/word-group
+  const words = str.split(' ');
+
+  return words.every((wordGroup) => {
+    // For hyphenated words, check each part
+    if (wordGroup.includes('-')) {
+      const hyphenatedParts = wordGroup.split('-');
+      return hyphenatedParts.every((part) => {
+        if (part === '') return true; // Skip empty parts
+        if (ignoreList.includes(part)) return true;
+        // First character should be uppercase, rest lowercase, all alphabetical
+        return /^[A-Z][a-z]*$/.test(part);
+      });
+    }
+
+    // For regular words
+    if (wordGroup === '') return true;
+    if (ignoreList.includes(wordGroup)) return true;
+    return /^[A-Z][a-z]*$/.test(wordGroup);
+  });
+}


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-306582
```
  xgen-IPA-126-tag-names-should-use-title-case:
    description: |
      Tag names in the OpenAPI specification should use Title Case.

      ##### Implementation details
      Rule checks for the following conditions:
        - All tag names defined in the OpenAPI tags object should use Title Case 
        - Title Case means each word starts with an uppercase letter, and the rest are lowercase
```

Found 13 violations


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
