### PR TITLE
Add Aliases to IPA Validation Rulesets

### DIFF
--- a/tools/spectral/ipa/__tests__/__helpers__/testRule.js
+++ b/tools/spectral/ipa/__tests__/__helpers__/testRule.js
@@ -51,5 +51,8 @@ async function createSpectral(ruleName) {
 function getRulesetForRule(ruleName, ruleset) {
   const modifiedRuleset = { rules: {} };
   modifiedRuleset.rules[ruleName] = ruleset.rules[ruleName].definition;
+  if (ruleset.aliases) {
+    modifiedRuleset.aliases = ruleset.aliases;
+  }
   return modifiedRuleset;
 }

--- a/tools/spectral/ipa/rulesets/IPA-104.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-104.yaml
@@ -9,6 +9,10 @@ functions:
   - IPA104GetMethodResponseHasNoInputFields
   - IPA104GetMethodHasNoRequestBody
 
+aliases:
+  GetOperationObject:
+    - '$.paths[*].get'
+
 rules:
   xgen-IPA-104-resource-has-GET:
     description: |
@@ -36,7 +40,7 @@ rules:
         - Different error messages are provided for standard vs singleton resources
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-get-method-returns-single-resource'
     severity: error
-    given: '$.paths[*].get.responses[*].content'
+    given: '#GetOperationObject.responses[*].content'
     then:
       field: '@key'
       function: 'IPA104GetMethodReturnsSingleResource'
@@ -50,7 +54,7 @@ rules:
         - Fails if the method lacks a 200 OK response or defines a different 2xx status code
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-get-method-response-code-is-200'
     severity: error
-    given: '$.paths[*].get'
+    given: '#GetOperationObject'
     then:
       function: 'IPA104GetResponseCodeShouldBe200OK'
   xgen-IPA-104-get-method-returns-response-suffixed-object:
@@ -63,7 +67,7 @@ rules:
         - Confirms the referenced schema name ends with "Response" suffix
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-get-method-returns-response-suffixed-object'
     severity: error
-    given: '$.paths[*].get.responses[*].content'
+    given: '#GetOperationObject.responses[*].content'
     then:
       field: '@key'
       function: 'IPA104GetMethodReturnsResponseSuffixedObject'
@@ -77,7 +81,7 @@ rules:
         - Fails if any writeOnly properties are found in the response schema
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-get-method-response-has-no-input-fields'
     severity: error
-    given: '$.paths[*].get.responses[*].content'
+    given: '#GetOperationObject.responses[*].content'
     then:
       field: '@key'
       function: 'IPA104GetMethodResponseHasNoInputFields'
@@ -90,6 +94,6 @@ rules:
         - Verifies that the operation object does not contain a requestBody property
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-104-get-method-no-request-body'
     severity: error
-    given: '$.paths[*].get'
+    given: '#GetOperationObject'
     then:
       function: 'IPA104GetMethodHasNoRequestBody'

--- a/tools/spectral/ipa/rulesets/IPA-105.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-105.yaml
@@ -7,6 +7,10 @@ functions:
   - IPA105EachResourceHasListMethod
   - IPA105ListMethodResponseIsGetMethodResponse
 
+aliases:
+  GetOperationObject:
+    - '$.paths[*].get'
+
 rules:
   xgen-IPA-105-list-method-response-code-is-200:
     description: |
@@ -20,7 +24,7 @@ rules:
         - Fails if the method lacks a 200 OK response or defines a different 2xx status code
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-105-list-method-response-code-is-200'
     severity: error
-    given: '$.paths[*].get'
+    given: '#GetOperationObject'
     then:
       function: 'IPA105ListResponseCodeShouldBe200OK'
   xgen-IPA-105-list-method-no-request-body:
@@ -34,7 +38,7 @@ rules:
         - Verifies that the operation object does not contain a requestBody property
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-105-list-method-no-request-body'
     severity: error
-    given: '$.paths[*].get'
+    given: '#GetOperationObject'
     then:
       function: 'IPA105ListMethodHasNoRequestBody'
   xgen-IPA-105-resource-has-list:
@@ -69,7 +73,7 @@ rules:
         - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-105-list-method-response-is-get-method-response'
     severity: error
-    given: '$.paths[*].get.responses.200.content'
+    given: '#GetOperationObject.responses.200.content'
     then:
       field: '@key'
       function: 'IPA105ListMethodResponseIsGetMethodResponse'

--- a/tools/spectral/ipa/rulesets/IPA-106.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-106.yaml
@@ -9,6 +9,10 @@ functions:
   - IPA106CreateMethodResponseCodeIs201Created
   - IPA106CreateMethodResponseIsGetMethodResponse
 
+aliases:
+  CreateOperationObject:
+    - '$.paths[*].post'
+
 rules:
   xgen-IPA-106-create-method-request-body-is-request-suffixed-object:
     description: |
@@ -22,7 +26,7 @@ rules:
         - Confirms the referenced schema name ends with "Request" suffix
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-106-create-method-request-body-is-request-suffixed-object'
     severity: error
-    given: '$.paths[*].post.requestBody.content'
+    given: '#CreateOperationObject.requestBody.content'
     then:
       field: '@key'
       function: 'IPA106CreateMethodRequestBodyIsRequestSuffixedObject'
@@ -37,7 +41,7 @@ rules:
         - Ignores specified parameters like 'pretty' and 'envelope' via configuration
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-106-create-method-should-not-have-query-parameters'
     severity: error
-    given: '$.paths[*].post'
+    given: '#CreateOperationObject'
     then:
       function: 'IPA106CreateMethodShouldNotHaveQueryParameters'
       functionOptions:
@@ -56,7 +60,7 @@ rules:
         - `oneOf` and `discriminator` definitions must match exactly.
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-106-create-method-request-body-is-get-method-response:'
     severity: error
-    given: '$.paths[*].post.requestBody.content'
+    given: '#CreateOperationObject.requestBody.content'
     then:
       field: '@key'
       function: 'IPA106CreateMethodRequestBodyIsGetResponse'
@@ -72,7 +76,7 @@ rules:
         - Fails if any readOnly properties are found in the request schema
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-106-create-method-request-has-no-readonly-fields'
     severity: error
-    given: '$.paths[*].post.requestBody.content'
+    given: '#CreateOperationObject.requestBody.content'
     then:
       field: '@key'
       function: 'IPA106CreateMethodRequestHasNoReadonlyFields'
@@ -87,7 +91,7 @@ rules:
         - Fails if the method lacks a 201 Created response or defines a different 2xx status code
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-106-create-method-response-code-is-201'
     severity: error
-    given: '$.paths[*].post'
+    given: '#CreateOperationObject'
     then:
       function: 'IPA106CreateMethodResponseCodeIs201Created'
   xgen-IPA-106-create-method-response-is-get-method-response:
@@ -104,7 +108,7 @@ rules:
         - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-106-create-method-response-is-get-method-response'
     severity: error
-    given: '$.paths[*].post.responses.201.content'
+    given: '#CreateOperationObject.responses.201.content'
     then:
       field: '@key'
       function: 'IPA106CreateMethodResponseIsGetMethodResponse'

--- a/tools/spectral/ipa/rulesets/IPA-107.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-107.yaml
@@ -9,6 +9,10 @@ functions:
   - IPA107UpdateMethodRequestBodyIsGetResponse
   - IPA107UpdateMethodRequestBodyIsUpdateRequestSuffixedObject
 
+aliases:
+  UpdateOperationObject:
+    - '$.paths[*][put,patch]'
+
 rules:
   xgen-IPA-107-update-must-not-have-query-params:
     description: >-
@@ -22,7 +26,7 @@ rules:
         - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-must-not-have-query-params'
     severity: error
-    given: '$.paths[*][put,patch]'
+    given: '#UpdateOperationObject'
     then:
       function: 'IPA107UpdateMethodMustNotHaveQueryParams'
       functionOptions:
@@ -38,7 +42,7 @@ rules:
         - Operation objects with `x-xgen-IPA-exception` for this rule are excluded from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-method-response-code-is-200'
     severity: error
-    given: '$.paths[*][put,patch]'
+    given: '#UpdateOperationObject'
     then:
       function: 'IPA107UpdateResponseCodeShouldBe200OK'
   xgen-IPA-107-update-method-response-is-get-method-response:
@@ -54,7 +58,7 @@ rules:
         - Paths with `x-xgen-IPA-exception` for this rule are excluded from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-method-response-is-get-method-response'
     severity: error
-    given: '$.paths[*][put,patch].responses.200.content'
+    given: '#UpdateOperationObject.responses.200.content'
     then:
       field: '@key'
       function: 'IPA107UpdateMethodResponseIsGetMethodResponse'
@@ -70,7 +74,7 @@ rules:
         - Fails if any readOnly properties are found in the request schema
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-method-request-has-no-readonly-fields'
     severity: error
-    given: '$.paths[*][put,patch].requestBody.content'
+    given: '#UpdateOperationObject.requestBody.content'
     then:
       field: '@key'
       function: 'IPA107UpdateMethodRequestHasNoReadonlyFields'
@@ -88,7 +92,7 @@ rules:
         - `oneOf` and `discriminator` definitions must match exactly.
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-method-request-body-is-get-method-response:'
     severity: error
-    given: '$.paths[*][put,patch].requestBody.content'
+    given: '#UpdateOperationObject.requestBody.content'
     then:
       field: '@key'
       function: 'IPA107UpdateMethodRequestBodyIsGetResponse'
@@ -104,7 +108,7 @@ rules:
         - Confirms the referenced schema name ends with "Request" suffix
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-107-update-method-request-body-is-update-request-suffixed-object'
     severity: error
-    given: '$.paths[*][put,patch].requestBody.content'
+    given: '#UpdateOperationObject.requestBody.content'
     then:
       field: '@key'
       function: 'IPA107UpdateMethodRequestBodyIsUpdateRequestSuffixedObject'

--- a/tools/spectral/ipa/rulesets/IPA-108.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-108.yaml
@@ -1,6 +1,10 @@
 # IPA-108: Delete
 # http://go/ipa/108
 
+aliases:
+  DeleteOperationObject:
+    - '$.paths[*].delete'
+
 rules:
   xgen-IPA-108-delete-response-should-be-empty:
     description: |
@@ -14,7 +18,7 @@ rules:
         - Skips validation for collection endpoints (without path parameters)
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-delete-response-should-be-empty'
     severity: error
-    given: $.paths[*].delete.responses[204]
+    given: '#DeleteOperationObject.responses[204]'
     then:
       function: IPA108DeleteMethodResponseShouldNotHaveSchema
 
@@ -32,7 +36,7 @@ rules:
         - Skips validation for collection endpoints (without path parameters)
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-delete-method-return-204-response'
     severity: error
-    given: $.paths[*].delete
+    given: '#DeleteOperationObject'
     then:
       function: IPA108DeleteMethod204Response
 
@@ -48,7 +52,7 @@ rules:
         - Skips validation for collection endpoints (without path parameters)
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-108-delete-request-no-body'
     severity: error
-    given: $.paths[*].delete
+    given: '#DeleteOperationObject'
     then:
       function: IPA108DeleteMethodNoRequestBody
 

--- a/tools/spectral/ipa/rulesets/IPA-110.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-110.yaml
@@ -9,6 +9,12 @@ functions:
   - IPA110CollectionsRequestIncludeCountNotRequired
   - IPA110CollectionsResponseDefineLinksArray
 
+aliases:
+  Get200ResponseContent:
+    - '$.paths[*].get.responses.200.content'
+  GetOperationObject:
+    - '$.paths[*].get'
+
 rules:
   xgen-IPA-110-collections-use-paginated-prefix:
     description: |
@@ -21,7 +27,7 @@ rules:
         - Checks that the 200 response schema references a schema with a "Paginated" prefix
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-110-collections-use-paginated-prefix'
     severity: error
-    given: '$.paths[*].get.responses.200.content'
+    given: '#Get200ResponseContent'
     then:
       field: '@key'
       function: 'IPA110CollectionsUsePaginatedPrefix'
@@ -35,7 +41,7 @@ rules:
         - Verifies the 200 response schema has the required results fields
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-110-collections-response-define-results-array'
     severity: error
-    given: '$.paths[*].get.responses.200.content'
+    given: '#Get200ResponseContent'
     then:
       field: '@key'
       function: 'IPA110CollectionsResponseDefineResultsArray'
@@ -53,7 +59,7 @@ rules:
         - Verifies the itemsPerPage query parameter has a default value of 100
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-110-collections-request-has-itemsPerPage-query-param'
     severity: error
-    given: '$.paths[*].get'
+    given: '#GetOperationObject'
     then:
       function: 'IPA110CollectionsRequestHasItemsPerPageQueryParam'
   xgen-IPA-110-collections-request-has-pageNum-query-param:
@@ -70,7 +76,7 @@ rules:
         - Verifies the pageNum query parameter has a default value of 1
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-110-collections-request-has-pageNum-query-param'
     severity: error
-    given: '$.paths[*].get'
+    given: '#GetOperationObject'
     then:
       function: 'IPA110CollectionsRequestHasPageNumQueryParam'
   xgen-IPA-110-collections-request-includeCount-not-required:
@@ -84,7 +90,7 @@ rules:
         - If it exists, verifies the includeCount parameter is not required
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-110-collections-request-includeCount-not-required'
     severity: error
-    given: '$.paths[*].get'
+    given: '#GetOperationObject'
     then:
       function: 'IPA110CollectionsRequestIncludeCountNotRequired'
   xgen-IPA-110-collections-response-define-links-array:
@@ -97,7 +103,7 @@ rules:
         - Verifies the response schema includes a links field of type array
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-110-collections-response-define-links-array'
     severity: error
-    given: '$.paths[*].get.responses.200.content'
+    given: '#Get200ResponseContent'
     then:
       field: '@key'
       function: 'IPA110CollectionsResponseDefineLinksArray'

--- a/tools/spectral/ipa/rulesets/IPA-114.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-114.yaml
@@ -7,6 +7,10 @@ functions:
   - IPA114AuthenticatedEndpointsHaveAuthErrors
   - IPA114ParameterizedPathsHave404NotFound
 
+aliases:
+  OperationObject:
+    - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
+
 rules:
   xgen-IPA-114-error-responses-refer-to-api-error:
     description: |
@@ -44,7 +48,7 @@ rules:
       and not containing '/unauth' in the path) include 401 and 403 responses.
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-114-authenticated-endpoints-have-auth-errors'
     severity: error
-    given: '$.paths[*][get,put,post,delete,options,head,patch,trace]'
+    given: '#OperationObject'
     then:
       function: 'IPA114AuthenticatedEndpointsHaveAuthErrors'
   xgen-IPA-114-parameterized-paths-have-404-not-found:
@@ -57,6 +61,6 @@ rules:
       is not found.
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-114-parameterized-paths-have-not-found'
     severity: error
-    given: '$.paths[*][get,put,post,delete,options,head,patch,trace]'
+    given: '#OperationObject'
     then:
       function: 'IPA114ParameterizedPathsHave404NotFound'

--- a/tools/spectral/ipa/rulesets/IPA-117.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-117.yaml
@@ -12,6 +12,17 @@ functions:
   - IPA117ObjectsMustBeWellDefined
   - IPA117ParameterHasExamplesOrSchema
 
+aliases:
+  OperationObject:
+    - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
+  DescribableObjects:
+    - '$.tags[*]'
+    - '#OperationObject'
+    - '#OperationObject.parameters[*]'
+    - '#OperationObject..content..properties[*]'
+    - '$.components.schemas..properties[*]'
+    - '$.components.parameters[*]'
+
 rules:
   xgen-IPA-117-description:
     description: |
@@ -30,12 +41,7 @@ rules:
     severity: error
     given:
       - '$.info'
-      - '$.tags[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
-      - '$.components.schemas..properties[*]'
-      - '$.components.parameters[*]'
+      - '#DescribableObjects'
     then:
       function: 'IPA117HasDescription'
   xgen-IPA-117-description-starts-with-uppercase:
@@ -54,12 +60,7 @@ rules:
     severity: error
     given:
       - '$.info'
-      - '$.tags[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
-      - '$.components.schemas..properties[*]'
-      - '$.components.parameters[*]'
+      - '#DescribableObjects'
     then:
       function: 'IPA117DescriptionStartsWithUpperCase'
   xgen-IPA-117-description-ends-with-period:
@@ -79,12 +80,7 @@ rules:
     severity: error
     given:
       - '$.info'
-      - '$.tags[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
-      - '$.components.schemas..properties[*]'
-      - '$.components.parameters[*]'
+      - '#DescribableObjects'
     then:
       function: 'IPA117DescriptionEndsWithPeriod'
   xgen-IPA-117-description-must-not-use-html:
@@ -104,12 +100,7 @@ rules:
     severity: error
     given:
       - '$.info'
-      - '$.tags[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
-      - '$.components.schemas..properties[*]'
-      - '$.components.parameters[*]'
+      - '#DescribableObjects'
     then:
       function: 'IPA117DescriptionMustNotUseHtml'
   xgen-IPA-117-description-should-not-use-inline-tables:
@@ -129,12 +120,7 @@ rules:
     severity: error
     given:
       - '$.info'
-      - '$.tags[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
-      - '$.components.schemas..properties[*]'
-      - '$.components.parameters[*]'
+      - '#DescribableObjects'
     then:
       function: 'IPA117DescriptionShouldNotUseTables'
   xgen-IPA-117-description-should-not-use-inline-links:
@@ -152,12 +138,7 @@ rules:
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-description-should-not-use-inline-links'
     severity: error
     given:
-      - '$.tags[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
-      - '$.components.schemas..properties[*]'
-      - '$.components.parameters[*]'
+      - '#DescribableObjects'
     then:
       function: 'IPA117DescriptionShouldNotUseLinks'
   xgen-IPA-117-plaintext-response-must-have-example:
@@ -172,7 +153,7 @@ rules:
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-plaintext-response-must-have-example'
     severity: error
     given:
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].responses[*].content'
+      - '#OperationObject.responses[*].content'
     then:
       field: '@key'
       function: 'IPA117PlaintextResponseMustHaveExample'
@@ -201,9 +182,9 @@ rules:
     severity: error
     resolved: false
     given:
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties[*]'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..items'
+      - '#OperationObject..content[*]'
+      - '#OperationObject..content..properties[*]'
+      - '#OperationObject..content..items'
       - '$.components.schemas[*]'
       - '$.components.schemas..properties[*]'
       - '$.components.schemas..items'
@@ -224,7 +205,7 @@ rules:
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-117-parameter-has-examples-or-schema'
     severity: error
     given:
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters[*]'
+      - '#OperationObject.parameters[*]'
       - '$.components.parameters[*]'
     then:
       function: 'IPA117ParameterHasExamplesOrSchema'

--- a/tools/spectral/ipa/rulesets/IPA-119.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-119.yaml
@@ -3,6 +3,11 @@
 
 functions:
   - IPA119NoDefaultForCloudProviders
+
+aliases:
+  OperationObject:
+    - '$.paths[*][get,put,post,delete,options,head,patch,trace]'
+
 rules:
   xgen-IPA-119-no-default-for-cloud-providers:
     description: |
@@ -14,8 +19,8 @@ rules:
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-119-no-default-for-cloud-providers'
     given:
       # Target properties with "cloudProvider" in their name
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace].parameters'
-      - '$.paths[*][get,put,post,delete,options,head,patch,trace]..content..properties'
+      - '#OperationObject.parameters'
+      - '#OperationObject..content..properties'
       - '$.components.schemas..properties'
     then:
       field: '@key'


### PR DESCRIPTION
Adds aliases to IPA Spectral rulesets to minimize duplication and increase reusability of similar `given` statements. Note: Aliases cannot be inherited from other spectral files, so they must be added to each yaml
