### PR TITLE
CLOUDP-311375: Update `foascli split` command to support `upcoming` apis

### DIFF
--- a/tools/cli/internal/apiversion/version.go
+++ b/tools/cli/internal/apiversion/version.go
@@ -65,6 +65,10 @@ func (v *APIVersion) newVersion(version string, date time.Time) {
 	if IsPreviewStabilityLevel(version) {
 		v.stabilityVersion = PreviewStabilityLevel
 	}
+
+	if IsUpcomingStabilityLevel(version) {
+		v.stabilityVersion = UpcomingStabilityLevel
+	}
 }
 
 // WithVersion sets the version on the APIVersion.
@@ -166,7 +170,7 @@ func (v *APIVersion) StabilityLevel() string {
 }
 
 func (v *APIVersion) ExactMatchOnly() bool {
-	return v.IsPreview()
+	return v.IsPreview() || v.IsUpcoming()
 }
 
 func (v *APIVersion) IsPreview() bool {
@@ -181,6 +185,7 @@ func (v *APIVersion) IsPublicPreview() bool {
 	return v.IsPreview() && !v.IsPrivatePreview()
 }
 
+func (v *APIVersion) IsUpcoming() bool { return IsUpcomingStabilityLevel(v.stabilityVersion) }
 func FindMatchesFromContentType(contentType string) []string {
 	return contentPattern.FindStringSubmatch(contentType)
 }

--- a/tools/cli/internal/cli/split/split_test.go
+++ b/tools/cli/internal/cli/split/split_test.go
@@ -78,6 +78,26 @@ func TestSplitPrivatePreviewRun(t *testing.T) {
 	require.Contains(t, info.Spec.Paths.Map(), "/api/atlas/v2/groups")
 }
 
+func TestSplitUpcomingRun(t *testing.T) {
+	t.Parallel()
+	fs := afero.NewMemMapFs()
+	opts := &Opts{
+		basePath:   "../../../test/data/openapi_with_upcoming.json",
+		outputPath: "foas.yaml",
+		fs:         fs,
+		env:        "dev",
+	}
+
+	require.NoError(t, opts.Run())
+
+	info, err := loadRunResultOas(fs, "foas-2025-09-22.upcoming.yaml")
+	require.NoError(t, err)
+
+	// check paths has only one
+	require.Len(t, info.Spec.Paths.Map(), 1)
+	require.Contains(t, info.Spec.Paths.Map(), "/api/atlas/v2/openapi/info")
+}
+
 func TestSplitMultiplePreviewsRun(t *testing.T) {
 	t.Parallel()
 	fs := afero.NewMemMapFs()

--- a/tools/cli/internal/openapi/filter/extension.go
+++ b/tools/cli/internal/openapi/filter/extension.go
@@ -18,7 +18,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// ExtensionFilter: is a filter that removes the x-xgen-IPA-exception extension from the OpenAPI spec.
+// ExtensionFilter is a filter that removes the x-xgen-IPA-exception extension from the OpenAPI spec.
 type ExtensionFilter struct {
 	oas      *openapi3.T
 	metadata *Metadata

--- a/tools/cli/internal/openapi/filter/hidden_envs.go
+++ b/tools/cli/internal/openapi/filter/hidden_envs.go
@@ -26,8 +26,8 @@ const (
 	hiddenEnvsExtKey    = "envs"
 )
 
-// HiddenEnvsFilter: is a filter that removes paths, operations,
-// request/response bodies and content types that are hidden for the target environment.
+// HiddenEnvsFilter removes paths, operations, request/response bodies and content types
+// that are hidden for the target environment.
 type HiddenEnvsFilter struct {
 	oas      *openapi3.T
 	metadata *Metadata

--- a/tools/cli/internal/openapi/filter/info.go
+++ b/tools/cli/internal/openapi/filter/info.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mongodb/openapi/tools/cli/internal/apiversion"
 )
 
-// InfoVersioningFilter: Filter that modifies the Info object in the OpenAPI spec with the target version.
+// InfoVersioningFilter modifies the Info object in the OpenAPI spec with the target version.
 type InfoVersioningFilter struct {
 	oas      *openapi3.T
 	metadata *Metadata

--- a/tools/cli/internal/openapi/filter/operations.go
+++ b/tools/cli/internal/openapi/filter/operations.go
@@ -18,7 +18,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// OperationsFilter: is a filter that removes the x-xgen-owner-team extension from operations.
+// OperationsFilter is a filter that removes the x-xgen-owner-team extension from operations.
 type OperationsFilter struct {
 	oas *openapi3.T
 }

--- a/tools/cli/internal/openapi/filter/tags.go
+++ b/tools/cli/internal/openapi/filter/tags.go
@@ -20,7 +20,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// TagsFilter: removes tags that are not used in the operations.
+// TagsFilter removes tags that are not used in the operations.
 type TagsFilter struct {
 	oas *openapi3.T
 }

--- a/tools/cli/internal/openapi/filter/versioning.go
+++ b/tools/cli/internal/openapi/filter/versioning.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mongodb/openapi/tools/cli/internal/apiversion"
 )
 
-// VersioningFilter: is a filter that modifies the OpenAPI spec by removing operations and responses
+// VersioningFilter is a filter that modifies the OpenAPI spec by removing paths, operations and responses
 // that are not supported by the target version.
 type VersioningFilter struct {
 	oas      *openapi3.T

--- a/tools/cli/internal/openapi/filter/versioning_extension.go
+++ b/tools/cli/internal/openapi/filter/versioning_extension.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mongodb/openapi/tools/cli/internal/apiversion"
 )
 
-// VersioningExtensionFilter: is a filter that updates the x-sunset and x-xgen-version extensions to a date string
+// VersioningExtensionFilter is a filter that updates the x-sunset and x-xgen-version extensions to a date string
 // and deletes the x-sunset extension if the latest matched version is deprecated by hidden versions
 // for the target environment.
 type VersioningExtensionFilter struct {


### PR DESCRIPTION
## Proposed changes
CLOUDP-311375

This PR updates `foascli split` to add support for `upcoming` api version.
