### PR TITLE
fix: Add retry for bump release

### DIFF
--- a/.github/scripts/generateSpecMapping.js
+++ b/.github/scripts/generateSpecMapping.js
@@ -15,7 +15,7 @@ function handleAdminAPIv1() {
   if (process.env.BRANCH_NAME === 'main') {
     SPEC_MAPPING.push({
       doc: process.env.ATLAS_ADMIN_V1_DOC_ID,
-      file: 'v1-deprecated/v1.json',
+      file: 'openapi/v1-deprecated/v1.json',
       branch: 'main',
     });
   }

--- a/.github/workflows/release-spec.yml
+++ b/.github/workflows/release-spec.yml
@@ -217,7 +217,7 @@ jobs:
       api_bot_pat: ${{ secrets.api_bot_pat }}
 
   retry-handler:
-    needs: [ release, release-postman, release-changelog]
+    needs: [ release, release-postman, release-changelog, release-bump-sh]
     if: ${{ always() && contains(needs.*.result, 'failure') && fromJSON(github.run_attempt) < 3}}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Proposed changes
This PR adds the bump release to the retry mechanism so that the release will restart the bump release in case of failure