### PR TITLE
CLOUDP-311390: Remove duplicate legacy Spectral rule

### DIFF
--- a/tools/spectral/.spectral.yaml
+++ b/tools/spectral/.spectral.yaml
@@ -85,20 +85,6 @@ rules:
       functionOptions:
         type: camel
 
-  xgen-docs-parameter-examples-or-schema:
-    message: "No example or schema provided for {{property}}."
-    description: "Without providing a well defined schema or example(s) an API consumer will have a hard time knowing how to interact with this API."
-    severity: error
-    given: "$.paths[*]..parameters[*]"
-    then:
-      function: schema
-      functionOptions:
-        schema:
-          anyOf:
-            - required: ["example"]
-            - required: ["examples"]
-            - required: ["schema"]
-
   x-xgen-hidden-env-format:
     description: "Ensure x-xgen-hidden-env extension has the correct format. https://go/openapi-hidden-extension"
     severity: error
@@ -190,7 +176,3 @@ overrides:
       - "*.yaml#/components/schemas/tokenFiltertrim"
     rules:
         xgen-schema-name-pascal-case: "off"
-  - files:
-      - "**#/components/schemas/ApiError/properties/parameters" # see https://github.com/stoplightio/spectral/issues/2592
-    rules:
-      xgen-docs-parameter-examples-or-schema: "off"


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-311390

Remove `xgen-docs-parameter-examples-or-schema` legacy Spectral rule, because the duplicate `xgen-IPA-117-parameter-has-examples-or-schema` will be rolled out

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
