### PR TITLE
CLOUDP-315586: Postman API retry on any error code

### DIFF
--- a/tools/postman/scripts/upload-collection.sh
+++ b/tools/postman/scripts/upload-collection.sh
@@ -103,7 +103,7 @@ else
      --data ${collection_transformed_path}"
 
   execute_curl --request PUT --retry 3 --retry-delay 30 --retry-max-time 1200 \
-     --show-error --fail --silent \
+     --show-error --fail --silent --retry-all-errors \
      --location "https://api.getpostman.com/collections/${collection_id}" \
      --header "Content-Type: application/json" \
      --header "X-API-Key: ${POSTMAN_API_KEY}" \


### PR DESCRIPTION
## Proposed changes

Previous change removed --retry-all-errors, so we weren't retrying on the 4xx API response
Reintroducing retry on 4xx here

Jira ticket: #[CLOUDP-315586](https://jira.mongodb.org/browse/CLOUDP-315586)
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->


<!--
What issue does this PR address? (for example, #1234), remove this section if none.
-->


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works

### Changes to Spectral
- [ ] I have read the [README](../tools/spectral/README.md) file for Spectral Updates

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
