### PR TITLE
chore: updates `golangci-lint-action`

### DIFF
--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -5,11 +5,13 @@ on:
       - main
     paths: 
       - 'tools/cli/**'
+      - '.github/workflows/code-health-foascli.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'tools/cli/**'
+      - '.github/workflows/code-health-foascli.yml'
   workflow_dispatch: {}
   workflow_call: {}
 
@@ -65,9 +67,9 @@ jobs:
           go-version-file: 'tools/cli/go.mod'
           cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:
-          version: v2.0.1
+          version: v2.1.0
           working-directory: tools/cli
       - name: Checkout GitHub actions
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332

--- a/tools/cli/Makefile
+++ b/tools/cli/Makefile
@@ -1,6 +1,6 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
-GOLANGCI_VERSION=v2.0.1
+GOLANGCI_VERSION=v2.1.0
 SOURCE_FILES?=./cmd
 BINARY_NAME=foascli
 VERSION=v0.0.1


### PR DESCRIPTION
## Proposed changes
This PR updates `golangci-lint-action` to 8.0.0