### PR TITLE
chore: run foascli code-health workflow when updating dependencies

### DIFF
--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -5,11 +5,13 @@ on:
       - main
     paths: 
       - 'tools/cli/**'
+      - '.github/workflows/code-health-foascli.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'tools/cli/**'
+      - '.github/workflows/code-health-foascli.yml'
   workflow_dispatch: {}
   workflow_call: {}
 

--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -6,14 +6,12 @@ on:
     paths: 
       - 'tools/postman/**'
       - 'tools/spectral/**'
-      - '.github/workflows/code-health-tools.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'tools/postman/**'
       - 'tools/spectral/**'
-      - '.github/workflows/code-health-tools.yml'
   workflow_dispatch: {}
   workflow_call: {}
 

--- a/.github/workflows/code-health-tools.yml
+++ b/.github/workflows/code-health-tools.yml
@@ -6,12 +6,14 @@ on:
     paths: 
       - 'tools/postman/**'
       - 'tools/spectral/**'
+      - '.github/workflows/code-health-tools.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'tools/postman/**'
       - 'tools/spectral/**'
+      - '.github/workflows/code-health-tools.yml'
   workflow_dispatch: {}
   workflow_call: {}
 


### PR DESCRIPTION
## Proposed changes
Updates the foascli workflow to run when dependatot updates go dependencies.