### PR TITLE
CLOUDP-314000: Clarify IPA-124 maxItems rule description

### DIFF
--- a/tools/spectral/ipa/rulesets/IPA-124.yaml
+++ b/tools/spectral/ipa/rulesets/IPA-124.yaml
@@ -7,16 +7,16 @@ functions:
 rules:
   xgen-IPA-124-array-max-items:
     description: |
-      Array fields must have a maxItems property defined to enforce an upper bound on the number of items (recommended max: 100). If the array field has the chance of being too large, the API should use a sub-resource instead.
+      Array fields must have a `maxItems` property defined to enforce an upper bound on the number of items (recommended max: 100). If the array field has the chance of being too large, the API should use a sub-resource instead.
 
       ##### Implementation details
       Rule checks for the following conditions:
 
-        - All schema objects with type 'array' must have a maxItems property
-        - The maxItems value must be set below the threshold of 100
+        - All schema objects with type 'array' must have a `maxItems` property
+        - The `maxItems` value must be lower than or equal to 100
 
       ##### Function options
-              - maxItems: Required integer parameter specifying the maximum allowed array size (default: 100)
+              - maxAllowedValue: Required integer parameter specifying the maximum allowed value for the `maxItems` property (100)
               - ignore: Required array parameter listing property names to be exempted from validation
     message: '{{error}} https://mdb.link/mongodb-atlas-openapi-validation#xgen-IPA-124-array-max-items'
     severity: error
@@ -25,7 +25,7 @@ rules:
     then:
       function: IPA124ArrayMaxItems
       functionOptions:
-        maxItems: 100
+        maxAllowedValue: 100
         ignore:
           - links
           - results

--- a/tools/spectral/ipa/rulesets/README.md
+++ b/tools/spectral/ipa/rulesets/README.md
@@ -852,16 +852,16 @@ Rules are based on [http://go/ipa/IPA-124](http://go/ipa/IPA-124).
 #### xgen-IPA-124-array-max-items
 
  ![error](https://img.shields.io/badge/error-red) 
-Array fields must have a maxItems property defined to enforce an upper bound on the number of items (recommended max: 100). If the array field has the chance of being too large, the API should use a sub-resource instead.
+Array fields must have a `maxItems` property defined to enforce an upper bound on the number of items (recommended max: 100). If the array field has the chance of being too large, the API should use a sub-resource instead.
 
 ##### Implementation details
 Rule checks for the following conditions:
 
-  - All schema objects with type 'array' must have a maxItems property
-  - The maxItems value must be set below the threshold of 100
+  - All schema objects with type 'array' must have a `maxItems` property
+  - The `maxItems` value must be lower than or equal to 100
 
 ##### Function options
-        - maxItems: Required integer parameter specifying the maximum allowed array size (default: 100)
+        - maxAllowedValue: Required integer parameter specifying the maximum allowed value for the `maxItems` property (100)
         - ignore: Required array parameter listing property names to be exempted from validation
 
 

--- a/tools/spectral/ipa/rulesets/functions/IPA124ArrayMaxItems.js
+++ b/tools/spectral/ipa/rulesets/functions/IPA124ArrayMaxItems.js
@@ -15,7 +15,7 @@ const RULE_NAME = 'xgen-IPA-124-array-max-items';
  * @param {object} options - Rule configuration options
  * @param {object} context - The context object containing the path and documentInventory
  */
-export default (input, { maxItems, ignore = [] }, { path }) => {
+export default (input, { maxAllowedValue, ignore = [] }, { path }) => {
   // Check for exception at the schema level
   if (hasException(input, RULE_NAME)) {
     collectException(input, RULE_NAME, path);
@@ -36,7 +36,7 @@ export default (input, { maxItems, ignore = [] }, { path }) => {
     return;
   }
 
-  const errors = checkViolationsAndReturnErrors(input, path, maxItems);
+  const errors = checkViolationsAndReturnErrors(input, path, maxAllowedValue);
   if (errors.length > 0) {
     return collectAndReturnViolation(path, RULE_NAME, errors);
   }
@@ -44,7 +44,7 @@ export default (input, { maxItems, ignore = [] }, { path }) => {
   collectAdoption(path, RULE_NAME);
 };
 
-function checkViolationsAndReturnErrors(input, path, maxItems) {
+function checkViolationsAndReturnErrors(input, path, maxAllowedValue) {
   try {
     // Check if maxItems is defined
     if (input.maxItems === undefined) {
@@ -56,10 +56,10 @@ function checkViolationsAndReturnErrors(input, path, maxItems) {
       ];
     }
     // Check if maxItems is larger than the recommended value
-    else if (input.maxItems > maxItems) {
+    else if (input.maxItems > maxAllowedValue) {
       return [
         {
-          message: `The maxItems value for arrays must be set to ${maxItems} or below, found: ${input.maxItems}. If the array field has the chance of being too large, the API should use a sub-resource instead.`,
+          message: `The maxItems value for arrays must be set to ${maxAllowedValue} or below, found: ${input.maxItems}. If the array field has the chance of being too large, the API should use a sub-resource instead.`,
           path,
         },
       ];


### PR DESCRIPTION
## Proposed changes

Based on feedback there was some confusion about the max allowed value for the `maxItems` property, since "default" was mentioned, it can be confused with the openapi property `default` or that this field is set to 100 by default. 

Clarified description of rule that 100 is the recommended max size of an array, and that the `maxItems` property value should not be larger than that.

_Jira ticket:_ [CLOUDP-314000](https://jira.mongodb.org/browse/CLOUDP-314000)
