### PR TITLE
CLOUDP-306499: Prevent generation of duplicate Postman collection versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.env
 
 /tools/postman/openapi
+/tools/postman/node_modules
 /node_modules
 
 # Tool generated files

--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -25,7 +25,7 @@ collection_transformed_path="${PWD}/${TMP_FOLDER}/${COLLECTION_TRANSFORMED_FILE_
 
 pushd "${OPENAPI_FOLDER}"
 
-current_collection_name="⭐MongoDB Atlas Administration API ${current_api_revision}"
+current_collection_name="⭐ MongoDB Atlas Administration API ${current_api_revision}"
 
 echo "Fetching list of current collections"
 echo "curl -o ${COLLECTIONS_LIST_FILE} 


### PR DESCRIPTION
## Proposed changes

### Description of the bug: 
Currently, a duplicate is being created every time a new version is being published without a change in the API Version

The search in the collection version comparison logic is looking for "⭐MongoDB Atlas Administration API 2025-03-12" but in Postman, the collections have a space after the star symbol ("⭐ MongoDB Atlas Administration API 2025-03-12")


<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-306499

<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates


<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
