### PR TITLE
CLOUDP-295480: Migrate to Assume-Role for IPA Metric Collection

### DIFF
--- a/.github/workflows/release-IPA-metrics.yml
+++ b/.github/workflows/release-IPA-metrics.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   issues: write
   contents: write
+  id-token: write
 
 jobs:
   # Generates and uploads the IPA validation metrics to S3
@@ -40,10 +41,15 @@ jobs:
         working-directory: tools/spectral/ipa/metrics/scripts
         run: node runMetricCollection.js "${{ github.workspace }}/v2.json"
 
+      - name: aws configure
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.IPA_METRIC_COLLECTION_AWS_S3_ROLE_TO_ASSUME_PROD }}
+          aws-region: ${{ vars.AWS_DEFAULT_REGION }}
+
       - name: Dump Metric Collection Job Data to S3
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.IPA_S3_BUCKET_DW_PROD_USERNAME }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.IPA_S3_BUCKET_DW_PROD_PASSWORD }}
+          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
           S3_BUCKET_PREFIX: ${{ secrets.IPA_S3_BUCKET_DW_PROD_PREFIX }}
         working-directory: tools/spectral/ipa/metrics/scripts
         run: node dataDump.js

--- a/tools/spectral/ipa/metrics/utils/dataDumpUtils.js
+++ b/tools/spectral/ipa/metrics/utils/dataDumpUtils.js
@@ -10,9 +10,7 @@ function loadS3Config() {
   }
   return {
     aws: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-      region: 'us-east-1',
+      region: process.env.AWS_REGION,
     },
     s3: {
       prefix: process.env.S3_BUCKET_PREFIX,
@@ -29,14 +27,14 @@ export function getS3FilePath() {
   return { bucketName, key };
 }
 
+/**
+ * Gets an S3 client configured to use AssumeRole credentials
+ * @returns {S3Client} Configured S3 client
+ */
 export function getS3Client() {
-  const AWSConfig = loadS3Config();
+  const S3Config = loadS3Config();
 
-  return new S3Client({
-    credentials: {
-      accessKeyId: AWSConfig.aws.accessKeyId,
-      secretAccessKey: AWSConfig.aws.secretAccessKey,
-    },
-    region: AWSConfig.aws.region,
-  });
+  // When running in GitHub Actions with aws-actions/configure-aws-credentials,
+  // the SDK will automatically use the credentials from the environment
+  return new S3Client({ region: S3Config.aws.region });
 }


### PR DESCRIPTION
## Proposed changes

Updated IPA metrics collection to use assume-role approach instead of API Keys. Tested with staging in previous [POC](https://github.com/mongodb/openapi/pull/558) and on this branch with prod

Post-merge:
- Will update wiki
- Will remove the unused API keys from the repo

_Jira ticket:_ [CLOUDP-295480](https://jira.mongodb.org/browse/CLOUDP-295480)
