### PR TITLE
CLOUDP-310535: Enable IPA validation on all env FOASes

### DIFF
--- a/.github/workflows/optional-spec-validations.yml
+++ b/.github/workflows/optional-spec-validations.yml
@@ -41,7 +41,6 @@ jobs:
           run-id: ${{ github.run_id }}
       - name: Run IPA validation
         id: ipa-spectral-validation
-        if: ${{ inputs.env == 'dev'}}
         run: |
           npx spectral lint openapi-foas.json --ruleset=./tools/spectral/ipa/ipa-spectral.yaml
       - name: Validate the FOAS can be used to generate Postman collection


### PR DESCRIPTION
## Proposed changes

Now that IPAs are rolled out, we can re-enable running them on all envs for the optional-spec-validation action.

_Jira ticket:_ [CLOUDP-310535](https://jira.mongodb.org/browse/CLOUDP-310535)
