### PR TITLE
CLOUDP-311382: Update `foas changelog metadata` command to support `upcoming`

### DIFF
--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -180,8 +180,8 @@ func NewEntries(basePath, revisionPath, exceptionFilePath string) ([]*Entry, err
 	}
 
 	for _, version := range changelog.RevisionMetadata.Versions {
-		// Skip preview versions
-		if apiversion.IsPreviewStabilityLevel(version) {
+		// Skip preview and upcoming versions
+		if apiversion.IsPreviewStabilityLevel(version) || apiversion.IsUpcomingStabilityLevel(version) {
 			continue
 		}
 
@@ -229,6 +229,12 @@ func NewEntriesBetweenRevisionVersions(revisionPath, exceptionFilePath string) (
 			if apiversion.IsPreviewStabilityLevel(fromVersion) || apiversion.IsPreviewStabilityLevel(toVersion) {
 				continue
 			}
+
+			// Skip upcoming preview version. It will be included in CLOUDP-315486
+			if apiversion.IsUpcomingStabilityLevel(fromVersion) || apiversion.IsUpcomingStabilityLevel(toVersion) {
+				continue
+			}
+
 			entry, err := newEntriesBetweenVersion(revisionMetadata, fromVersion, toVersion, exceptionFilePath)
 			if err != nil {
 				return nil, err

--- a/tools/cli/internal/changelog/changelog.go
+++ b/tools/cli/internal/changelog/changelog.go
@@ -230,7 +230,7 @@ func NewEntriesBetweenRevisionVersions(revisionPath, exceptionFilePath string) (
 				continue
 			}
 
-			// Skip upcoming preview version. It will be included in CLOUDP-315486
+			// Skip upcoming version. It will be included in CLOUDP-315486
 			if apiversion.IsUpcomingStabilityLevel(fromVersion) || apiversion.IsUpcomingStabilityLevel(toVersion) {
 				continue
 			}

--- a/tools/cli/internal/cli/changelog/metadata/create.go
+++ b/tools/cli/internal/cli/changelog/metadata/create.go
@@ -17,9 +17,9 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
+	"github.com/mongodb/openapi/tools/cli/internal/apiversion"
 	"github.com/mongodb/openapi/tools/cli/internal/changelog"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/flag"
 	"github.com/mongodb/openapi/tools/cli/internal/cli/usage"
@@ -73,9 +73,7 @@ func (o *Opts) PreRun() error {
 
 	// Validate that the API version use the correct date format YYYY-MM-DD
 	for _, version := range o.versions {
-		// Upcoming version has the format YYYY-MM-DD.upcoming, here we remove .upcoming to validate the date format.
-		version = strings.ReplaceAll(version, ".upcoming", "")
-		if _, err := time.Parse("2006-01-02", version); err != nil {
+		if _, err := apiversion.New(apiversion.WithVersion(version)); err != nil {
 			return fmt.Errorf("invalid version date: %w. Make sure to use the format YYYY-MM-DD", err)
 		}
 	}

--- a/tools/cli/internal/cli/changelog/metadata/create.go
+++ b/tools/cli/internal/cli/changelog/metadata/create.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mongodb/openapi/tools/cli/internal/changelog"
@@ -70,7 +71,10 @@ func (o *Opts) PreRun() error {
 		}
 	}
 
+	// Validate that the API version use the correct date format YYYY-MM-DD
 	for _, version := range o.versions {
+		// Upcoming version has the format YYYY-MM-DD.upcoming, here we remove .upcoming to validate the date format.
+		version = strings.ReplaceAll(version, ".upcoming", "")
 		if _, err := time.Parse("2006-01-02", version); err != nil {
 			return fmt.Errorf("invalid version date: %w. Make sure to use the format YYYY-MM-DD", err)
 		}
@@ -79,7 +83,8 @@ func (o *Opts) PreRun() error {
 	return nil
 }
 
-// changelog metadata create [--run-date=2024-09-22] --sha=e624d716e86f6910757b60cefdf3aa3181582d38 versions=2023-01-01,2023-02-01.
+// CreateBuilder creates the Cobra command for changelog metadata create [--run-date=2024-09-22]
+// --sha=e624d716e86f6910757b60cefdf3aa3181582d38 versions=2023-01-01,2023-02-01.
 func CreateBuilder() *cobra.Command {
 	opts := &Opts{
 		fs: afero.NewOsFs(),

--- a/tools/cli/internal/cli/changelog/metadata/create_test.go
+++ b/tools/cli/internal/cli/changelog/metadata/create_test.go
@@ -28,7 +28,7 @@ func TestCreateBuild_Run(t *testing.T) {
 	opts := &Opts{
 		specRevision: "11110c256dffdb163be71a3ca70854a57fad5f6f",
 		runDate:      "2024-01-01",
-		versions:     []string{"2024-01-01"},
+		versions:     []string{"2024-01-01", "2024-01-01.upcoming"},
 		fs:           fs,
 	}
 
@@ -45,6 +45,18 @@ func TestCreateBuild_PreRun_InvalidVersion(t *testing.T) {
 	}
 
 	require.ErrorContains(t, opts.PreRun(), "invalid version date")
+}
+
+func TestCreateBuild_PreRun_UpcomingVersion(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	opts := &Opts{
+		specRevision: "test",
+		runDate:      "2024-01-01",
+		versions:     []string{"2024-01-01.upcoming", "2025-01-01"},
+		fs:           fs,
+	}
+
+	require.NoError(t, opts.PreRun())
 }
 
 func TestCreateBuilder(t *testing.T) {


### PR DESCRIPTION
## Proposed changes
CLOUDP-311382
<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

This PR proposes the following changes:
- updates the `foas changelog metadata create` to consider upcoming API version when generating the metadata file
- updates the `foas changelog create` to skip upcoming api version when generating the changelog. The support will be added in CLOUDP-315486


## Next
I will test the changes once the PR is merged by running the FOAS release. I may have to create follow up PRs to fix the release flow.