### PR TITLE
CLOUDP-321939: Fix curl examples for POST/PU/PATCH

### DIFF
--- a/tools/cli/internal/openapi/filter/code_sample.go
+++ b/tools/cli/internal/openapi/filter/code_sample.go
@@ -66,8 +66,8 @@ func (f *CodeSampleFilter) newCurlCodeSamplesForOperation(pathName, opMethod str
 		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName + "\""
 	case "POST", "PATCH", "PUT":
 		source += "--header \"Content-Type: application/vnd.atlas." + version + "+json\" \\\n  "
-		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName + "\"\n  "
-		source += "-d " + "{ <Payload> }"
+		source += "-X " + opMethod + " \"https://cloud.mongodb.com" + pathName + "\" \\\n  "
+		source += "-d " + "'{ <Payload> }'"
 	}
 
 	return codeSample{

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
@@ -772,7 +772,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -907,7 +907,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1139,7 +1139,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1392,7 +1392,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1605,7 +1605,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1872,7 +1872,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2030,7 +2030,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2393,7 +2393,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2616,7 +2616,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2701,7 +2701,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3022,7 +3022,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3240,7 +3240,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3406,7 +3406,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3487,7 +3487,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3613,7 +3613,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3736,7 +3736,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3879,7 +3879,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4169,7 +4169,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4297,7 +4297,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4535,7 +4535,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4691,7 +4691,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4857,7 +4857,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4937,7 +4937,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5185,7 +5185,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5348,7 +5348,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5588,7 +5588,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5973,7 +5973,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6136,7 +6136,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6630,7 +6630,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6722,7 +6722,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6811,7 +6811,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7381,7 +7381,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7754,7 +7754,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7991,7 +7991,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8175,7 +8175,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8351,7 +8351,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8524,7 +8524,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8913,7 +8913,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9154,7 +9154,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9322,7 +9322,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9390,7 +9390,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9566,7 +9566,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9882,7 +9882,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9968,7 +9968,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10118,7 +10118,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10467,7 +10467,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10817,7 +10817,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11121,7 +11121,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11259,7 +11259,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11485,7 +11485,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11633,7 +11633,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11853,7 +11853,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12175,7 +12175,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12567,7 +12567,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12823,7 +12823,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12993,7 +12993,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13368,7 +13368,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13515,7 +13515,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14622,7 +14622,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14725,7 +14725,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14869,7 +14869,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14937,7 +14937,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15160,7 +15160,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15564,7 +15564,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15644,7 +15644,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15725,7 +15725,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15934,7 +15934,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16109,7 +16109,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16163,7 +16163,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16217,7 +16217,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16388,7 +16388,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16668,7 +16668,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16897,7 +16897,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17026,7 +17026,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17249,7 +17249,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17487,7 +17487,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17559,7 +17559,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17901,7 +17901,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17973,7 +17973,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18102,7 +18102,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18254,7 +18254,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18501,7 +18501,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18849,7 +18849,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19174,7 +19174,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19315,7 +19315,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20891,7 +20891,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20964,7 +20964,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21036,7 +21036,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21240,7 +21240,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21408,7 +21408,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21797,7 +21797,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22026,7 +22026,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22161,7 +22161,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22318,7 +22318,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22485,7 +22485,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22611,7 +22611,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22793,7 +22793,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23104,7 +23104,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23259,7 +23259,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23464,7 +23464,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23604,7 +23604,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23833,7 +23833,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24011,7 +24011,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24254,7 +24254,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24811,7 +24811,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24883,7 +24883,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25109,7 +25109,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25655,7 +25655,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25790,7 +25790,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25945,7 +25945,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26268,7 +26268,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26450,7 +26450,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26771,7 +26771,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26839,7 +26839,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
@@ -28642,8 +28642,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateConnectedOrgConfig --help
@@ -28730,8 +28730,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRoleMapping --help
@@ -28885,8 +28885,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateRoleMapping --help
@@ -29056,8 +29056,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateIdentityProvider --help
@@ -29195,8 +29195,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProject --help
@@ -29320,8 +29320,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProject --help
@@ -29418,8 +29418,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectIpAccessList --help
@@ -29663,8 +29663,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAlertConfiguration --help
@@ -29823,8 +29823,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAlertConfiguration --help
@@ -29886,8 +29886,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAlertConfiguration --help
@@ -30104,8 +30104,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api acknowledgeAlert --help
@@ -30244,8 +30244,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectApiKey --help
@@ -30352,8 +30352,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKeyRoles --help
@@ -30407,8 +30407,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectApiKey --help
@@ -30489,8 +30489,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAuditingConfiguration --help
@@ -30569,8 +30569,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAWSCustomDNS --help
@@ -30661,8 +30661,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createExportBucket --help
@@ -30856,8 +30856,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDataProtectionSettings --help
@@ -30940,8 +30940,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCloudProviderAccessRole --help
@@ -31098,8 +31098,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api authorizeCloudProviderAccessRole --help
@@ -31198,8 +31198,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCluster --help
@@ -31365,8 +31365,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCluster --help
@@ -31472,8 +31472,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupExportJob --help
@@ -31632,8 +31632,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupRestoreJob --help
@@ -31894,8 +31894,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateBackupSchedule --help
@@ -32003,8 +32003,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api takeSnapshot --help
@@ -32178,8 +32178,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateSnapshotRetention --help
@@ -32396,8 +32396,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api downloadSharedClusterBackup --help
@@ -32456,8 +32456,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createSharedClusterBackupRestoreJob --help
@@ -32832,8 +32832,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndexDeprecated --help
@@ -33086,8 +33086,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexDeprecated --help
@@ -33246,8 +33246,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomZoneMapping --help
@@ -33370,8 +33370,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createManagedNamespace --help
@@ -33493,8 +33493,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRollingIndex --help
@@ -33606,8 +33606,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOnlineArchive --help
@@ -33796,8 +33796,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOnlineArchive --help
@@ -34032,8 +34032,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startOutageSimulation --help
@@ -34146,8 +34146,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateClusterAdvancedConfiguration --help
@@ -34193,8 +34193,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api testFailover --help
@@ -34312,8 +34312,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLegacyBackupRestoreJob --help
@@ -34527,8 +34527,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchDeployment --help
@@ -34586,8 +34586,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchDeployment --help
@@ -34693,8 +34693,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotSchedule --help
@@ -34926,8 +34926,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotRetention --help
@@ -35157,8 +35157,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedCluster --help
@@ -35210,8 +35210,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedClusterToServerless --help
@@ -35314,8 +35314,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringContainer --help
@@ -35473,8 +35473,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringContainer --help
@@ -35602,8 +35602,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomDatabaseRole --help
@@ -35749,8 +35749,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCustomDatabaseRole --help
@@ -35846,8 +35846,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createFederatedDatabase --help
@@ -35990,8 +35990,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateFederatedDatabase --help
@@ -36228,8 +36228,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOneDataFederationQueryLimit --help
@@ -36476,8 +36476,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUser --help
@@ -36683,8 +36683,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDatabaseUser --help
@@ -36797,8 +36797,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUserCertificate --help
@@ -37059,8 +37059,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateEncryptionAtRest --help
@@ -37155,8 +37155,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createEncryptionAtRestPrivateEndpoint --help
@@ -37884,8 +37884,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createThirdPartyIntegration --help
@@ -37953,8 +37953,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateThirdPartyIntegration --help
@@ -38048,8 +38048,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitation --help
@@ -38094,8 +38094,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectInvitation --help
@@ -38246,8 +38246,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitationById --help
@@ -38571,8 +38571,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setProjectLimit --help
@@ -38632,8 +38632,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushMigration --help
@@ -38717,8 +38717,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api cutoverMigration --help
@@ -38771,8 +38771,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api validateMigration --help
@@ -38938,8 +38938,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateMaintenanceWindow --help
@@ -38975,8 +38975,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleMaintenanceAutoDefer --help
@@ -39012,8 +39012,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api deferMaintenanceWindow --help
@@ -39122,8 +39122,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api enableSlowOperationThresholding --help
@@ -39303,8 +39303,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringConnection --help
@@ -39455,8 +39455,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringConnection --help
@@ -39541,8 +39541,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPipeline --help
@@ -39691,8 +39691,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePipeline --help
@@ -39846,8 +39846,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pausePipeline --help
@@ -39895,8 +39895,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api resumePipeline --help
@@ -40121,8 +40121,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api triggerSnapshotIngestion --help
@@ -40354,8 +40354,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpoint --help
@@ -40529,8 +40529,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpointService --help
@@ -40613,8 +40613,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleRegionalizedPrivateEndpointSetting --help
@@ -40719,8 +40719,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessPrivateEndpoint --help
@@ -40888,8 +40888,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessPrivateEndpoint --help
@@ -40978,8 +40978,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api disablePeering --help
@@ -41086,8 +41086,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDataFederationPrivateEndpoint --help
@@ -42189,8 +42189,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePushBasedLogConfiguration --help
@@ -42238,8 +42238,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushBasedLogConfiguration --help
@@ -42288,8 +42288,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api loadSampleDataset --help
@@ -42419,8 +42419,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessInstance --help
@@ -42528,8 +42528,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessBackupRestoreJob --help
@@ -42786,8 +42786,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setServerlessAutoIndexing --help
@@ -42938,8 +42938,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessInstance --help
@@ -43026,8 +43026,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectSettings --help
@@ -43126,8 +43126,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addAllTeamsToProject --help
@@ -43239,8 +43239,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateTeamRoles --help
@@ -43324,8 +43324,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api saveLDAPConfiguration --help
@@ -43445,8 +43445,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api verifyLDAPConfiguration --help
@@ -43646,8 +43646,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectRoles --help
@@ -43795,8 +43795,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganization --help
@@ -43934,8 +43934,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameOrganization --help
@@ -44023,8 +44023,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKey --help
@@ -44176,8 +44176,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKey --help
@@ -44289,8 +44289,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKeyAccessList --help
@@ -44452,8 +44452,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCostExplorerQueryProcess --help
@@ -44825,8 +44825,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitation --help
@@ -44873,8 +44873,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganizationInvitation --help
@@ -45023,8 +45023,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitationById --help
@@ -45391,8 +45391,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLinkToken --help
@@ -45479,8 +45479,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationSettings --help
@@ -45578,8 +45578,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createTeam --help
@@ -45743,8 +45743,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameTeam --help
@@ -45863,8 +45863,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addTeamUser --help
@@ -46122,8 +46122,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationRoles --help
@@ -46173,8 +46173,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createUser --help

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
@@ -776,7 +776,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -911,7 +911,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1143,7 +1143,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1396,7 +1396,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1609,7 +1609,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1876,7 +1876,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1952,7 +1952,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2110,7 +2110,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2473,7 +2473,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2696,7 +2696,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2781,7 +2781,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3102,7 +3102,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3320,7 +3320,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3486,7 +3486,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3567,7 +3567,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3693,7 +3693,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3816,7 +3816,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3959,7 +3959,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4249,7 +4249,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4377,7 +4377,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4615,7 +4615,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4771,7 +4771,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4937,7 +4937,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5017,7 +5017,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5263,7 +5263,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5426,7 +5426,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5666,7 +5666,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6051,7 +6051,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6214,7 +6214,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6708,7 +6708,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6800,7 +6800,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6889,7 +6889,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7459,7 +7459,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7832,7 +7832,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8069,7 +8069,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8253,7 +8253,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8429,7 +8429,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8602,7 +8602,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8991,7 +8991,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9232,7 +9232,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9400,7 +9400,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9467,7 +9467,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9642,7 +9642,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9958,7 +9958,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10044,7 +10044,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10194,7 +10194,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10543,7 +10543,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10891,7 +10891,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11195,7 +11195,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11333,7 +11333,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11559,7 +11559,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11707,7 +11707,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11927,7 +11927,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12249,7 +12249,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12641,7 +12641,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12897,7 +12897,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13067,7 +13067,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13442,7 +13442,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13589,7 +13589,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14696,7 +14696,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14799,7 +14799,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14943,7 +14943,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15011,7 +15011,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15234,7 +15234,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15638,7 +15638,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15718,7 +15718,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15799,7 +15799,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16008,7 +16008,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16183,7 +16183,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16237,7 +16237,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16291,7 +16291,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16462,7 +16462,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16742,7 +16742,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16971,7 +16971,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17100,7 +17100,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17323,7 +17323,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17561,7 +17561,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17633,7 +17633,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17975,7 +17975,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18047,7 +18047,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18176,7 +18176,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18328,7 +18328,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18575,7 +18575,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18923,7 +18923,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19248,7 +19248,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19389,7 +19389,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20965,7 +20965,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21038,7 +21038,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21110,7 +21110,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21314,7 +21314,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21482,7 +21482,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21871,7 +21871,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22100,7 +22100,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22235,7 +22235,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22367,7 +22367,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22598,7 +22598,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22853,7 +22853,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23100,7 +23100,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23257,7 +23257,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23424,7 +23424,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23550,7 +23550,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23732,7 +23732,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24043,7 +24043,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24198,7 +24198,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24403,7 +24403,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24543,7 +24543,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24772,7 +24772,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24950,7 +24950,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25193,7 +25193,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25750,7 +25750,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25822,7 +25822,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26048,7 +26048,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26594,7 +26594,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26729,7 +26729,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26884,7 +26884,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27207,7 +27207,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27389,7 +27389,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27710,7 +27710,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27778,7 +27778,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-02-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-02-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
@@ -29006,8 +29006,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateConnectedOrgConfig --help
@@ -29094,8 +29094,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRoleMapping --help
@@ -29249,8 +29249,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateRoleMapping --help
@@ -29420,8 +29420,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateIdentityProvider --help
@@ -29559,8 +29559,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProject --help
@@ -29684,8 +29684,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProject --help
@@ -29734,8 +29734,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addUserToProject --help
@@ -29832,8 +29832,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectIpAccessList --help
@@ -30077,8 +30077,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAlertConfiguration --help
@@ -30237,8 +30237,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAlertConfiguration --help
@@ -30300,8 +30300,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAlertConfiguration --help
@@ -30518,8 +30518,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api acknowledgeAlert --help
@@ -30658,8 +30658,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectApiKey --help
@@ -30766,8 +30766,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKeyRoles --help
@@ -30821,8 +30821,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectApiKey --help
@@ -30903,8 +30903,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAuditingConfiguration --help
@@ -30983,8 +30983,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAWSCustomDNS --help
@@ -31075,8 +31075,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createExportBucket --help
@@ -31270,8 +31270,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDataProtectionSettings --help
@@ -31354,8 +31354,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCloudProviderAccessRole --help
@@ -31512,8 +31512,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api authorizeCloudProviderAccessRole --help
@@ -31612,8 +31612,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCluster --help
@@ -31777,8 +31777,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCluster --help
@@ -31884,8 +31884,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupExportJob --help
@@ -32044,8 +32044,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupRestoreJob --help
@@ -32306,8 +32306,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateBackupSchedule --help
@@ -32415,8 +32415,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api takeSnapshot --help
@@ -32590,8 +32590,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateSnapshotRetention --help
@@ -32808,8 +32808,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api downloadSharedClusterBackup --help
@@ -32868,8 +32868,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createSharedClusterBackupRestoreJob --help
@@ -33244,8 +33244,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndexDeprecated --help
@@ -33498,8 +33498,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexDeprecated --help
@@ -33658,8 +33658,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomZoneMapping --help
@@ -33782,8 +33782,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createManagedNamespace --help
@@ -33905,8 +33905,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRollingIndex --help
@@ -34018,8 +34018,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOnlineArchive --help
@@ -34208,8 +34208,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOnlineArchive --help
@@ -34444,8 +34444,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startOutageSimulation --help
@@ -34558,8 +34558,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateClusterAdvancedConfiguration --help
@@ -34604,8 +34604,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api testFailover --help
@@ -34722,8 +34722,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLegacyBackupRestoreJob --help
@@ -34937,8 +34937,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchDeployment --help
@@ -34996,8 +34996,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchDeployment --help
@@ -35103,8 +35103,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotSchedule --help
@@ -35336,8 +35336,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotRetention --help
@@ -35565,8 +35565,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedCluster --help
@@ -35618,8 +35618,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedClusterToServerless --help
@@ -35722,8 +35722,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringContainer --help
@@ -35881,8 +35881,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringContainer --help
@@ -36010,8 +36010,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomDatabaseRole --help
@@ -36157,8 +36157,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCustomDatabaseRole --help
@@ -36254,8 +36254,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createFederatedDatabase --help
@@ -36398,8 +36398,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateFederatedDatabase --help
@@ -36636,8 +36636,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOneDataFederationQueryLimit --help
@@ -36884,8 +36884,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUser --help
@@ -37091,8 +37091,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDatabaseUser --help
@@ -37205,8 +37205,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUserCertificate --help
@@ -37467,8 +37467,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateEncryptionAtRest --help
@@ -37563,8 +37563,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createEncryptionAtRestPrivateEndpoint --help
@@ -38292,8 +38292,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createThirdPartyIntegration --help
@@ -38361,8 +38361,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateThirdPartyIntegration --help
@@ -38456,8 +38456,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitation --help
@@ -38502,8 +38502,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectInvitation --help
@@ -38654,8 +38654,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitationById --help
@@ -38979,8 +38979,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setProjectLimit --help
@@ -39040,8 +39040,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushMigration --help
@@ -39125,8 +39125,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api cutoverMigration --help
@@ -39179,8 +39179,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api validateMigration --help
@@ -39346,8 +39346,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateMaintenanceWindow --help
@@ -39383,8 +39383,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleMaintenanceAutoDefer --help
@@ -39420,8 +39420,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api deferMaintenanceWindow --help
@@ -39530,8 +39530,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api enableSlowOperationThresholding --help
@@ -39711,8 +39711,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringConnection --help
@@ -39863,8 +39863,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringConnection --help
@@ -39949,8 +39949,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPipeline --help
@@ -40099,8 +40099,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePipeline --help
@@ -40254,8 +40254,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pausePipeline --help
@@ -40303,8 +40303,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api resumePipeline --help
@@ -40529,8 +40529,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api triggerSnapshotIngestion --help
@@ -40762,8 +40762,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpoint --help
@@ -40937,8 +40937,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpointService --help
@@ -41021,8 +41021,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleRegionalizedPrivateEndpointSetting --help
@@ -41127,8 +41127,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessPrivateEndpoint --help
@@ -41296,8 +41296,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessPrivateEndpoint --help
@@ -41386,8 +41386,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api disablePeering --help
@@ -41494,8 +41494,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDataFederationPrivateEndpoint --help
@@ -42597,8 +42597,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePushBasedLogConfiguration --help
@@ -42646,8 +42646,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushBasedLogConfiguration --help
@@ -42696,8 +42696,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api loadSampleDataset --help
@@ -42827,8 +42827,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessInstance --help
@@ -42936,8 +42936,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessBackupRestoreJob --help
@@ -43194,8 +43194,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setServerlessAutoIndexing --help
@@ -43346,8 +43346,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessInstance --help
@@ -43434,8 +43434,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectSettings --help
@@ -43518,8 +43518,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamInstance --help
@@ -43669,8 +43669,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamInstance --help
@@ -43836,8 +43836,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamConnection --help
@@ -43998,8 +43998,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamConnection --help
@@ -44098,8 +44098,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addAllTeamsToProject --help
@@ -44211,8 +44211,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateTeamRoles --help
@@ -44296,8 +44296,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api saveLDAPConfiguration --help
@@ -44417,8 +44417,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api verifyLDAPConfiguration --help
@@ -44618,8 +44618,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectRoles --help
@@ -44767,8 +44767,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganization --help
@@ -44906,8 +44906,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameOrganization --help
@@ -44995,8 +44995,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKey --help
@@ -45148,8 +45148,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKey --help
@@ -45261,8 +45261,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKeyAccessList --help
@@ -45424,8 +45424,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCostExplorerQueryProcess --help
@@ -45797,8 +45797,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitation --help
@@ -45845,8 +45845,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganizationInvitation --help
@@ -45995,8 +45995,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitationById --help
@@ -46363,8 +46363,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLinkToken --help
@@ -46451,8 +46451,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationSettings --help
@@ -46550,8 +46550,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createTeam --help
@@ -46715,8 +46715,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameTeam --help
@@ -46835,8 +46835,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addTeamUser --help
@@ -47094,8 +47094,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationRoles --help
@@ -47145,8 +47145,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-02-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-02-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createUser --help

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
@@ -776,7 +776,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -911,7 +911,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1143,7 +1143,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1396,7 +1396,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1609,7 +1609,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1876,7 +1876,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1952,7 +1952,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2110,7 +2110,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2473,7 +2473,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2696,7 +2696,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2781,7 +2781,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3102,7 +3102,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3320,7 +3320,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3486,7 +3486,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3567,7 +3567,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3693,7 +3693,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3816,7 +3816,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3959,7 +3959,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4245,7 +4245,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4372,7 +4372,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4610,7 +4610,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4766,7 +4766,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4932,7 +4932,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5012,7 +5012,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5258,7 +5258,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5421,7 +5421,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5661,7 +5661,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6046,7 +6046,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6209,7 +6209,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6703,7 +6703,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6795,7 +6795,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6884,7 +6884,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7454,7 +7454,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7827,7 +7827,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8064,7 +8064,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8248,7 +8248,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8424,7 +8424,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8597,7 +8597,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8986,7 +8986,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9227,7 +9227,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9395,7 +9395,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9462,7 +9462,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9637,7 +9637,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9953,7 +9953,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10039,7 +10039,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10189,7 +10189,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10538,7 +10538,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10886,7 +10886,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11190,7 +11190,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11328,7 +11328,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11554,7 +11554,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11702,7 +11702,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11922,7 +11922,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12244,7 +12244,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12636,7 +12636,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12892,7 +12892,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13062,7 +13062,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13437,7 +13437,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13584,7 +13584,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14691,7 +14691,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14794,7 +14794,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14938,7 +14938,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15006,7 +15006,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15229,7 +15229,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15633,7 +15633,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15713,7 +15713,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15794,7 +15794,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16003,7 +16003,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16178,7 +16178,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16232,7 +16232,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16286,7 +16286,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16457,7 +16457,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16737,7 +16737,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16966,7 +16966,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17095,7 +17095,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17318,7 +17318,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17556,7 +17556,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17628,7 +17628,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17970,7 +17970,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18042,7 +18042,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18171,7 +18171,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18323,7 +18323,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18570,7 +18570,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18918,7 +18918,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19243,7 +19243,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19384,7 +19384,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20960,7 +20960,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21033,7 +21033,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21105,7 +21105,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21309,7 +21309,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21477,7 +21477,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21866,7 +21866,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22095,7 +22095,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22231,7 +22231,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22449,7 +22449,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22532,7 +22532,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22667,7 +22667,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22799,7 +22799,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23030,7 +23030,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23285,7 +23285,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23532,7 +23532,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23689,7 +23689,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23856,7 +23856,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23982,7 +23982,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24164,7 +24164,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24475,7 +24475,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24630,7 +24630,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24835,7 +24835,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24975,7 +24975,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25204,7 +25204,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25382,7 +25382,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25625,7 +25625,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26182,7 +26182,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26254,7 +26254,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26480,7 +26480,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27026,7 +27026,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27161,7 +27161,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27375,7 +27375,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27530,7 +27530,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27740,7 +27740,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27895,7 +27895,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28218,7 +28218,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28400,7 +28400,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28721,7 +28721,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28789,7 +28789,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-10-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-10-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
@@ -29427,8 +29427,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateConnectedOrgConfig --help
@@ -29515,8 +29515,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRoleMapping --help
@@ -29670,8 +29670,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateRoleMapping --help
@@ -29841,8 +29841,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateIdentityProvider --help
@@ -29980,8 +29980,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProject --help
@@ -30105,8 +30105,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProject --help
@@ -30155,8 +30155,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addUserToProject --help
@@ -30253,8 +30253,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectIpAccessList --help
@@ -30498,8 +30498,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAlertConfiguration --help
@@ -30658,8 +30658,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAlertConfiguration --help
@@ -30721,8 +30721,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAlertConfiguration --help
@@ -30939,8 +30939,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api acknowledgeAlert --help
@@ -31079,8 +31079,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectApiKey --help
@@ -31187,8 +31187,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKeyRoles --help
@@ -31242,8 +31242,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectApiKey --help
@@ -31324,8 +31324,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAuditingConfiguration --help
@@ -31404,8 +31404,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAWSCustomDNS --help
@@ -31496,8 +31496,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createExportBucket --help
@@ -31687,8 +31687,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDataProtectionSettings --help
@@ -31770,8 +31770,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCloudProviderAccessRole --help
@@ -31928,8 +31928,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api authorizeCloudProviderAccessRole --help
@@ -32028,8 +32028,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCluster --help
@@ -32193,8 +32193,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCluster --help
@@ -32300,8 +32300,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupExportJob --help
@@ -32460,8 +32460,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupRestoreJob --help
@@ -32722,8 +32722,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateBackupSchedule --help
@@ -32831,8 +32831,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api takeSnapshot --help
@@ -33006,8 +33006,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateSnapshotRetention --help
@@ -33224,8 +33224,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api downloadSharedClusterBackup --help
@@ -33284,8 +33284,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createSharedClusterBackupRestoreJob --help
@@ -33660,8 +33660,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndexDeprecated --help
@@ -33914,8 +33914,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexDeprecated --help
@@ -34074,8 +34074,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomZoneMapping --help
@@ -34198,8 +34198,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createManagedNamespace --help
@@ -34321,8 +34321,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRollingIndex --help
@@ -34434,8 +34434,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOnlineArchive --help
@@ -34624,8 +34624,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOnlineArchive --help
@@ -34860,8 +34860,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startOutageSimulation --help
@@ -34974,8 +34974,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateClusterAdvancedConfiguration --help
@@ -35020,8 +35020,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api testFailover --help
@@ -35138,8 +35138,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLegacyBackupRestoreJob --help
@@ -35353,8 +35353,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchDeployment --help
@@ -35412,8 +35412,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchDeployment --help
@@ -35519,8 +35519,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotSchedule --help
@@ -35752,8 +35752,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotRetention --help
@@ -35981,8 +35981,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedCluster --help
@@ -36034,8 +36034,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedClusterToServerless --help
@@ -36138,8 +36138,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringContainer --help
@@ -36297,8 +36297,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringContainer --help
@@ -36426,8 +36426,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomDatabaseRole --help
@@ -36573,8 +36573,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCustomDatabaseRole --help
@@ -36670,8 +36670,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createFederatedDatabase --help
@@ -36814,8 +36814,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateFederatedDatabase --help
@@ -37052,8 +37052,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOneDataFederationQueryLimit --help
@@ -37300,8 +37300,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUser --help
@@ -37507,8 +37507,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDatabaseUser --help
@@ -37621,8 +37621,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUserCertificate --help
@@ -37883,8 +37883,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateEncryptionAtRest --help
@@ -37979,8 +37979,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createEncryptionAtRestPrivateEndpoint --help
@@ -38708,8 +38708,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createThirdPartyIntegration --help
@@ -38777,8 +38777,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateThirdPartyIntegration --help
@@ -38872,8 +38872,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitation --help
@@ -38918,8 +38918,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectInvitation --help
@@ -39070,8 +39070,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitationById --help
@@ -39395,8 +39395,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setProjectLimit --help
@@ -39456,8 +39456,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushMigration --help
@@ -39541,8 +39541,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api cutoverMigration --help
@@ -39595,8 +39595,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api validateMigration --help
@@ -39762,8 +39762,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateMaintenanceWindow --help
@@ -39799,8 +39799,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleMaintenanceAutoDefer --help
@@ -39836,8 +39836,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api deferMaintenanceWindow --help
@@ -39946,8 +39946,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api enableSlowOperationThresholding --help
@@ -40127,8 +40127,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringConnection --help
@@ -40279,8 +40279,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringConnection --help
@@ -40365,8 +40365,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPipeline --help
@@ -40515,8 +40515,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePipeline --help
@@ -40670,8 +40670,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pausePipeline --help
@@ -40719,8 +40719,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api resumePipeline --help
@@ -40945,8 +40945,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api triggerSnapshotIngestion --help
@@ -41178,8 +41178,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpoint --help
@@ -41353,8 +41353,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpointService --help
@@ -41437,8 +41437,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleRegionalizedPrivateEndpointSetting --help
@@ -41543,8 +41543,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessPrivateEndpoint --help
@@ -41712,8 +41712,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessPrivateEndpoint --help
@@ -41802,8 +41802,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api disablePeering --help
@@ -41910,8 +41910,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDataFederationPrivateEndpoint --help
@@ -43013,8 +43013,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePushBasedLogConfiguration --help
@@ -43062,8 +43062,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushBasedLogConfiguration --help
@@ -43112,8 +43112,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api loadSampleDataset --help
@@ -43243,8 +43243,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessInstance --help
@@ -43352,8 +43352,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessBackupRestoreJob --help
@@ -43610,8 +43610,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setServerlessAutoIndexing --help
@@ -43762,8 +43762,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessInstance --help
@@ -43849,8 +43849,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectServiceAccount --help
@@ -43991,8 +43991,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectServiceAccount --help
@@ -44047,8 +44047,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectServiceAccount --help
@@ -44135,8 +44135,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectSettings --help
@@ -44219,8 +44219,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamInstance --help
@@ -44370,8 +44370,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamInstance --help
@@ -44537,8 +44537,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamConnection --help
@@ -44699,8 +44699,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamConnection --help
@@ -44799,8 +44799,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addAllTeamsToProject --help
@@ -44912,8 +44912,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateTeamRoles --help
@@ -44997,8 +44997,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api saveLDAPConfiguration --help
@@ -45118,8 +45118,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api verifyLDAPConfiguration --help
@@ -45319,8 +45319,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectRoles --help
@@ -45468,8 +45468,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganization --help
@@ -45607,8 +45607,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameOrganization --help
@@ -45696,8 +45696,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKey --help
@@ -45849,8 +45849,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKey --help
@@ -45962,8 +45962,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKeyAccessList --help
@@ -46125,8 +46125,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCostExplorerQueryProcess --help
@@ -46498,8 +46498,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitation --help
@@ -46546,8 +46546,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganizationInvitation --help
@@ -46696,8 +46696,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitationById --help
@@ -47064,8 +47064,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLinkToken --help
@@ -47150,8 +47150,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccount --help
@@ -47289,8 +47289,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServiceAccount --help
@@ -47388,8 +47388,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccountSecret --help
@@ -47524,8 +47524,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationSettings --help
@@ -47623,8 +47623,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createTeam --help
@@ -47788,8 +47788,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameTeam --help
@@ -47908,8 +47908,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addTeamUser --help
@@ -48167,8 +48167,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationRoles --help
@@ -48218,8 +48218,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-10-01+json" \
                       --header "Content-Type: application/vnd.atlas.2023-10-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createUser --help

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
@@ -780,7 +780,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -915,7 +915,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1147,7 +1147,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1317,7 +1317,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1534,7 +1534,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1813,7 +1813,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2080,7 +2080,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2156,7 +2156,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2314,7 +2314,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2677,7 +2677,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2900,7 +2900,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2985,7 +2985,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3306,7 +3306,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3524,7 +3524,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3690,7 +3690,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3771,7 +3771,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3897,7 +3897,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4020,7 +4020,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4163,7 +4163,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4449,7 +4449,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4576,7 +4576,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4814,7 +4814,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4970,7 +4970,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5136,7 +5136,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5216,7 +5216,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5462,7 +5462,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5625,7 +5625,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5865,7 +5865,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6250,7 +6250,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6413,7 +6413,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6907,7 +6907,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6999,7 +6999,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7088,7 +7088,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7731,7 +7731,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7823,7 +7823,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7906,7 +7906,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7997,7 +7997,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8370,7 +8370,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8607,7 +8607,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8791,7 +8791,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8967,7 +8967,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9140,7 +9140,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9529,7 +9529,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9770,7 +9770,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9938,7 +9938,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10005,7 +10005,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10180,7 +10180,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10496,7 +10496,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10582,7 +10582,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10732,7 +10732,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11081,7 +11081,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11720,7 +11720,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12024,7 +12024,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12162,7 +12162,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12388,7 +12388,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12536,7 +12536,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12756,7 +12756,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13078,7 +13078,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13470,7 +13470,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13726,7 +13726,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13896,7 +13896,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14271,7 +14271,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14418,7 +14418,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15525,7 +15525,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15628,7 +15628,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15772,7 +15772,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15840,7 +15840,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16063,7 +16063,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16467,7 +16467,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16547,7 +16547,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16628,7 +16628,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16837,7 +16837,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17012,7 +17012,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17066,7 +17066,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17120,7 +17120,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17291,7 +17291,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17571,7 +17571,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17800,7 +17800,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17929,7 +17929,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18152,7 +18152,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18390,7 +18390,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18462,7 +18462,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18804,7 +18804,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18876,7 +18876,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19005,7 +19005,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19157,7 +19157,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19404,7 +19404,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19752,7 +19752,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20077,7 +20077,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20218,7 +20218,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21977,7 +21977,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22050,7 +22050,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22122,7 +22122,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22326,7 +22326,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22494,7 +22494,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -22883,7 +22883,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23112,7 +23112,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23248,7 +23248,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23466,7 +23466,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23549,7 +23549,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23684,7 +23684,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23816,7 +23816,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24047,7 +24047,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24302,7 +24302,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24549,7 +24549,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24706,7 +24706,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24873,7 +24873,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24999,7 +24999,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25181,7 +25181,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25492,7 +25492,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25647,7 +25647,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25852,7 +25852,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25992,7 +25992,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26221,7 +26221,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26399,7 +26399,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26642,7 +26642,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27199,7 +27199,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27271,7 +27271,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27497,7 +27497,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28043,7 +28043,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28178,7 +28178,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28392,7 +28392,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28547,7 +28547,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28757,7 +28757,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28912,7 +28912,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29235,7 +29235,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29417,7 +29417,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29738,7 +29738,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29849,7 +29849,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2023-11-15+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2023-11-15+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
@@ -29948,8 +29948,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateConnectedOrgConfig --help
@@ -30036,8 +30036,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRoleMapping --help
@@ -30191,8 +30191,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateRoleMapping --help
@@ -30306,8 +30306,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createIdentityProvider --help
@@ -30454,8 +30454,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateIdentityProvider --help
@@ -30636,8 +30636,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProject --help
@@ -30761,8 +30761,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProject --help
@@ -30811,8 +30811,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addUserToProject --help
@@ -30909,8 +30909,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectIpAccessList --help
@@ -31154,8 +31154,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAlertConfiguration --help
@@ -31314,8 +31314,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAlertConfiguration --help
@@ -31377,8 +31377,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAlertConfiguration --help
@@ -31595,8 +31595,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api acknowledgeAlert --help
@@ -31735,8 +31735,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectApiKey --help
@@ -31843,8 +31843,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKeyRoles --help
@@ -31898,8 +31898,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectApiKey --help
@@ -31980,8 +31980,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAuditingConfiguration --help
@@ -32060,8 +32060,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAWSCustomDNS --help
@@ -32152,8 +32152,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createExportBucket --help
@@ -32343,8 +32343,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDataProtectionSettings --help
@@ -32426,8 +32426,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCloudProviderAccessRole --help
@@ -32584,8 +32584,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api authorizeCloudProviderAccessRole --help
@@ -32684,8 +32684,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCluster --help
@@ -32849,8 +32849,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCluster --help
@@ -33112,8 +33112,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupExportJob --help
@@ -33272,8 +33272,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupRestoreJob --help
@@ -33534,8 +33534,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateBackupSchedule --help
@@ -33643,8 +33643,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api takeSnapshot --help
@@ -33818,8 +33818,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateSnapshotRetention --help
@@ -34036,8 +34036,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api downloadSharedClusterBackup --help
@@ -34096,8 +34096,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createSharedClusterBackupRestoreJob --help
@@ -34521,8 +34521,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinNamespacesPatch --help
@@ -34584,8 +34584,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinNamespacesPut --help
@@ -34641,8 +34641,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api unpinNamespaces --help
@@ -34703,8 +34703,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndexDeprecated --help
@@ -34957,8 +34957,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexDeprecated --help
@@ -35117,8 +35117,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomZoneMapping --help
@@ -35241,8 +35241,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createManagedNamespace --help
@@ -35364,8 +35364,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRollingIndex --help
@@ -35477,8 +35477,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOnlineArchive --help
@@ -35667,8 +35667,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOnlineArchive --help
@@ -35903,8 +35903,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startOutageSimulation --help
@@ -36017,8 +36017,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateClusterAdvancedConfiguration --help
@@ -36063,8 +36063,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api testFailover --help
@@ -36181,8 +36181,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLegacyBackupRestoreJob --help
@@ -36396,8 +36396,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchDeployment --help
@@ -36455,8 +36455,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchDeployment --help
@@ -36562,8 +36562,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotSchedule --help
@@ -36795,8 +36795,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotRetention --help
@@ -37024,8 +37024,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedCluster --help
@@ -37077,8 +37077,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedClusterToServerless --help
@@ -37220,8 +37220,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringContainer --help
@@ -37379,8 +37379,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringContainer --help
@@ -37508,8 +37508,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomDatabaseRole --help
@@ -37655,8 +37655,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCustomDatabaseRole --help
@@ -37752,8 +37752,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createFederatedDatabase --help
@@ -37896,8 +37896,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateFederatedDatabase --help
@@ -38134,8 +38134,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOneDataFederationQueryLimit --help
@@ -38382,8 +38382,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUser --help
@@ -38589,8 +38589,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDatabaseUser --help
@@ -38703,8 +38703,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUserCertificate --help
@@ -38965,8 +38965,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateEncryptionAtRest --help
@@ -39061,8 +39061,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createEncryptionAtRestPrivateEndpoint --help
@@ -39790,8 +39790,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createThirdPartyIntegration --help
@@ -39859,8 +39859,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateThirdPartyIntegration --help
@@ -39954,8 +39954,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitation --help
@@ -40000,8 +40000,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectInvitation --help
@@ -40152,8 +40152,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitationById --help
@@ -40477,8 +40477,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setProjectLimit --help
@@ -40538,8 +40538,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushMigration --help
@@ -40623,8 +40623,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api cutoverMigration --help
@@ -40677,8 +40677,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api validateMigration --help
@@ -40844,8 +40844,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateMaintenanceWindow --help
@@ -40881,8 +40881,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleMaintenanceAutoDefer --help
@@ -40918,8 +40918,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api deferMaintenanceWindow --help
@@ -41028,8 +41028,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api enableSlowOperationThresholding --help
@@ -41209,8 +41209,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringConnection --help
@@ -41361,8 +41361,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringConnection --help
@@ -41447,8 +41447,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPipeline --help
@@ -41597,8 +41597,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePipeline --help
@@ -41752,8 +41752,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pausePipeline --help
@@ -41801,8 +41801,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api resumePipeline --help
@@ -42027,8 +42027,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api triggerSnapshotIngestion --help
@@ -42260,8 +42260,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpoint --help
@@ -42435,8 +42435,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpointService --help
@@ -42519,8 +42519,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleRegionalizedPrivateEndpointSetting --help
@@ -42625,8 +42625,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessPrivateEndpoint --help
@@ -42794,8 +42794,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessPrivateEndpoint --help
@@ -42884,8 +42884,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api disablePeering --help
@@ -42992,8 +42992,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDataFederationPrivateEndpoint --help
@@ -44213,8 +44213,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePushBasedLogConfiguration --help
@@ -44262,8 +44262,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushBasedLogConfiguration --help
@@ -44312,8 +44312,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api loadSampleDataset --help
@@ -44443,8 +44443,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessInstance --help
@@ -44552,8 +44552,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessBackupRestoreJob --help
@@ -44810,8 +44810,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setServerlessAutoIndexing --help
@@ -44962,8 +44962,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessInstance --help
@@ -45049,8 +45049,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectServiceAccount --help
@@ -45191,8 +45191,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectServiceAccount --help
@@ -45247,8 +45247,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectServiceAccount --help
@@ -45335,8 +45335,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectSettings --help
@@ -45419,8 +45419,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamInstance --help
@@ -45570,8 +45570,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamInstance --help
@@ -45737,8 +45737,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamConnection --help
@@ -45899,8 +45899,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamConnection --help
@@ -45999,8 +45999,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addAllTeamsToProject --help
@@ -46112,8 +46112,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateTeamRoles --help
@@ -46197,8 +46197,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api saveLDAPConfiguration --help
@@ -46318,8 +46318,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api verifyLDAPConfiguration --help
@@ -46519,8 +46519,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectRoles --help
@@ -46668,8 +46668,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganization --help
@@ -46807,8 +46807,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameOrganization --help
@@ -46896,8 +46896,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKey --help
@@ -47049,8 +47049,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKey --help
@@ -47162,8 +47162,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKeyAccessList --help
@@ -47325,8 +47325,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCostExplorerQueryProcess --help
@@ -47698,8 +47698,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitation --help
@@ -47746,8 +47746,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganizationInvitation --help
@@ -47896,8 +47896,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitationById --help
@@ -48264,8 +48264,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLinkToken --help
@@ -48350,8 +48350,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccount --help
@@ -48489,8 +48489,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServiceAccount --help
@@ -48588,8 +48588,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccountSecret --help
@@ -48724,8 +48724,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationSettings --help
@@ -48823,8 +48823,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createTeam --help
@@ -48988,8 +48988,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameTeam --help
@@ -49108,8 +49108,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addTeamUser --help
@@ -49367,8 +49367,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationRoles --help
@@ -49448,8 +49448,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2023-11-15+json" \
                       --header "Content-Type: application/vnd.atlas.2023-11-15+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createUser --help

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
@@ -780,7 +780,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -915,7 +915,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1147,7 +1147,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1317,7 +1317,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1534,7 +1534,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1813,7 +1813,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2080,7 +2080,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2156,7 +2156,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2314,7 +2314,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2677,7 +2677,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2900,7 +2900,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2985,7 +2985,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3305,7 +3305,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3522,7 +3522,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3688,7 +3688,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3769,7 +3769,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3895,7 +3895,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4018,7 +4018,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4211,7 +4211,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4528,7 +4528,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4655,7 +4655,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4893,7 +4893,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5049,7 +5049,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5215,7 +5215,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5295,7 +5295,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5541,7 +5541,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5704,7 +5704,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5944,7 +5944,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6329,7 +6329,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6492,7 +6492,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6986,7 +6986,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7078,7 +7078,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7167,7 +7167,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7810,7 +7810,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7902,7 +7902,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7985,7 +7985,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8076,7 +8076,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8449,7 +8449,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8686,7 +8686,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8870,7 +8870,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9046,7 +9046,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9219,7 +9219,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9608,7 +9608,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9849,7 +9849,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10017,7 +10017,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10084,7 +10084,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10259,7 +10259,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10573,7 +10573,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10657,7 +10657,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10834,7 +10834,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11260,7 +11260,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11544,7 +11544,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11693,7 +11693,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12042,7 +12042,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12431,7 +12431,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12512,7 +12512,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12851,7 +12851,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13155,7 +13155,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13293,7 +13293,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13519,7 +13519,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13667,7 +13667,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13887,7 +13887,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14209,7 +14209,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14601,7 +14601,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14857,7 +14857,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15027,7 +15027,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15402,7 +15402,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15549,7 +15549,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16656,7 +16656,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16759,7 +16759,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16903,7 +16903,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16971,7 +16971,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17194,7 +17194,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17598,7 +17598,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17676,7 +17676,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17754,7 +17754,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17962,7 +17962,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18137,7 +18137,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18191,7 +18191,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18245,7 +18245,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18416,7 +18416,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18696,7 +18696,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18925,7 +18925,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19054,7 +19054,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19277,7 +19277,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19515,7 +19515,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19587,7 +19587,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19929,7 +19929,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20001,7 +20001,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20130,7 +20130,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20282,7 +20282,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20529,7 +20529,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20877,7 +20877,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21202,7 +21202,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21343,7 +21343,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23102,7 +23102,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23175,7 +23175,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23247,7 +23247,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23451,7 +23451,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23619,7 +23619,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24008,7 +24008,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24237,7 +24237,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24373,7 +24373,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24591,7 +24591,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24674,7 +24674,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24809,7 +24809,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24941,7 +24941,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25172,7 +25172,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25427,7 +25427,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25674,7 +25674,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25757,7 +25757,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25995,7 +25995,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26076,7 +26076,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26314,7 +26314,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26481,7 +26481,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26607,7 +26607,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26789,7 +26789,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27100,7 +27100,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27165,7 +27165,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27320,7 +27320,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27525,7 +27525,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27665,7 +27665,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27894,7 +27894,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28072,7 +28072,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28315,7 +28315,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28872,7 +28872,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28944,7 +28944,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29170,7 +29170,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29716,7 +29716,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29851,7 +29851,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30065,7 +30065,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30220,7 +30220,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30430,7 +30430,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30585,7 +30585,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30908,7 +30908,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31090,7 +31090,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31411,7 +31411,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31522,7 +31522,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-05-30+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-05-30+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
@@ -30215,8 +30215,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateConnectedOrgConfig --help
@@ -30303,8 +30303,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRoleMapping --help
@@ -30458,8 +30458,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateRoleMapping --help
@@ -30573,8 +30573,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createIdentityProvider --help
@@ -30721,8 +30721,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateIdentityProvider --help
@@ -30903,8 +30903,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProject --help
@@ -31028,8 +31028,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProject --help
@@ -31078,8 +31078,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addUserToProject --help
@@ -31176,8 +31176,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectIpAccessList --help
@@ -31421,8 +31421,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAlertConfiguration --help
@@ -31581,8 +31581,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAlertConfiguration --help
@@ -31644,8 +31644,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAlertConfiguration --help
@@ -31861,8 +31861,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api acknowledgeAlert --help
@@ -32000,8 +32000,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectApiKey --help
@@ -32108,8 +32108,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKeyRoles --help
@@ -32163,8 +32163,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectApiKey --help
@@ -32245,8 +32245,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAuditingConfiguration --help
@@ -32325,8 +32325,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAWSCustomDNS --help
@@ -32451,8 +32451,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createExportBucket --help
@@ -32662,8 +32662,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDataProtectionSettings --help
@@ -32745,8 +32745,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCloudProviderAccessRole --help
@@ -32903,8 +32903,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api authorizeCloudProviderAccessRole --help
@@ -33003,8 +33003,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCluster --help
@@ -33168,8 +33168,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCluster --help
@@ -33431,8 +33431,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupExportJob --help
@@ -33591,8 +33591,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupRestoreJob --help
@@ -33853,8 +33853,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateBackupSchedule --help
@@ -33962,8 +33962,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api takeSnapshot --help
@@ -34137,8 +34137,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateSnapshotRetention --help
@@ -34355,8 +34355,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api downloadSharedClusterBackup --help
@@ -34415,8 +34415,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createSharedClusterBackupRestoreJob --help
@@ -34840,8 +34840,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinNamespacesPatch --help
@@ -34903,8 +34903,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinNamespacesPut --help
@@ -34960,8 +34960,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api unpinNamespaces --help
@@ -35022,8 +35022,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndexDeprecated --help
@@ -35276,8 +35276,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexDeprecated --help
@@ -35436,8 +35436,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomZoneMapping --help
@@ -35560,8 +35560,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createManagedNamespace --help
@@ -35683,8 +35683,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRollingIndex --help
@@ -35796,8 +35796,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOnlineArchive --help
@@ -35986,8 +35986,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOnlineArchive --help
@@ -36222,8 +36222,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startOutageSimulation --help
@@ -36336,8 +36336,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateClusterAdvancedConfiguration --help
@@ -36382,8 +36382,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api testFailover --help
@@ -36500,8 +36500,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLegacyBackupRestoreJob --help
@@ -36712,8 +36712,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchDeployment --help
@@ -36769,8 +36769,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchDeployment --help
@@ -36887,8 +36887,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndex --help
@@ -37170,8 +37170,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexByName --help
@@ -37362,8 +37362,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndex --help
@@ -37468,8 +37468,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotSchedule --help
@@ -37701,8 +37701,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotRetention --help
@@ -37806,8 +37806,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinFeatureCompatibilityVersion --help
@@ -37861,8 +37861,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api unpinFeatureCompatibilityVersion --help
@@ -38045,8 +38045,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedCluster --help
@@ -38098,8 +38098,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedClusterToServerless --help
@@ -38241,8 +38241,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringContainer --help
@@ -38400,8 +38400,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringContainer --help
@@ -38529,8 +38529,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomDatabaseRole --help
@@ -38676,8 +38676,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCustomDatabaseRole --help
@@ -38773,8 +38773,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createFederatedDatabase --help
@@ -38917,8 +38917,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateFederatedDatabase --help
@@ -39155,8 +39155,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOneDataFederationQueryLimit --help
@@ -39403,8 +39403,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUser --help
@@ -39610,8 +39610,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDatabaseUser --help
@@ -39724,8 +39724,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUserCertificate --help
@@ -39986,8 +39986,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateEncryptionAtRest --help
@@ -40082,8 +40082,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createEncryptionAtRestPrivateEndpoint --help
@@ -40811,8 +40811,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createThirdPartyIntegration --help
@@ -40880,8 +40880,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateThirdPartyIntegration --help
@@ -40975,8 +40975,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitation --help
@@ -41021,8 +41021,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectInvitation --help
@@ -41173,8 +41173,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitationById --help
@@ -41498,8 +41498,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setProjectLimit --help
@@ -41557,8 +41557,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushMigration --help
@@ -41641,8 +41641,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api cutoverMigration --help
@@ -41693,8 +41693,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api validateMigration --help
@@ -41859,8 +41859,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateMaintenanceWindow --help
@@ -41896,8 +41896,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleMaintenanceAutoDefer --help
@@ -41933,8 +41933,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api deferMaintenanceWindow --help
@@ -42043,8 +42043,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api enableSlowOperationThresholding --help
@@ -42224,8 +42224,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringConnection --help
@@ -42376,8 +42376,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringConnection --help
@@ -42462,8 +42462,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPipeline --help
@@ -42612,8 +42612,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePipeline --help
@@ -42767,8 +42767,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pausePipeline --help
@@ -42816,8 +42816,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api resumePipeline --help
@@ -43042,8 +43042,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api triggerSnapshotIngestion --help
@@ -43275,8 +43275,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpoint --help
@@ -43450,8 +43450,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpointService --help
@@ -43534,8 +43534,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleRegionalizedPrivateEndpointSetting --help
@@ -43640,8 +43640,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessPrivateEndpoint --help
@@ -43809,8 +43809,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessPrivateEndpoint --help
@@ -43899,8 +43899,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api disablePeering --help
@@ -44007,8 +44007,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDataFederationPrivateEndpoint --help
@@ -45228,8 +45228,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePushBasedLogConfiguration --help
@@ -45277,8 +45277,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushBasedLogConfiguration --help
@@ -45327,8 +45327,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api loadSampleDataset --help
@@ -45458,8 +45458,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessInstance --help
@@ -45567,8 +45567,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessBackupRestoreJob --help
@@ -45825,8 +45825,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setServerlessAutoIndexing --help
@@ -45977,8 +45977,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessInstance --help
@@ -46064,8 +46064,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectServiceAccount --help
@@ -46206,8 +46206,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectServiceAccount --help
@@ -46262,8 +46262,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectServiceAccount --help
@@ -46350,8 +46350,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectSettings --help
@@ -46434,8 +46434,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamInstance --help
@@ -46585,8 +46585,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamInstance --help
@@ -46752,8 +46752,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamConnection --help
@@ -46914,8 +46914,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamConnection --help
@@ -46969,8 +46969,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamProcessor --help
@@ -47124,8 +47124,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startStreamProcessor --help
@@ -47178,8 +47178,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api stopStreamProcessor --help
@@ -47327,8 +47327,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addAllTeamsToProject --help
@@ -47440,8 +47440,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateTeamRoles --help
@@ -47525,8 +47525,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api saveLDAPConfiguration --help
@@ -47646,8 +47646,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api verifyLDAPConfiguration --help
@@ -47847,8 +47847,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectRoles --help
@@ -47891,8 +47891,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api migrateProjectToAnotherOrg --help
@@ -48040,8 +48040,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganization --help
@@ -48179,8 +48179,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameOrganization --help
@@ -48268,8 +48268,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKey --help
@@ -48421,8 +48421,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKey --help
@@ -48534,8 +48534,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKeyAccessList --help
@@ -48697,8 +48697,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCostExplorerQueryProcess --help
@@ -49070,8 +49070,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitation --help
@@ -49118,8 +49118,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganizationInvitation --help
@@ -49268,8 +49268,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitationById --help
@@ -49636,8 +49636,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLinkToken --help
@@ -49722,8 +49722,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccount --help
@@ -49861,8 +49861,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServiceAccount --help
@@ -49960,8 +49960,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccountSecret --help
@@ -50096,8 +50096,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationSettings --help
@@ -50195,8 +50195,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createTeam --help
@@ -50360,8 +50360,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameTeam --help
@@ -50480,8 +50480,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addTeamUser --help
@@ -50739,8 +50739,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationRoles --help
@@ -50820,8 +50820,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-05-30+json" \
                       --header "Content-Type: application/vnd.atlas.2024-05-30+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createUser --help

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
@@ -780,7 +780,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -915,7 +915,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1147,7 +1147,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1317,7 +1317,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1534,7 +1534,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1813,7 +1813,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2080,7 +2080,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2156,7 +2156,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2314,7 +2314,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2677,7 +2677,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2900,7 +2900,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2985,7 +2985,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3305,7 +3305,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3522,7 +3522,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3688,7 +3688,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3769,7 +3769,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3895,7 +3895,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4018,7 +4018,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4211,7 +4211,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4528,7 +4528,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4655,7 +4655,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4893,7 +4893,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5053,7 +5053,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5218,7 +5218,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5298,7 +5298,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5542,7 +5542,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5704,7 +5704,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5944,7 +5944,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6324,7 +6324,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6486,7 +6486,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6980,7 +6980,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7072,7 +7072,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7161,7 +7161,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7804,7 +7804,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7896,7 +7896,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7979,7 +7979,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8070,7 +8070,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8443,7 +8443,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8676,7 +8676,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8857,7 +8857,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9032,7 +9032,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9205,7 +9205,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9594,7 +9594,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9835,7 +9835,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10000,7 +10000,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10066,7 +10066,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10241,7 +10241,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10555,7 +10555,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10639,7 +10639,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10816,7 +10816,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11242,7 +11242,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11526,7 +11526,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11675,7 +11675,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12024,7 +12024,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12413,7 +12413,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12494,7 +12494,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12833,7 +12833,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13137,7 +13137,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13275,7 +13275,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13501,7 +13501,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13649,7 +13649,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13869,7 +13869,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14191,7 +14191,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14583,7 +14583,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14839,7 +14839,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15009,7 +15009,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15384,7 +15384,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15531,7 +15531,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16638,7 +16638,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16741,7 +16741,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16885,7 +16885,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16953,7 +16953,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17176,7 +17176,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17580,7 +17580,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17658,7 +17658,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17736,7 +17736,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17944,7 +17944,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18119,7 +18119,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18173,7 +18173,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18227,7 +18227,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18398,7 +18398,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18678,7 +18678,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18907,7 +18907,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19036,7 +19036,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19259,7 +19259,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19497,7 +19497,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19569,7 +19569,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19911,7 +19911,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19983,7 +19983,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20112,7 +20112,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20264,7 +20264,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20511,7 +20511,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20859,7 +20859,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21184,7 +21184,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21325,7 +21325,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23084,7 +23084,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23157,7 +23157,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23229,7 +23229,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23433,7 +23433,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23601,7 +23601,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23990,7 +23990,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24219,7 +24219,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24355,7 +24355,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24573,7 +24573,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24656,7 +24656,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24791,7 +24791,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24923,7 +24923,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25154,7 +25154,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25409,7 +25409,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25656,7 +25656,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25739,7 +25739,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25977,7 +25977,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26058,7 +26058,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26296,7 +26296,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26463,7 +26463,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26589,7 +26589,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26771,7 +26771,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27082,7 +27082,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27147,7 +27147,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27302,7 +27302,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27507,7 +27507,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27647,7 +27647,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27876,7 +27876,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28054,7 +28054,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28297,7 +28297,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28854,7 +28854,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28926,7 +28926,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29152,7 +29152,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29698,7 +29698,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29833,7 +29833,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30047,7 +30047,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30202,7 +30202,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30412,7 +30412,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30567,7 +30567,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30890,7 +30890,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31072,7 +31072,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31393,7 +31393,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31504,7 +31504,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2024-08-05+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2024-08-05+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
@@ -30493,8 +30493,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateConnectedOrgConfig --help
@@ -30581,8 +30581,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRoleMapping --help
@@ -30736,8 +30736,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateRoleMapping --help
@@ -30851,8 +30851,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createIdentityProvider --help
@@ -30999,8 +30999,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateIdentityProvider --help
@@ -31181,8 +31181,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProject --help
@@ -31306,8 +31306,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProject --help
@@ -31356,8 +31356,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addUserToProject --help
@@ -31454,8 +31454,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectIpAccessList --help
@@ -31699,8 +31699,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAlertConfiguration --help
@@ -31859,8 +31859,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAlertConfiguration --help
@@ -31922,8 +31922,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAlertConfiguration --help
@@ -32139,8 +32139,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api acknowledgeAlert --help
@@ -32278,8 +32278,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectApiKey --help
@@ -32386,8 +32386,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKeyRoles --help
@@ -32441,8 +32441,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectApiKey --help
@@ -32523,8 +32523,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAuditingConfiguration --help
@@ -32603,8 +32603,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAWSCustomDNS --help
@@ -32729,8 +32729,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createExportBucket --help
@@ -32940,8 +32940,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDataProtectionSettings --help
@@ -33023,8 +33023,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCloudProviderAccessRole --help
@@ -33181,8 +33181,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api authorizeCloudProviderAccessRole --help
@@ -33406,8 +33406,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCluster --help
@@ -33568,8 +33568,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCluster --help
@@ -33830,8 +33830,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupExportJob --help
@@ -33990,8 +33990,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupRestoreJob --help
@@ -34247,8 +34247,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateBackupSchedule --help
@@ -34355,8 +34355,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api takeSnapshot --help
@@ -34530,8 +34530,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateSnapshotRetention --help
@@ -34748,8 +34748,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api downloadSharedClusterBackup --help
@@ -34808,8 +34808,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createSharedClusterBackupRestoreJob --help
@@ -35233,8 +35233,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinNamespacesPatch --help
@@ -35296,8 +35296,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinNamespacesPut --help
@@ -35353,8 +35353,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api unpinNamespaces --help
@@ -35415,8 +35415,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndexDeprecated --help
@@ -35669,8 +35669,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexDeprecated --help
@@ -35825,8 +35825,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomZoneMapping --help
@@ -35946,8 +35946,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createManagedNamespace --help
@@ -36068,8 +36068,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRollingIndex --help
@@ -36181,8 +36181,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOnlineArchive --help
@@ -36371,8 +36371,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOnlineArchive --help
@@ -36607,8 +36607,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startOutageSimulation --help
@@ -36718,8 +36718,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateClusterAdvancedConfiguration --help
@@ -36763,8 +36763,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api testFailover --help
@@ -36881,8 +36881,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLegacyBackupRestoreJob --help
@@ -37093,8 +37093,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchDeployment --help
@@ -37150,8 +37150,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchDeployment --help
@@ -37268,8 +37268,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndex --help
@@ -37551,8 +37551,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexByName --help
@@ -37743,8 +37743,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndex --help
@@ -37849,8 +37849,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotSchedule --help
@@ -38082,8 +38082,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotRetention --help
@@ -38187,8 +38187,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinFeatureCompatibilityVersion --help
@@ -38242,8 +38242,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api unpinFeatureCompatibilityVersion --help
@@ -38426,8 +38426,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedCluster --help
@@ -38479,8 +38479,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedClusterToServerless --help
@@ -38622,8 +38622,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringContainer --help
@@ -38781,8 +38781,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringContainer --help
@@ -38910,8 +38910,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomDatabaseRole --help
@@ -39057,8 +39057,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCustomDatabaseRole --help
@@ -39154,8 +39154,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createFederatedDatabase --help
@@ -39298,8 +39298,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateFederatedDatabase --help
@@ -39536,8 +39536,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOneDataFederationQueryLimit --help
@@ -39784,8 +39784,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUser --help
@@ -39991,8 +39991,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDatabaseUser --help
@@ -40105,8 +40105,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUserCertificate --help
@@ -40367,8 +40367,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateEncryptionAtRest --help
@@ -40463,8 +40463,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createEncryptionAtRestPrivateEndpoint --help
@@ -41192,8 +41192,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createThirdPartyIntegration --help
@@ -41261,8 +41261,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateThirdPartyIntegration --help
@@ -41356,8 +41356,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitation --help
@@ -41402,8 +41402,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectInvitation --help
@@ -41554,8 +41554,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitationById --help
@@ -41879,8 +41879,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setProjectLimit --help
@@ -41938,8 +41938,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushMigration --help
@@ -42022,8 +42022,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api cutoverMigration --help
@@ -42074,8 +42074,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api validateMigration --help
@@ -42240,8 +42240,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateMaintenanceWindow --help
@@ -42277,8 +42277,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleMaintenanceAutoDefer --help
@@ -42314,8 +42314,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api deferMaintenanceWindow --help
@@ -42424,8 +42424,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api enableSlowOperationThresholding --help
@@ -42605,8 +42605,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringConnection --help
@@ -42757,8 +42757,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringConnection --help
@@ -42843,8 +42843,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPipeline --help
@@ -42993,8 +42993,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePipeline --help
@@ -43148,8 +43148,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pausePipeline --help
@@ -43197,8 +43197,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api resumePipeline --help
@@ -43423,8 +43423,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api triggerSnapshotIngestion --help
@@ -43656,8 +43656,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpoint --help
@@ -43831,8 +43831,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpointService --help
@@ -43915,8 +43915,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleRegionalizedPrivateEndpointSetting --help
@@ -44021,8 +44021,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessPrivateEndpoint --help
@@ -44190,8 +44190,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessPrivateEndpoint --help
@@ -44280,8 +44280,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api disablePeering --help
@@ -44388,8 +44388,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDataFederationPrivateEndpoint --help
@@ -45609,8 +45609,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePushBasedLogConfiguration --help
@@ -45658,8 +45658,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushBasedLogConfiguration --help
@@ -45708,8 +45708,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api loadSampleDataset --help
@@ -45839,8 +45839,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessInstance --help
@@ -45948,8 +45948,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessBackupRestoreJob --help
@@ -46206,8 +46206,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setServerlessAutoIndexing --help
@@ -46358,8 +46358,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessInstance --help
@@ -46445,8 +46445,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectServiceAccount --help
@@ -46587,8 +46587,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectServiceAccount --help
@@ -46643,8 +46643,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectServiceAccount --help
@@ -46731,8 +46731,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectSettings --help
@@ -46815,8 +46815,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamInstance --help
@@ -46966,8 +46966,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamInstance --help
@@ -47133,8 +47133,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamConnection --help
@@ -47295,8 +47295,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamConnection --help
@@ -47350,8 +47350,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamProcessor --help
@@ -47505,8 +47505,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startStreamProcessor --help
@@ -47559,8 +47559,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api stopStreamProcessor --help
@@ -47708,8 +47708,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addAllTeamsToProject --help
@@ -47821,8 +47821,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateTeamRoles --help
@@ -47906,8 +47906,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api saveLDAPConfiguration --help
@@ -48027,8 +48027,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api verifyLDAPConfiguration --help
@@ -48228,8 +48228,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectRoles --help
@@ -48272,8 +48272,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api migrateProjectToAnotherOrg --help
@@ -48421,8 +48421,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganization --help
@@ -48560,8 +48560,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameOrganization --help
@@ -48649,8 +48649,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKey --help
@@ -48802,8 +48802,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKey --help
@@ -48915,8 +48915,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKeyAccessList --help
@@ -49078,8 +49078,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCostExplorerQueryProcess --help
@@ -49451,8 +49451,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitation --help
@@ -49499,8 +49499,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganizationInvitation --help
@@ -49649,8 +49649,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitationById --help
@@ -50017,8 +50017,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLinkToken --help
@@ -50103,8 +50103,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccount --help
@@ -50242,8 +50242,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServiceAccount --help
@@ -50341,8 +50341,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccountSecret --help
@@ -50477,8 +50477,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationSettings --help
@@ -50576,8 +50576,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createTeam --help
@@ -50741,8 +50741,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameTeam --help
@@ -50861,8 +50861,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addTeamUser --help
@@ -51120,8 +51120,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationRoles --help
@@ -51201,8 +51201,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2024-08-05+json" \
                       --header "Content-Type: application/vnd.atlas.2024-08-05+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createUser --help

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
@@ -780,7 +780,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -915,7 +915,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1147,7 +1147,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1317,7 +1317,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1534,7 +1534,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -1813,7 +1813,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2080,7 +2080,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2156,7 +2156,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2314,7 +2314,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2677,7 +2677,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2900,7 +2900,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -2985,7 +2985,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3305,7 +3305,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3522,7 +3522,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3688,7 +3688,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3769,7 +3769,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -3895,7 +3895,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4018,7 +4018,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4211,7 +4211,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4528,7 +4528,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4655,7 +4655,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -4893,7 +4893,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5053,7 +5053,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5218,7 +5218,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5298,7 +5298,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5542,7 +5542,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5704,7 +5704,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -5944,7 +5944,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6324,7 +6324,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6486,7 +6486,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -6980,7 +6980,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7072,7 +7072,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7161,7 +7161,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7804,7 +7804,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7896,7 +7896,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -7979,7 +7979,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8070,7 +8070,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8443,7 +8443,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8676,7 +8676,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -8857,7 +8857,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9032,7 +9032,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9205,7 +9205,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9594,7 +9594,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -9835,7 +9835,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10000,7 +10000,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10066,7 +10066,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10241,7 +10241,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10555,7 +10555,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10639,7 +10639,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -10816,7 +10816,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11242,7 +11242,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11526,7 +11526,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -11675,7 +11675,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12024,7 +12024,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12413,7 +12413,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12494,7 +12494,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -12833,7 +12833,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13137,7 +13137,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13275,7 +13275,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13501,7 +13501,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13649,7 +13649,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -13869,7 +13869,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14191,7 +14191,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14583,7 +14583,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -14839,7 +14839,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15009,7 +15009,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15384,7 +15384,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -15531,7 +15531,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16638,7 +16638,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16741,7 +16741,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16885,7 +16885,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -16953,7 +16953,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17176,7 +17176,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17580,7 +17580,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17658,7 +17658,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17736,7 +17736,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -17944,7 +17944,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18119,7 +18119,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18173,7 +18173,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18227,7 +18227,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18398,7 +18398,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18678,7 +18678,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -18907,7 +18907,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19036,7 +19036,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19259,7 +19259,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19497,7 +19497,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19569,7 +19569,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19911,7 +19911,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -19983,7 +19983,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20112,7 +20112,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20264,7 +20264,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20511,7 +20511,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -20859,7 +20859,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21184,7 +21184,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -21325,7 +21325,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23084,7 +23084,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23157,7 +23157,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23229,7 +23229,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23433,7 +23433,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23601,7 +23601,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -23990,7 +23990,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24219,7 +24219,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24355,7 +24355,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24573,7 +24573,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24656,7 +24656,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24791,7 +24791,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -24923,7 +24923,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25154,7 +25154,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25409,7 +25409,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25656,7 +25656,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25739,7 +25739,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -25977,7 +25977,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26058,7 +26058,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26296,7 +26296,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26463,7 +26463,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26589,7 +26589,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -26771,7 +26771,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27082,7 +27082,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27220,7 +27220,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/uss\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/uss\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27452,7 +27452,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/uss/{name}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/uss/{name}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27517,7 +27517,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27672,7 +27672,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -27877,7 +27877,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28017,7 +28017,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28246,7 +28246,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28424,7 +28424,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -28667,7 +28667,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29224,7 +29224,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29296,7 +29296,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -29522,7 +29522,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30154,7 +30154,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30289,7 +30289,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30503,7 +30503,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30658,7 +30658,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -30868,7 +30868,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31023,7 +31023,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31346,7 +31346,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PATCH \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31528,7 +31528,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31849,7 +31849,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X PUT \"https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",
@@ -31960,7 +31960,7 @@
           {
             "lang": "cURL",
             "label": "curl",
-            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\"\n  -d { <Payload> }"
+            "source": "curl --user \"{PUBLIC-KEY}:{PRIVATE-KEY}\" \\\n  --digest \\\n  --header \"Accept: application/vnd.atlas.2025-01-01+json\" \\\n  --header \"Content-Type: application/vnd.atlas.2025-01-01+json\" \\\n  -X POST \"https://cloud.mongodb.com/api/atlas/v2/users\" \\\n  -d '{ <Payload> }'"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
@@ -30905,8 +30905,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateConnectedOrgConfig --help
@@ -30993,8 +30993,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRoleMapping --help
@@ -31148,8 +31148,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/connectedOrgConfigs/{orgId}/roleMappings/{id}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateRoleMapping --help
@@ -31263,8 +31263,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createIdentityProvider --help
@@ -31411,8 +31411,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/federationSettings/{federationSettingsId}/identityProviders/{identityProviderId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateIdentityProvider --help
@@ -31593,8 +31593,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProject --help
@@ -31718,8 +31718,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProject --help
@@ -31768,8 +31768,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/access" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addUserToProject --help
@@ -31866,8 +31866,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectIpAccessList --help
@@ -32111,8 +32111,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAlertConfiguration --help
@@ -32271,8 +32271,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAlertConfiguration --help
@@ -32334,8 +32334,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alertConfigs/{alertConfigId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAlertConfiguration --help
@@ -32551,8 +32551,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/alerts/{alertId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api acknowledgeAlert --help
@@ -32690,8 +32690,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectApiKey --help
@@ -32798,8 +32798,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKeyRoles --help
@@ -32853,8 +32853,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectApiKey --help
@@ -32935,8 +32935,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/auditLog" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAuditingConfiguration --help
@@ -33015,8 +33015,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/awsCustomDNS" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleAWSCustomDNS --help
@@ -33141,8 +33141,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backup/exportBuckets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createExportBucket --help
@@ -33352,8 +33352,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/backupCompliancePolicy" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDataProtectionSettings --help
@@ -33435,8 +33435,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCloudProviderAccessRole --help
@@ -33593,8 +33593,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/cloudProviderAccess/{roleId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api authorizeCloudProviderAccessRole --help
@@ -33818,8 +33818,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCluster --help
@@ -33980,8 +33980,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCluster --help
@@ -34242,8 +34242,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/exports" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupExportJob --help
@@ -34402,8 +34402,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createBackupRestoreJob --help
@@ -34659,8 +34659,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/schedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateBackupSchedule --help
@@ -34767,8 +34767,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api takeSnapshot --help
@@ -34942,8 +34942,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateSnapshotRetention --help
@@ -35160,8 +35160,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/download" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api downloadSharedClusterBackup --help
@@ -35220,8 +35220,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/backup/tenant/restore" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createSharedClusterBackupRestoreJob --help
@@ -35645,8 +35645,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinNamespacesPatch --help
@@ -35708,8 +35708,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/pinned" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinNamespacesPut --help
@@ -35765,8 +35765,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/collStats/unpin" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api unpinNamespaces --help
@@ -35827,8 +35827,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndexDeprecated --help
@@ -36081,8 +36081,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/fts/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexDeprecated --help
@@ -36237,8 +36237,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/customZoneMapping" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomZoneMapping --help
@@ -36358,8 +36358,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/globalWrites/managedNamespaces" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createManagedNamespace --help
@@ -36480,8 +36480,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/index" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createRollingIndex --help
@@ -36593,8 +36593,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOnlineArchive --help
@@ -36783,8 +36783,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/onlineArchives/{archiveId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOnlineArchive --help
@@ -37019,8 +37019,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/outageSimulation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startOutageSimulation --help
@@ -37130,8 +37130,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/processArgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateClusterAdvancedConfiguration --help
@@ -37175,8 +37175,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restartPrimaries" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api testFailover --help
@@ -37293,8 +37293,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLegacyBackupRestoreJob --help
@@ -37505,8 +37505,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchDeployment --help
@@ -37562,8 +37562,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/deployment" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchDeployment --help
@@ -37680,8 +37680,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createAtlasSearchIndex --help
@@ -37963,8 +37963,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{databaseName}/{collectionName}/{indexName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndexByName --help
@@ -38155,8 +38155,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/search/indexes/{indexId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateAtlasSearchIndex --help
@@ -38261,8 +38261,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshotSchedule" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotSchedule --help
@@ -38494,8 +38494,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}/snapshots/{snapshotId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateLegacySnapshotRetention --help
@@ -38599,8 +38599,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:pinFeatureCompatibilityVersion" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pinFeatureCompatibilityVersion --help
@@ -38654,8 +38654,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/{clusterName}:unpinFeatureCompatibilityVersion" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api unpinFeatureCompatibilityVersion --help
@@ -38838,8 +38838,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgrade" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedCluster --help
@@ -38891,8 +38891,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/clusters/tenantUpgradeToServerless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api upgradeSharedClusterToServerless --help
@@ -39034,8 +39034,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringContainer --help
@@ -39193,8 +39193,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/containers/{containerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringContainer --help
@@ -39322,8 +39322,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCustomDatabaseRole --help
@@ -39469,8 +39469,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/customDBRoles/roles/{roleName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateCustomDatabaseRole --help
@@ -39566,8 +39566,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createFederatedDatabase --help
@@ -39710,8 +39710,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateFederatedDatabase --help
@@ -39948,8 +39948,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/dataFederation/{tenantName}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOneDataFederationQueryLimit --help
@@ -40196,8 +40196,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUser --help
@@ -40403,8 +40403,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{databaseName}/{username}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateDatabaseUser --help
@@ -40517,8 +40517,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/databaseUsers/{username}/certs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDatabaseUserCertificate --help
@@ -40779,8 +40779,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateEncryptionAtRest --help
@@ -40875,8 +40875,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/encryptionAtRest/{cloudProvider}/privateEndpoints" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createEncryptionAtRestPrivateEndpoint --help
@@ -41604,8 +41604,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createThirdPartyIntegration --help
@@ -41673,8 +41673,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/integrations/{integrationType}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateThirdPartyIntegration --help
@@ -41768,8 +41768,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitation --help
@@ -41814,8 +41814,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectInvitation --help
@@ -41966,8 +41966,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectInvitationById --help
@@ -42291,8 +42291,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/limits/{limitName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setProjectLimit --help
@@ -42350,8 +42350,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushMigration --help
@@ -42434,8 +42434,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/{liveMigrationId}/cutover" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api cutoverMigration --help
@@ -42486,8 +42486,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/liveMigrations/validate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api validateMigration --help
@@ -42652,8 +42652,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateMaintenanceWindow --help
@@ -42689,8 +42689,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/autoDefer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleMaintenanceAutoDefer --help
@@ -42726,8 +42726,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/maintenanceWindow/defer" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api deferMaintenanceWindow --help
@@ -42836,8 +42836,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/managedSlowMs/enable" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api enableSlowOperationThresholding --help
@@ -43017,8 +43017,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPeeringConnection --help
@@ -43169,8 +43169,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/peers/{peerId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePeeringConnection --help
@@ -43255,8 +43255,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPipeline --help
@@ -43405,8 +43405,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePipeline --help
@@ -43560,8 +43560,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/pause" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api pausePipeline --help
@@ -43609,8 +43609,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/resume" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api resumePipeline --help
@@ -43835,8 +43835,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pipelines/{pipelineName}/trigger" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api triggerSnapshotIngestion --help
@@ -44068,8 +44068,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/{cloudProvider}/endpointService/{endpointServiceId}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpoint --help
@@ -44243,8 +44243,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/endpointService" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPrivateEndpointService --help
@@ -44327,8 +44327,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/regionalMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api toggleRegionalizedPrivateEndpointSetting --help
@@ -44433,8 +44433,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessPrivateEndpoint --help
@@ -44602,8 +44602,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateEndpoint/serverless/instance/{instanceName}/endpoint/{endpointId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessPrivateEndpoint --help
@@ -44692,8 +44692,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateIpMode" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api disablePeering --help
@@ -44800,8 +44800,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/privateNetworkSettings/endpointIds" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createDataFederationPrivateEndpoint --help
@@ -46021,8 +46021,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updatePushBasedLogConfiguration --help
@@ -46070,8 +46070,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/pushBasedLogExport" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createPushBasedLogConfiguration --help
@@ -46120,8 +46120,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/sampleDatasetLoad/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api loadSampleDataset --help
@@ -46251,8 +46251,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessInstance --help
@@ -46360,8 +46360,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/backup/restoreJobs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServerlessBackupRestoreJob --help
@@ -46618,8 +46618,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{clusterName}/performanceAdvisor/autoIndexing" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api setServerlessAutoIndexing --help
@@ -46770,8 +46770,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serverless/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServerlessInstance --help
@@ -46857,8 +46857,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createProjectServiceAccount --help
@@ -46999,8 +46999,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectServiceAccount --help
@@ -47055,8 +47055,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addProjectServiceAccount --help
@@ -47143,8 +47143,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectSettings --help
@@ -47227,8 +47227,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamInstance --help
@@ -47378,8 +47378,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamInstance --help
@@ -47545,8 +47545,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamConnection --help
@@ -47707,8 +47707,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/connections/{connectionName}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateStreamConnection --help
@@ -47762,8 +47762,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createStreamProcessor --help
@@ -47917,8 +47917,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:start" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api startStreamProcessor --help
@@ -47971,8 +47971,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/streams/{tenantName}/processor/{processorName}:stop" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api stopStreamProcessor --help
@@ -48120,8 +48120,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addAllTeamsToProject --help
@@ -48233,8 +48233,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateTeamRoles --help
@@ -48318,8 +48318,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api saveLDAPConfiguration --help
@@ -48439,8 +48439,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/userSecurity/ldap/verify" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api verifyLDAPConfiguration --help
@@ -48640,8 +48640,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateProjectRoles --help
@@ -48727,8 +48727,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/uss"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/uss" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createUSSInstance --help
@@ -48881,8 +48881,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/uss/{name}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}/uss/{name}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateUSSInstance --help
@@ -48925,8 +48925,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/groups/{groupId}:migrate" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api migrateProjectToAnotherOrg --help
@@ -49074,8 +49074,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganization --help
@@ -49213,8 +49213,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameOrganization --help
@@ -49302,8 +49302,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKey --help
@@ -49455,8 +49455,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateApiKey --help
@@ -49568,8 +49568,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/apiKeys/{apiUserId}/accessList" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createApiKeyAccessList --help
@@ -49731,8 +49731,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/billing/costExplorer/usage" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createCostExplorerQueryProcess --help
@@ -50104,8 +50104,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitation --help
@@ -50152,8 +50152,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createOrganizationInvitation --help
@@ -50302,8 +50302,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/invites/{invitationId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationInvitationById --help
@@ -50725,8 +50725,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/liveMigrations/linkTokens" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createLinkToken --help
@@ -50811,8 +50811,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccount --help
@@ -50950,8 +50950,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateServiceAccount --help
@@ -51049,8 +51049,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/serviceAccounts/{serviceAccountId}/secrets" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createServiceAccountSecret --help
@@ -51185,8 +51185,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/settings" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationSettings --help
@@ -51284,8 +51284,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createTeam --help
@@ -51449,8 +51449,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}"
-                      -d { <Payload> }
+                      -X PATCH "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api renameTeam --help
@@ -51569,8 +51569,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/teams/{teamId}/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api addTeamUser --help
@@ -51828,8 +51828,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles"
-                      -d { <Payload> }
+                      -X PUT "https://cloud.mongodb.com/api/atlas/v2/orgs/{orgId}/users/{userId}/roles" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api updateOrganizationRoles --help
@@ -51909,8 +51909,8 @@ paths:
                       --digest \
                       --header "Accept: application/vnd.atlas.2025-01-01+json" \
                       --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
-                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users"
-                      -d { <Payload> }
+                      -X POST "https://cloud.mongodb.com/api/atlas/v2/users" \
+                      -d '{ <Payload> }'
                 - label: Atlas CLI
                   lang: cURL
                   source: atlas api createUser --help


### PR DESCRIPTION
## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-321939

## Description
### Bug
Doc team feedback: cURL commands for PUT, PATCH, and POST methods are not valid. Users receive errors if copying and pasting into terminal and replacing variables with their own data. Each command that uses these methods and requires a request body needs an extra `\` after the endpoint URI in order for shells to handle the line break.

### Fix
This PR adds an additional `\`  and update the payload from `{ <Payload> }`  to `'{ <Payload> }'` for PUT, PATCH, and POST.  

You can check how this change renders in https://redocly.github.io/redoc/#tag/Projects/operation/createProject. Example:

```bash
curl --user "{PUBLIC-KEY}:{PRIVATE-KEY}" \
  --digest \
  --header "Accept: application/vnd.atlas.2025-01-01+json" \
  --header "Content-Type: application/vnd.atlas.2025-01-01+json" \
  -X POST "https://cloud.mongodb.com/api/atlas/v2/groups" \
  -d '{ <Payload> }'
```
