### PR TITLE
feat: autogenerate go SDK example in the codeSample

### DIFF
--- a/tools/cli/internal/openapi/filter/code_sample.go
+++ b/tools/cli/internal/openapi/filter/code_sample.go
@@ -49,9 +49,9 @@ func main() {
   }
   
   params = &sdk.{{ .OperationID }}ApiParams{}
-{{ if eq .Method "DELETE" }}  httpResp, err := sdk.{{ .Tag }}Api.
+{{ if eq .Method "DELETE" }}  httpResp, err := client.{{ .Tag }}Api.
     {{ .OperationID }}WithParams(ctx, params).
-    Execute(){{ else }}  sdkResp, httpResp, err := sdk.{{ .Tag }}Api.
+    Execute(){{ else }}  sdkResp, httpResp, err := client.{{ .Tag }}Api.
     {{ .OperationID }}WithParams(ctx, params).
     Execute(){{ end}}
 }`

--- a/tools/cli/internal/openapi/filter/code_sample_test.go
+++ b/tools/cli/internal/openapi/filter/code_sample_test.go
@@ -98,7 +98,7 @@ func TestCodeSampleFilter(t *testing.T) {
 										"\t\tsdk.UseBaseURL(url))\n\n" +
 										"\tif err != nil {\n" + "\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n" +
 										"\tparams = &sdk.TestOperationIDApiParams{}\n" +
-										"\tsdkResp, httpResp, err := sdk.TestTagApi.\n" +
+										"\tsdkResp, httpResp, err := client.TestTagApi.\n" +
 										"\t\tTestOperationIDWithParams(ctx, params).\n" +
 										"\t\tExecute()" + "\n}",
 								},

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.json
@@ -248,7 +248,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -315,7 +315,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -388,7 +388,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -461,7 +461,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -525,7 +525,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -601,7 +601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -684,7 +684,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -765,7 +765,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -857,7 +857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -930,7 +930,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1012,7 +1012,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1095,7 +1095,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1179,7 +1179,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1274,7 +1274,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1382,7 +1382,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1466,7 +1466,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1557,7 +1557,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1628,7 +1628,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1704,7 +1704,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1800,7 +1800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1884,7 +1884,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1954,7 +1954,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2022,7 +2022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2107,7 +2107,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2187,7 +2187,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2285,7 +2285,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2370,7 +2370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := sdk.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2456,7 +2456,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2543,7 +2543,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2619,7 +2619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2698,7 +2698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2778,7 +2778,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := sdk.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2859,7 +2859,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2951,7 +2951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3046,7 +3046,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3138,7 +3138,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3230,7 +3230,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3312,7 +3312,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3407,7 +3407,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3499,7 +3499,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3579,7 +3579,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3655,7 +3655,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3741,7 +3741,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3841,7 +3841,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3932,7 +3932,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3999,7 +3999,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4078,7 +4078,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4145,7 +4145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4221,7 +4221,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4298,7 +4298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4384,7 +4384,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4468,7 +4468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4547,7 +4547,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4619,7 +4619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4714,7 +4714,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4782,7 +4782,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4862,7 +4862,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4953,7 +4953,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := sdk.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5032,7 +5032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5130,7 +5130,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5216,7 +5216,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5306,7 +5306,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5402,7 +5402,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5492,7 +5492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5582,7 +5582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5676,7 +5676,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := sdk.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5761,7 +5761,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5860,7 +5860,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5949,7 +5949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6043,7 +6043,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6128,7 +6128,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6216,7 +6216,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6313,7 +6313,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6407,7 +6407,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6496,7 +6496,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6576,7 +6576,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6655,7 +6655,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6748,7 +6748,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6840,7 +6840,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6931,7 +6931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7022,7 +7022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7114,7 +7114,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7196,7 +7196,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7290,7 +7290,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7382,7 +7382,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7485,7 +7485,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7587,7 +7587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7686,7 +7686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7768,7 +7768,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7862,7 +7862,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7944,7 +7944,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8038,7 +8038,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8127,7 +8127,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8225,7 +8225,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8326,7 +8326,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8432,7 +8432,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8532,7 +8532,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8627,7 +8627,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8739,7 +8739,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8824,7 +8824,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8909,7 +8909,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9006,7 +9006,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9110,7 +9110,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9210,7 +9210,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9396,7 +9396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9488,7 +9488,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9589,7 +9589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9708,7 +9708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9806,7 +9806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := sdk.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9905,7 +9905,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10018,7 +10018,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10107,7 +10107,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10194,7 +10194,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10289,7 +10289,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10376,7 +10376,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10477,7 +10477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10555,7 +10555,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10659,7 +10659,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10751,7 +10751,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10846,7 +10846,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10929,7 +10929,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11011,7 +11011,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11107,7 +11107,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11203,7 +11203,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11284,7 +11284,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11373,7 +11373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11476,7 +11476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11571,7 +11571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := sdk.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11661,7 +11661,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11762,7 +11762,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11841,7 +11841,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11969,7 +11969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12064,7 +12064,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12152,7 +12152,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12228,7 +12228,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12317,7 +12317,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12395,7 +12395,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12496,7 +12496,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12566,7 +12566,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12654,7 +12654,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12736,7 +12736,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12813,7 +12813,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12910,7 +12910,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12993,7 +12993,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13078,7 +13078,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13154,7 +13154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13231,7 +13231,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13328,7 +13328,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13410,7 +13410,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13498,7 +13498,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13587,7 +13587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13690,7 +13690,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13796,7 +13796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13872,7 +13872,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14112,7 +14112,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14204,7 +14204,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := sdk.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14291,7 +14291,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14398,7 +14398,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14486,7 +14486,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14588,7 +14588,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14721,7 +14721,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14851,7 +14851,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14918,7 +14918,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15003,7 +15003,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15082,7 +15082,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15170,7 +15170,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15272,7 +15272,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15361,7 +15361,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15504,7 +15504,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15595,7 +15595,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15665,7 +15665,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15781,7 +15781,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15900,7 +15900,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16011,7 +16011,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16093,7 +16093,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16188,7 +16188,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16281,7 +16281,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16397,7 +16397,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16510,7 +16510,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16590,7 +16590,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16674,7 +16674,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16752,7 +16752,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16830,7 +16830,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16912,7 +16912,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17005,7 +17005,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17076,7 +17076,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17155,7 +17155,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17252,7 +17252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17350,7 +17350,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17459,7 +17459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17549,7 +17549,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17640,7 +17640,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17727,7 +17727,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17803,7 +17803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17879,7 +17879,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17943,7 +17943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := sdk.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18008,7 +18008,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18084,7 +18084,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18148,7 +18148,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18212,7 +18212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18279,7 +18279,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18346,7 +18346,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := sdk.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18413,7 +18413,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18541,7 +18541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18634,7 +18634,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18723,7 +18723,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18805,7 +18805,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18885,7 +18885,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18982,7 +18982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19052,7 +19052,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19131,7 +19131,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19210,7 +19210,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19290,7 +19290,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19384,7 +19384,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19469,7 +19469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19570,7 +19570,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19652,7 +19652,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19734,7 +19734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19835,7 +19835,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19930,7 +19930,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20023,7 +20023,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20116,7 +20116,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20198,7 +20198,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20268,7 +20268,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20347,7 +20347,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20428,7 +20428,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20519,7 +20519,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20609,7 +20609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20697,7 +20697,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20796,7 +20796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20881,7 +20881,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20975,7 +20975,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21070,7 +21070,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21184,7 +21184,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21288,7 +21288,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21393,7 +21393,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21465,7 +21465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21549,7 +21549,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21631,7 +21631,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21710,7 +21710,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21792,7 +21792,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21875,7 +21875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21951,7 +21951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22029,7 +22029,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22116,7 +22116,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22203,7 +22203,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22329,7 +22329,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22416,7 +22416,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22500,7 +22500,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22635,7 +22635,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22877,7 +22877,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22973,7 +22973,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23093,7 +23093,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23229,7 +23229,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23302,7 +23302,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := sdk.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23373,7 +23373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23456,7 +23456,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23539,7 +23539,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23621,7 +23621,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23697,7 +23697,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23773,7 +23773,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23855,7 +23855,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23946,7 +23946,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24043,7 +24043,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24137,7 +24137,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24228,7 +24228,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24320,7 +24320,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24399,7 +24399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24482,7 +24482,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24567,7 +24567,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := sdk.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24650,7 +24650,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24741,7 +24741,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24814,7 +24814,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24896,7 +24896,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24981,7 +24981,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25073,7 +25073,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25159,7 +25159,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25260,7 +25260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25327,7 +25327,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25406,7 +25406,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25470,7 +25470,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := sdk.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25537,7 +25537,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := sdk.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25618,7 +25618,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25697,7 +25697,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25791,7 +25791,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25873,7 +25873,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25969,7 +25969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26059,7 +26059,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26144,7 +26144,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26220,7 +26220,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26294,7 +26294,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26379,7 +26379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26459,7 +26459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26539,7 +26539,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26622,7 +26622,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26703,7 +26703,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26798,7 +26798,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26890,7 +26890,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26996,7 +26996,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27096,7 +27096,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27191,7 +27191,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27269,7 +27269,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27360,7 +27360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27475,7 +27475,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27566,7 +27566,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27639,7 +27639,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27729,7 +27729,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27814,7 +27814,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27896,7 +27896,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27978,7 +27978,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28060,7 +28060,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28140,7 +28140,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28234,7 +28234,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28392,7 +28392,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28462,7 +28462,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28550,7 +28550,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28631,7 +28631,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28704,7 +28704,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28771,7 +28771,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := sdk.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28850,7 +28850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28923,7 +28923,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29005,7 +29005,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29091,7 +29091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29180,7 +29180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29266,7 +29266,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29355,7 +29355,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29442,7 +29442,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29543,7 +29543,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29641,7 +29641,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29745,7 +29745,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29843,7 +29843,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29925,7 +29925,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30010,7 +30010,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30106,7 +30106,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30184,7 +30184,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30261,7 +30261,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30340,7 +30340,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-01-01.yaml
@@ -28320,7 +28320,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSystemStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		GetSystemStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -28391,7 +28391,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).
                     		Execute()
                     }
@@ -28463,7 +28463,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersForAllProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersForAllProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -28535,7 +28535,7 @@ paths:
                     	}
 
                     	params = &sdk.ListEventTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListEventTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -28605,7 +28605,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederationAppApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteFederationAppWithParams(ctx, params).
                     		Execute()
                     }
@@ -28680,7 +28680,7 @@ paths:
                     	}
 
                     	params = &sdk.ListConnectedOrgConfigsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListConnectedOrgConfigsWithParams(ctx, params).
                     		Execute()
                     }
@@ -28763,7 +28763,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveConnectedOrgConfigApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RemoveConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -28845,7 +28845,7 @@ paths:
                     	}
 
                     	params = &sdk.GetConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -28934,7 +28934,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -29012,7 +29012,7 @@ paths:
                     	}
 
                     	params = &sdk.ListRoleMappingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListRoleMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -29092,7 +29092,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29178,7 +29178,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteRoleMappingApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29261,7 +29261,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29351,7 +29351,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29452,7 +29452,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIdentityProvidersApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListIdentityProvidersWithParams(ctx, params).
                     		Execute()
                     }
@@ -29535,7 +29535,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -29626,7 +29626,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -29704,7 +29704,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderMetadataApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderMetadataWithParams(ctx, params).
                     		Execute()
                     }
@@ -29778,7 +29778,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -29869,7 +29869,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -29945,7 +29945,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30016,7 +30016,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30098,7 +30098,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30178,7 +30178,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectIpAccessListsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		ListProjectIpAccessListsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30266,7 +30266,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectIpAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		CreateProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -30358,7 +30358,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectIpAccessListApiParams{}
-                    	httpResp, err := sdk.ProjectIPAccessListApi.
+                    	httpResp, err := client.ProjectIPAccessListApi.
                     		DeleteProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -30442,7 +30442,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpListWithParams(ctx, params).
                     		Execute()
                     }
@@ -30526,7 +30526,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpAccessListStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpAccessListStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -30602,7 +30602,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30683,7 +30683,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		CreateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -30770,7 +30770,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAlertConfigurationApiParams{}
-                    	httpResp, err := sdk.AlertConfigurationsApi.
+                    	httpResp, err := client.AlertConfigurationsApi.
                     		DeleteAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -30854,7 +30854,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		GetAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -30947,7 +30947,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ToggleAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31046,7 +31046,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		UpdateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31138,7 +31138,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsByAlertConfigurationIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsByAlertConfigurationIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -31225,7 +31225,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31309,7 +31309,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		GetAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -31402,7 +31402,7 @@ paths:
                     	}
 
                     	params = &sdk.AcknowledgeAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		AcknowledgeAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -31494,7 +31494,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsByAlertIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsByAlertIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -31570,7 +31570,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListProjectApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -31646,7 +31646,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -31734,7 +31734,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		RemoveProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -31824,7 +31824,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -31915,7 +31915,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		AddProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -31989,7 +31989,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		GetAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32067,7 +32067,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		UpdateAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32141,7 +32141,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		GetAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -32217,7 +32217,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		ToggleAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -32295,7 +32295,7 @@ paths:
                     	}
 
                     	params = &sdk.ListExportBucketsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListExportBucketsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32379,7 +32379,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -32467,7 +32467,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteExportBucketApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -32548,7 +32548,7 @@ paths:
                     	}
 
                     	params = &sdk.GetExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -32622,7 +32622,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32712,7 +32712,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32787,7 +32787,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderAccessRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		ListCloudProviderAccessRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -32866,7 +32866,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		CreateCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -32957,7 +32957,7 @@ paths:
                     	}
 
                     	params = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}
-                    	httpResp, err := sdk.CloudProviderAccessApi.
+                    	httpResp, err := client.CloudProviderAccessApi.
                     		DeauthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33036,7 +33036,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		GetCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33128,7 +33128,7 @@ paths:
                     	}
 
                     	params = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		AuthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33212,7 +33212,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersWithParams(ctx, params).
                     		Execute()
                     }
@@ -33298,7 +33298,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		CreateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -33392,7 +33392,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteClusterApiParams{}
-                    	httpResp, err := sdk.ClustersApi.
+                    	httpResp, err := client.ClustersApi.
                     		DeleteClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -33476,7 +33476,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -33569,7 +33569,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -33656,7 +33656,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupExportJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupExportJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33746,7 +33746,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -33834,7 +33834,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -33916,7 +33916,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34010,7 +34010,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34104,7 +34104,7 @@ paths:
                     	}
 
                     	params = &sdk.CancelBackupRestoreJobApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		CancelBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34191,7 +34191,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34272,7 +34272,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllBackupSchedulesApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteAllBackupSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -34352,7 +34352,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34444,7 +34444,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34533,7 +34533,7 @@ paths:
                     	}
 
                     	params = &sdk.ListReplicaSetBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListReplicaSetBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34623,7 +34623,7 @@ paths:
                     	}
 
                     	params = &sdk.TakeSnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		TakeSnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -34717,7 +34717,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteReplicaSetBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -34806,7 +34806,7 @@ paths:
                     	}
 
                     	params = &sdk.GetReplicaSetBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -34902,7 +34902,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateSnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateSnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -34994,7 +34994,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteShardedClusterBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35083,7 +35083,7 @@ paths:
                     	}
 
                     	params = &sdk.GetShardedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35164,7 +35164,7 @@ paths:
                     	}
 
                     	params = &sdk.ListShardedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListShardedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35258,7 +35258,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		DownloadSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35354,7 +35354,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		CreateSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -35439,7 +35439,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		ListSharedClusterBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35529,7 +35529,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		GetSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -35610,7 +35610,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		ListSharedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35700,7 +35700,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		GetSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35783,7 +35783,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupCheckpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupCheckpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35876,7 +35876,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupCheckpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupCheckpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -35970,7 +35970,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36072,7 +36072,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36167,7 +36167,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36259,7 +36259,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36362,7 +36362,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36450,7 +36450,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		GetManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -36534,7 +36534,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllCustomZoneMappingsApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteAllCustomZoneMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36626,7 +36626,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomZoneMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateCustomZoneMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -36726,7 +36726,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteManagedNamespaceApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -36820,7 +36820,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -36979,7 +36979,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRollingIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.RollingIndexApi.
+                    	sdkResp, httpResp, err := client.RollingIndexApi.
                     		CreateRollingIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -37068,7 +37068,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOnlineArchivesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		ListOnlineArchivesWithParams(ctx, params).
                     		Execute()
                     }
@@ -37162,7 +37162,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		CreateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -37259,7 +37259,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOnlineArchiveApiParams{}
-                    	httpResp, err := sdk.OnlineArchiveApi.
+                    	httpResp, err := client.OnlineArchiveApi.
                     		DeleteOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -37353,7 +37353,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		GetOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -37456,7 +37456,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		UpdateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -37569,7 +37569,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		DownloadOnlineArchiveQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37655,7 +37655,7 @@ paths:
                     	}
 
                     	params = &sdk.EndOutageSimulationApiParams{}
-                    	httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	httpResp, err := client.ClusterOutageSimulationApi.
                     		EndOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -37740,7 +37740,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		GetOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -37830,7 +37830,7 @@ paths:
                     	}
 
                     	params = &sdk.StartOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		StartOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -37919,7 +37919,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38014,7 +38014,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38097,7 +38097,7 @@ paths:
                     	}
 
                     	params = &sdk.TestFailoverApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		TestFailoverWithParams(ctx, params).
                     		Execute()
                     }
@@ -38198,7 +38198,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38286,7 +38286,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		CreateLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -38384,7 +38384,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -38466,7 +38466,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchDeploymentApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -38548,7 +38548,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -38639,7 +38639,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -38734,7 +38734,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -38822,7 +38822,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -38911,7 +38911,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -39008,7 +39008,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacySnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacySnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39099,7 +39099,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLegacySnapshotApiParams{}
-                    	httpResp, err := sdk.LegacyBackupApi.
+                    	httpResp, err := client.LegacyBackupApi.
                     		DeleteLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -39187,7 +39187,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -39282,7 +39282,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -39365,7 +39365,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -39480,7 +39480,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39566,7 +39566,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderRegionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListCloudProviderRegionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39651,7 +39651,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -39740,7 +39740,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterToServerlessApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterToServerlessWithParams(ctx, params).
                     		Execute()
                     }
@@ -39830,7 +39830,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainerByCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainerByCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -39914,7 +39914,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40004,7 +40004,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringContainerApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40083,7 +40083,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40177,7 +40177,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40254,7 +40254,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainersApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainersWithParams(ctx, params).
                     		Execute()
                     }
@@ -40326,7 +40326,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCustomDatabaseRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		ListCustomDatabaseRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -40410,7 +40410,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		CreateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -40494,7 +40494,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteCustomDatabaseRoleApiParams{}
-                    	httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	httpResp, err := client.CustomDatabaseRolesApi.
                     		DeleteCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -40571,7 +40571,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		GetCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -40661,7 +40661,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		UpdateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -40746,7 +40746,7 @@ paths:
                     	}
 
                     	params = &sdk.ListFederatedDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListFederatedDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -40828,7 +40828,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -40908,7 +40908,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederatedDatabaseApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -40986,7 +40986,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41076,7 +41076,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		UpdateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41160,7 +41160,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -41254,7 +41254,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -41348,7 +41348,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -41452,7 +41452,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOneDataFederationQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateOneDataFederationQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -41556,7 +41556,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		DownloadFederatedDatabaseQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -41629,7 +41629,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		ListDatabaseUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -41804,7 +41804,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		CreateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -41908,7 +41908,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDatabaseUserApiParams{}
-                    	httpResp, err := sdk.DatabaseUsersApi.
+                    	httpResp, err := client.DatabaseUsersApi.
                     		DeleteDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42005,7 +42005,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		GetDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42115,7 +42115,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		UpdateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42200,7 +42200,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUserCertificatesApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		ListDatabaseUserCertificatesWithParams(ctx, params).
                     		Execute()
                     }
@@ -42299,7 +42299,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserCertificateApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		CreateDatabaseUserCertificateWithParams(ctx, params).
                     		Execute()
                     }
@@ -42419,7 +42419,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByClusterNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByClusterNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42532,7 +42532,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByHostnameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByHostnameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42605,7 +42605,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -42699,7 +42699,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		UpdateEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -42781,7 +42781,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -42865,7 +42865,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		CreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -42963,7 +42963,7 @@ paths:
                     	}
 
                     	params = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}
-                    	httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43049,7 +43049,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -43176,7 +43176,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListProjectEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43266,7 +43266,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetProjectEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -43338,7 +43338,7 @@ paths:
                     	}
 
                     	params = &sdk.ListMetricTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListMetricTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -43440,7 +43440,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43541,7 +43541,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43641,7 +43641,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43718,7 +43718,7 @@ paths:
                     	}
 
                     	params = &sdk.ListThirdPartyIntegrationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		ListThirdPartyIntegrationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43810,7 +43810,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteThirdPartyIntegrationApiParams{}
-                    	httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	httpResp, err := client.Third - PartyIntegrationsApi.
                     		DeleteThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -43901,7 +43901,7 @@ paths:
                     	}
 
                     	params = &sdk.GetThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		GetThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44004,7 +44004,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		CreateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44109,7 +44109,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		UpdateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44192,7 +44192,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44274,7 +44274,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44356,7 +44356,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44440,7 +44440,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectInvitationApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44522,7 +44522,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44612,7 +44612,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -44689,7 +44689,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ReturnAllIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -44767,7 +44767,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44877,7 +44877,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectLimitApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -44988,7 +44988,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45109,7 +45109,7 @@ paths:
                     	}
 
                     	params = &sdk.SetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		SetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45206,7 +45206,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreatePushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45286,7 +45286,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetPushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45361,7 +45361,7 @@ paths:
                     	}
 
                     	params = &sdk.CutoverMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CutoverMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45451,7 +45451,7 @@ paths:
                     	}
 
                     	params = &sdk.ValidateMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ValidateMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45541,7 +45541,7 @@ paths:
                     	}
 
                     	params = &sdk.GetValidationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetValidationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -45610,7 +45610,7 @@ paths:
                     	}
 
                     	params = &sdk.ResetMaintenanceWindowApiParams{}
-                    	httpResp, err := sdk.MaintenanceWindowsApi.
+                    	httpResp, err := client.MaintenanceWindowsApi.
                     		ResetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -45679,7 +45679,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		GetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -45756,7 +45756,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		UpdateMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -45829,7 +45829,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleMaintenanceAutoDeferApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		ToggleMaintenanceAutoDeferWithParams(ctx, params).
                     		Execute()
                     }
@@ -45902,7 +45902,7 @@ paths:
                     	}
 
                     	params = &sdk.DeferMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		DeferMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -45976,7 +45976,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedSlowMsApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetManagedSlowMsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46046,7 +46046,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableSlowOperationThresholdingApiParams{}
-                    	httpResp, err := sdk.PerformanceAdvisorApi.
+                    	httpResp, err := client.PerformanceAdvisorApi.
                     		DisableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -46116,7 +46116,7 @@ paths:
                     	}
 
                     	params = &sdk.EnableSlowOperationThresholdingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		EnableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -46231,7 +46231,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLTSVersionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLTSVersionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46316,7 +46316,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46401,7 +46401,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -46486,7 +46486,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringConnectionApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -46566,7 +46566,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -46657,7 +46657,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -46734,7 +46734,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelinesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelinesWithParams(ctx, params).
                     		Execute()
                     }
@@ -46813,7 +46813,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		CreatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -46897,7 +46897,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -46977,7 +46977,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47067,7 +47067,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		UpdatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47154,7 +47154,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSchedulesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47245,7 +47245,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47326,7 +47326,7 @@ paths:
                     	}
 
                     	params = &sdk.PausePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		PausePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47411,7 +47411,7 @@ paths:
                     	}
 
                     	params = &sdk.ResumePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ResumePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47506,7 +47506,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineRunsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineRunsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47597,7 +47597,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineRunDatasetApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineRunDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -47687,7 +47687,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineRunApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineRunWithParams(ctx, params).
                     		Execute()
                     }
@@ -47775,7 +47775,7 @@ paths:
                     	}
 
                     	params = &sdk.TriggerSnapshotIngestionApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		TriggerSnapshotIngestionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47862,7 +47862,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPrivateEndpointServicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ListPrivateEndpointServicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47952,7 +47952,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointServiceApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -48043,7 +48043,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -48146,7 +48146,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -48247,7 +48247,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -48345,7 +48345,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -48425,7 +48425,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -48501,7 +48501,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -48579,7 +48579,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -48664,7 +48664,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		ListServerlessPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48755,7 +48755,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		CreateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -48847,7 +48847,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		DeleteServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -48934,7 +48934,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		GetServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49028,7 +49028,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		UpdateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49106,7 +49106,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -49188,7 +49188,7 @@ paths:
                     	}
 
                     	params = &sdk.DisablePeeringApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		DisablePeeringWithParams(ctx, params).
                     		Execute()
                     }
@@ -49269,7 +49269,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDataFederationPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListDataFederationPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -49366,7 +49366,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49451,7 +49451,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDataFederationPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49533,7 +49533,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49606,7 +49606,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasProcessesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListAtlasProcessesWithParams(ctx, params).
                     		Execute()
                     }
@@ -49684,7 +49684,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetAtlasProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -49765,7 +49765,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -49849,7 +49849,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -49959,7 +49959,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50040,7 +50040,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskPartitionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskPartitionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50123,7 +50123,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50249,7 +50249,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50486,7 +50486,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50584,7 +50584,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueryNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueryNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50699,7 +50699,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50821,7 +50821,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSuggestedIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSuggestedIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50895,7 +50895,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePushBasedLogConfigurationApiParams{}
-                    	httpResp, err := sdk.Push - BasedLogExportApi.
+                    	httpResp, err := client.Push - BasedLogExportApi.
                     		DeletePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -50968,7 +50968,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		GetPushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51049,7 +51049,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		UpdatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51134,7 +51134,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		CreatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51220,7 +51220,7 @@ paths:
                     	}
 
                     	params = &sdk.LoadSampleDatasetApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		LoadSampleDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -51302,7 +51302,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSampleDatasetLoadStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetSampleDatasetLoadStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -51375,7 +51375,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		ListServerlessInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51455,7 +51455,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		CreateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -51543,7 +51543,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51634,7 +51634,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -51728,7 +51728,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -51812,7 +51812,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51902,7 +51902,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -51981,7 +51981,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52064,7 +52064,7 @@ paths:
                     	}
 
                     	params = &sdk.SetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		SetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52151,7 +52151,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessInstanceApiParams{}
-                    	httpResp, err := sdk.ServerlessInstancesApi.
+                    	httpResp, err := client.ServerlessInstancesApi.
                     		DeleteServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52233,7 +52233,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		GetServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52320,7 +52320,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		UpdateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52398,7 +52398,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52478,7 +52478,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52561,7 +52561,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListProjectTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52648,7 +52648,7 @@ paths:
                     	}
 
                     	params = &sdk.AddAllTeamsToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddAllTeamsToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -52737,7 +52737,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveProjectTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -52831,7 +52831,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateTeamRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		UpdateTeamRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -52905,7 +52905,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -52986,7 +52986,7 @@ paths:
                     	}
 
                     	params = &sdk.SaveLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		SaveLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53062,7 +53062,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableCustomerManagedX509ApiParams{}
-                    	httpResp, err := sdk.X509AuthenticationApi.
+                    	httpResp, err := client.X509AuthenticationApi.
                     		DisableCustomerManagedX509WithParams(ctx, params).
                     		Execute()
                     }
@@ -53132,7 +53132,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLDAPConfigurationApiParams{}
-                    	httpResp, err := sdk.LDAPConfigurationApi.
+                    	httpResp, err := client.LDAPConfigurationApi.
                     		DeleteLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53211,7 +53211,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		VerifyLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53294,7 +53294,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -53379,7 +53379,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -53460,7 +53460,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectUserApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		RemoveProjectUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -53550,7 +53550,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53637,7 +53637,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -53720,7 +53720,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53803,7 +53803,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53889,7 +53889,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53964,7 +53964,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -54046,7 +54046,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		RenameOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -54126,7 +54126,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -54205,7 +54205,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -54291,7 +54291,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -54372,7 +54372,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -54462,7 +54462,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -54551,7 +54551,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeyAccessListsEntriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeyAccessListsEntriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54645,7 +54645,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -54743,7 +54743,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyAccessListEntryApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyAccessListEntryWithParams(ctx, params).
                     		Execute()
                     }
@@ -54834,7 +54834,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -54912,7 +54912,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -55004,7 +55004,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcess_1WithParams(ctx, params).
                     		Execute()
                     }
@@ -55109,7 +55109,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListOrganizationEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55199,7 +55199,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetOrganizationEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -55273,7 +55273,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetFederationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55363,7 +55363,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55445,7 +55445,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55525,7 +55525,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55609,7 +55609,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55693,7 +55693,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationInvitationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55774,7 +55774,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55863,7 +55863,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -56001,7 +56001,7 @@ paths:
                     	}
 
                     	params = &sdk.ListInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -56088,7 +56088,7 @@ paths:
                     	}
 
                     	params = &sdk.GetInvoiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		GetInvoiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56176,7 +56176,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadInvoiceCSVApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		DownloadInvoiceCSVWithParams(ctx, params).
                     		Execute()
                     }
@@ -56248,7 +56248,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPendingInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListPendingInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -56322,7 +56322,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSourceProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ListSourceProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56393,7 +56393,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLinkTokenApiParams{}
-                    	httpResp, err := sdk.CloudMigrationServiceApi.
+                    	httpResp, err := client.CloudMigrationServiceApi.
                     		DeleteLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -56471,7 +56471,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLinkTokenApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreateLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -56549,7 +56549,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56629,7 +56629,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56713,7 +56713,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListOrganizationTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56798,7 +56798,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		CreateTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -56888,7 +56888,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		DeleteTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -56973,7 +56973,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -57067,7 +57067,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		RenameTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -57161,7 +57161,7 @@ paths:
                     	}
 
                     	params = &sdk.ListTeamUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListTeamUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -57257,7 +57257,7 @@ paths:
                     	}
 
                     	params = &sdk.AddTeamUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -57354,7 +57354,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveTeamUserApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -57437,7 +57437,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -57514,7 +57514,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -57598,7 +57598,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveOrganizationUserApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		RemoveOrganizationUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -57688,7 +57688,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -57775,7 +57775,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		CreateUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -57859,7 +57859,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -57937,7 +57937,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserByUsernameApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserByUsernameWithParams(ctx, params).
                     		Execute()
                     }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.json
@@ -252,7 +252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -319,7 +319,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -392,7 +392,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -465,7 +465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -529,7 +529,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -605,7 +605,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -688,7 +688,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -769,7 +769,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -861,7 +861,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -934,7 +934,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1016,7 +1016,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1099,7 +1099,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1183,7 +1183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1278,7 +1278,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1386,7 +1386,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1470,7 +1470,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1561,7 +1561,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1632,7 +1632,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1708,7 +1708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1804,7 +1804,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1888,7 +1888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1958,7 +1958,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2026,7 +2026,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2111,7 +2111,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2197,7 +2197,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2277,7 +2277,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2375,7 +2375,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2460,7 +2460,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := sdk.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2546,7 +2546,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2633,7 +2633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2709,7 +2709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2788,7 +2788,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2868,7 +2868,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := sdk.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2949,7 +2949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3041,7 +3041,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3136,7 +3136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3228,7 +3228,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3320,7 +3320,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3402,7 +3402,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3497,7 +3497,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3589,7 +3589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3669,7 +3669,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3745,7 +3745,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3831,7 +3831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3931,7 +3931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4022,7 +4022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4089,7 +4089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4168,7 +4168,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4235,7 +4235,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4311,7 +4311,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4388,7 +4388,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4474,7 +4474,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4558,7 +4558,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4637,7 +4637,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4709,7 +4709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4804,7 +4804,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4872,7 +4872,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4952,7 +4952,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5043,7 +5043,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := sdk.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5122,7 +5122,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5220,7 +5220,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5306,7 +5306,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5396,7 +5396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5492,7 +5492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5582,7 +5582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5672,7 +5672,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5765,7 +5765,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := sdk.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5849,7 +5849,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5948,7 +5948,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6037,7 +6037,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6131,7 +6131,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6216,7 +6216,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6304,7 +6304,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6401,7 +6401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6495,7 +6495,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6584,7 +6584,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6664,7 +6664,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6743,7 +6743,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6836,7 +6836,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6928,7 +6928,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7019,7 +7019,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7110,7 +7110,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7202,7 +7202,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7284,7 +7284,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7378,7 +7378,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7470,7 +7470,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7573,7 +7573,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7675,7 +7675,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7774,7 +7774,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7856,7 +7856,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7950,7 +7950,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8032,7 +8032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8126,7 +8126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8215,7 +8215,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8313,7 +8313,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8414,7 +8414,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8520,7 +8520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8620,7 +8620,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8715,7 +8715,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8827,7 +8827,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8912,7 +8912,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8997,7 +8997,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9094,7 +9094,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9198,7 +9198,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9298,7 +9298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9484,7 +9484,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9576,7 +9576,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9677,7 +9677,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9796,7 +9796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9894,7 +9894,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := sdk.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9993,7 +9993,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10106,7 +10106,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10195,7 +10195,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10282,7 +10282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10377,7 +10377,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10464,7 +10464,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10565,7 +10565,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10642,7 +10642,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10745,7 +10745,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10837,7 +10837,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10932,7 +10932,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11015,7 +11015,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11097,7 +11097,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11193,7 +11193,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11289,7 +11289,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11370,7 +11370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11459,7 +11459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11562,7 +11562,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11657,7 +11657,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := sdk.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11747,7 +11747,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11848,7 +11848,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11927,7 +11927,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12054,7 +12054,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12148,7 +12148,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12236,7 +12236,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12312,7 +12312,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12401,7 +12401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12479,7 +12479,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12580,7 +12580,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12650,7 +12650,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12738,7 +12738,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12820,7 +12820,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12897,7 +12897,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12994,7 +12994,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13077,7 +13077,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13162,7 +13162,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13238,7 +13238,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13315,7 +13315,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13412,7 +13412,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13494,7 +13494,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13582,7 +13582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13671,7 +13671,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13774,7 +13774,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13880,7 +13880,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13956,7 +13956,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14196,7 +14196,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14288,7 +14288,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := sdk.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14375,7 +14375,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14482,7 +14482,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14570,7 +14570,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14672,7 +14672,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14805,7 +14805,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14935,7 +14935,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15002,7 +15002,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15087,7 +15087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15166,7 +15166,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15254,7 +15254,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15356,7 +15356,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15445,7 +15445,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15588,7 +15588,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15679,7 +15679,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15749,7 +15749,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15865,7 +15865,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15984,7 +15984,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16095,7 +16095,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16177,7 +16177,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16272,7 +16272,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16365,7 +16365,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16481,7 +16481,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16594,7 +16594,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16674,7 +16674,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16758,7 +16758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16836,7 +16836,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16914,7 +16914,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16996,7 +16996,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17089,7 +17089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17160,7 +17160,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17239,7 +17239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17336,7 +17336,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17434,7 +17434,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17543,7 +17543,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17633,7 +17633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17724,7 +17724,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17811,7 +17811,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17887,7 +17887,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17963,7 +17963,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18027,7 +18027,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := sdk.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18092,7 +18092,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18168,7 +18168,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18232,7 +18232,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18296,7 +18296,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18363,7 +18363,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18430,7 +18430,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := sdk.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18497,7 +18497,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18625,7 +18625,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18718,7 +18718,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18807,7 +18807,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18889,7 +18889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18969,7 +18969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19066,7 +19066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19136,7 +19136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19215,7 +19215,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19294,7 +19294,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19374,7 +19374,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19468,7 +19468,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19553,7 +19553,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19654,7 +19654,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19736,7 +19736,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19818,7 +19818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19919,7 +19919,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20014,7 +20014,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20107,7 +20107,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20200,7 +20200,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20282,7 +20282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20352,7 +20352,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20431,7 +20431,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20512,7 +20512,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20603,7 +20603,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20693,7 +20693,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20781,7 +20781,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20880,7 +20880,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20965,7 +20965,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21059,7 +21059,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21154,7 +21154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21268,7 +21268,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21372,7 +21372,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21477,7 +21477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21549,7 +21549,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21633,7 +21633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21715,7 +21715,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21794,7 +21794,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21876,7 +21876,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21959,7 +21959,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22035,7 +22035,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22113,7 +22113,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22200,7 +22200,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22287,7 +22287,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22413,7 +22413,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22500,7 +22500,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22584,7 +22584,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22719,7 +22719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22961,7 +22961,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23057,7 +23057,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23177,7 +23177,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23313,7 +23313,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23386,7 +23386,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := sdk.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23457,7 +23457,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23540,7 +23540,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23623,7 +23623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23705,7 +23705,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23781,7 +23781,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23857,7 +23857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23939,7 +23939,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24030,7 +24030,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24127,7 +24127,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24221,7 +24221,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24312,7 +24312,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24404,7 +24404,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24483,7 +24483,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24566,7 +24566,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24651,7 +24651,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := sdk.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24734,7 +24734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24825,7 +24825,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24898,7 +24898,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24980,7 +24980,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25053,7 +25053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25132,7 +25132,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25214,7 +25214,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25299,7 +25299,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25393,7 +25393,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25502,7 +25502,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25587,7 +25587,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25678,7 +25678,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25769,7 +25769,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25852,7 +25852,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25955,7 +25955,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26040,7 +26040,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26132,7 +26132,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26218,7 +26218,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26319,7 +26319,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26386,7 +26386,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26465,7 +26465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26529,7 +26529,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := sdk.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26596,7 +26596,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := sdk.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26677,7 +26677,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26756,7 +26756,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26850,7 +26850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26932,7 +26932,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27028,7 +27028,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27118,7 +27118,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27203,7 +27203,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27279,7 +27279,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27353,7 +27353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27438,7 +27438,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27518,7 +27518,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27598,7 +27598,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27681,7 +27681,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27762,7 +27762,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27857,7 +27857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27949,7 +27949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28055,7 +28055,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28155,7 +28155,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28250,7 +28250,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28328,7 +28328,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28419,7 +28419,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28534,7 +28534,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28625,7 +28625,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28698,7 +28698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28788,7 +28788,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28873,7 +28873,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28955,7 +28955,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29037,7 +29037,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29119,7 +29119,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29199,7 +29199,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29293,7 +29293,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29451,7 +29451,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29521,7 +29521,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29609,7 +29609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29690,7 +29690,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29763,7 +29763,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29830,7 +29830,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := sdk.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29909,7 +29909,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29982,7 +29982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30064,7 +30064,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30150,7 +30150,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30239,7 +30239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30325,7 +30325,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30414,7 +30414,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30501,7 +30501,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30602,7 +30602,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30700,7 +30700,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30804,7 +30804,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30902,7 +30902,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30984,7 +30984,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31069,7 +31069,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31165,7 +31165,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31243,7 +31243,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31320,7 +31320,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31399,7 +31399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20230201001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-02-01.yaml
@@ -28684,7 +28684,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSystemStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		GetSystemStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -28755,7 +28755,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).
                     		Execute()
                     }
@@ -28827,7 +28827,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersForAllProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersForAllProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -28899,7 +28899,7 @@ paths:
                     	}
 
                     	params = &sdk.ListEventTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListEventTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -28969,7 +28969,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederationAppApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteFederationAppWithParams(ctx, params).
                     		Execute()
                     }
@@ -29044,7 +29044,7 @@ paths:
                     	}
 
                     	params = &sdk.ListConnectedOrgConfigsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListConnectedOrgConfigsWithParams(ctx, params).
                     		Execute()
                     }
@@ -29127,7 +29127,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveConnectedOrgConfigApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RemoveConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -29209,7 +29209,7 @@ paths:
                     	}
 
                     	params = &sdk.GetConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -29298,7 +29298,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -29376,7 +29376,7 @@ paths:
                     	}
 
                     	params = &sdk.ListRoleMappingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListRoleMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -29456,7 +29456,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29542,7 +29542,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteRoleMappingApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29625,7 +29625,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29715,7 +29715,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29816,7 +29816,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIdentityProvidersApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListIdentityProvidersWithParams(ctx, params).
                     		Execute()
                     }
@@ -29899,7 +29899,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -29990,7 +29990,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -30068,7 +30068,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderMetadataApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderMetadataWithParams(ctx, params).
                     		Execute()
                     }
@@ -30142,7 +30142,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30233,7 +30233,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30309,7 +30309,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30380,7 +30380,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30462,7 +30462,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30548,7 +30548,7 @@ paths:
                     	}
 
                     	params = &sdk.AddUserToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		AddUserToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30628,7 +30628,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectIpAccessListsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		ListProjectIpAccessListsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30716,7 +30716,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectIpAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		CreateProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -30808,7 +30808,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectIpAccessListApiParams{}
-                    	httpResp, err := sdk.ProjectIPAccessListApi.
+                    	httpResp, err := client.ProjectIPAccessListApi.
                     		DeleteProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -30892,7 +30892,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpListWithParams(ctx, params).
                     		Execute()
                     }
@@ -30976,7 +30976,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpAccessListStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpAccessListStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -31052,7 +31052,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31133,7 +31133,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		CreateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31220,7 +31220,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAlertConfigurationApiParams{}
-                    	httpResp, err := sdk.AlertConfigurationsApi.
+                    	httpResp, err := client.AlertConfigurationsApi.
                     		DeleteAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31304,7 +31304,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		GetAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31397,7 +31397,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ToggleAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31496,7 +31496,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		UpdateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31588,7 +31588,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsByAlertConfigurationIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsByAlertConfigurationIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -31675,7 +31675,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31759,7 +31759,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		GetAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -31852,7 +31852,7 @@ paths:
                     	}
 
                     	params = &sdk.AcknowledgeAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		AcknowledgeAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -31944,7 +31944,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsByAlertIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsByAlertIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -32020,7 +32020,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListProjectApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -32096,7 +32096,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -32184,7 +32184,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		RemoveProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -32274,7 +32274,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -32365,7 +32365,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		AddProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -32439,7 +32439,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		GetAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32517,7 +32517,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		UpdateAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32591,7 +32591,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		GetAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -32667,7 +32667,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		ToggleAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -32745,7 +32745,7 @@ paths:
                     	}
 
                     	params = &sdk.ListExportBucketsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListExportBucketsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32829,7 +32829,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -32917,7 +32917,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteExportBucketApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -32998,7 +32998,7 @@ paths:
                     	}
 
                     	params = &sdk.GetExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -33072,7 +33072,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33162,7 +33162,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33237,7 +33237,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderAccessRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		ListCloudProviderAccessRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -33316,7 +33316,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		CreateCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33407,7 +33407,7 @@ paths:
                     	}
 
                     	params = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}
-                    	httpResp, err := sdk.CloudProviderAccessApi.
+                    	httpResp, err := client.CloudProviderAccessApi.
                     		DeauthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33486,7 +33486,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		GetCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33578,7 +33578,7 @@ paths:
                     	}
 
                     	params = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		AuthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33662,7 +33662,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersWithParams(ctx, params).
                     		Execute()
                     }
@@ -33748,7 +33748,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		CreateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -33841,7 +33841,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteClusterApiParams{}
-                    	httpResp, err := sdk.ClustersApi.
+                    	httpResp, err := client.ClustersApi.
                     		DeleteClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -33924,7 +33924,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -34017,7 +34017,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -34104,7 +34104,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupExportJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupExportJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34194,7 +34194,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34282,7 +34282,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34364,7 +34364,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34458,7 +34458,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34552,7 +34552,7 @@ paths:
                     	}
 
                     	params = &sdk.CancelBackupRestoreJobApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		CancelBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34639,7 +34639,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34720,7 +34720,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllBackupSchedulesApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteAllBackupSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -34800,7 +34800,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34892,7 +34892,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34981,7 +34981,7 @@ paths:
                     	}
 
                     	params = &sdk.ListReplicaSetBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListReplicaSetBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35071,7 +35071,7 @@ paths:
                     	}
 
                     	params = &sdk.TakeSnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		TakeSnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -35165,7 +35165,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteReplicaSetBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35254,7 +35254,7 @@ paths:
                     	}
 
                     	params = &sdk.GetReplicaSetBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35350,7 +35350,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateSnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateSnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -35442,7 +35442,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteShardedClusterBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35531,7 +35531,7 @@ paths:
                     	}
 
                     	params = &sdk.GetShardedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35612,7 +35612,7 @@ paths:
                     	}
 
                     	params = &sdk.ListShardedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListShardedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35706,7 +35706,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		DownloadSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35802,7 +35802,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		CreateSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -35887,7 +35887,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		ListSharedClusterBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35977,7 +35977,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		GetSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36058,7 +36058,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		ListSharedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36148,7 +36148,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		GetSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -36231,7 +36231,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupCheckpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupCheckpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36324,7 +36324,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupCheckpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupCheckpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -36418,7 +36418,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36520,7 +36520,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36615,7 +36615,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36707,7 +36707,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36810,7 +36810,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36898,7 +36898,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		GetManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -36982,7 +36982,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllCustomZoneMappingsApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteAllCustomZoneMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37074,7 +37074,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomZoneMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateCustomZoneMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -37174,7 +37174,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteManagedNamespaceApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -37268,7 +37268,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -37427,7 +37427,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRollingIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.RollingIndexApi.
+                    	sdkResp, httpResp, err := client.RollingIndexApi.
                     		CreateRollingIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -37516,7 +37516,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOnlineArchivesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		ListOnlineArchivesWithParams(ctx, params).
                     		Execute()
                     }
@@ -37610,7 +37610,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		CreateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -37707,7 +37707,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOnlineArchiveApiParams{}
-                    	httpResp, err := sdk.OnlineArchiveApi.
+                    	httpResp, err := client.OnlineArchiveApi.
                     		DeleteOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -37801,7 +37801,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		GetOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -37904,7 +37904,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		UpdateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -38017,7 +38017,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		DownloadOnlineArchiveQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38103,7 +38103,7 @@ paths:
                     	}
 
                     	params = &sdk.EndOutageSimulationApiParams{}
-                    	httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	httpResp, err := client.ClusterOutageSimulationApi.
                     		EndOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38188,7 +38188,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		GetOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38278,7 +38278,7 @@ paths:
                     	}
 
                     	params = &sdk.StartOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		StartOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38367,7 +38367,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38462,7 +38462,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38544,7 +38544,7 @@ paths:
                     	}
 
                     	params = &sdk.TestFailoverApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		TestFailoverWithParams(ctx, params).
                     		Execute()
                     }
@@ -38644,7 +38644,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38732,7 +38732,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		CreateLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -38830,7 +38830,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -38912,7 +38912,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchDeploymentApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -38994,7 +38994,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -39085,7 +39085,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -39180,7 +39180,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -39268,7 +39268,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -39357,7 +39357,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -39454,7 +39454,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacySnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacySnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39545,7 +39545,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLegacySnapshotApiParams{}
-                    	httpResp, err := sdk.LegacyBackupApi.
+                    	httpResp, err := client.LegacyBackupApi.
                     		DeleteLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -39633,7 +39633,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -39728,7 +39728,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -39811,7 +39811,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -39925,7 +39925,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40010,7 +40010,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderRegionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListCloudProviderRegionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40095,7 +40095,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -40184,7 +40184,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterToServerlessApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterToServerlessWithParams(ctx, params).
                     		Execute()
                     }
@@ -40274,7 +40274,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainerByCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainerByCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -40358,7 +40358,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40448,7 +40448,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringContainerApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40527,7 +40527,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40621,7 +40621,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40698,7 +40698,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainersApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainersWithParams(ctx, params).
                     		Execute()
                     }
@@ -40770,7 +40770,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCustomDatabaseRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		ListCustomDatabaseRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -40854,7 +40854,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		CreateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -40938,7 +40938,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteCustomDatabaseRoleApiParams{}
-                    	httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	httpResp, err := client.CustomDatabaseRolesApi.
                     		DeleteCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41015,7 +41015,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		GetCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41105,7 +41105,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		UpdateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41190,7 +41190,7 @@ paths:
                     	}
 
                     	params = &sdk.ListFederatedDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListFederatedDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -41272,7 +41272,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41352,7 +41352,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederatedDatabaseApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41430,7 +41430,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41520,7 +41520,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		UpdateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41604,7 +41604,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -41698,7 +41698,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -41792,7 +41792,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -41896,7 +41896,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOneDataFederationQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateOneDataFederationQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -42000,7 +42000,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		DownloadFederatedDatabaseQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -42073,7 +42073,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		ListDatabaseUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -42248,7 +42248,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		CreateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42352,7 +42352,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDatabaseUserApiParams{}
-                    	httpResp, err := sdk.DatabaseUsersApi.
+                    	httpResp, err := client.DatabaseUsersApi.
                     		DeleteDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42449,7 +42449,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		GetDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42559,7 +42559,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		UpdateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42644,7 +42644,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUserCertificatesApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		ListDatabaseUserCertificatesWithParams(ctx, params).
                     		Execute()
                     }
@@ -42743,7 +42743,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserCertificateApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		CreateDatabaseUserCertificateWithParams(ctx, params).
                     		Execute()
                     }
@@ -42863,7 +42863,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByClusterNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByClusterNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42976,7 +42976,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByHostnameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByHostnameWithParams(ctx, params).
                     		Execute()
                     }
@@ -43049,7 +43049,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -43143,7 +43143,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		UpdateEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -43225,7 +43225,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -43309,7 +43309,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		CreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -43407,7 +43407,7 @@ paths:
                     	}
 
                     	params = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}
-                    	httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43493,7 +43493,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -43620,7 +43620,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListProjectEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43710,7 +43710,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetProjectEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -43782,7 +43782,7 @@ paths:
                     	}
 
                     	params = &sdk.ListMetricTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListMetricTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -43884,7 +43884,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43985,7 +43985,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44085,7 +44085,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44162,7 +44162,7 @@ paths:
                     	}
 
                     	params = &sdk.ListThirdPartyIntegrationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		ListThirdPartyIntegrationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44254,7 +44254,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteThirdPartyIntegrationApiParams{}
-                    	httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	httpResp, err := client.Third - PartyIntegrationsApi.
                     		DeleteThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44345,7 +44345,7 @@ paths:
                     	}
 
                     	params = &sdk.GetThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		GetThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44448,7 +44448,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		CreateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44553,7 +44553,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		UpdateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44636,7 +44636,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44718,7 +44718,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44800,7 +44800,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44884,7 +44884,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectInvitationApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44966,7 +44966,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45056,7 +45056,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -45133,7 +45133,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ReturnAllIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -45211,7 +45211,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45321,7 +45321,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectLimitApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45432,7 +45432,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45553,7 +45553,7 @@ paths:
                     	}
 
                     	params = &sdk.SetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		SetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45650,7 +45650,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreatePushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45730,7 +45730,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetPushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45805,7 +45805,7 @@ paths:
                     	}
 
                     	params = &sdk.CutoverMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CutoverMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45895,7 +45895,7 @@ paths:
                     	}
 
                     	params = &sdk.ValidateMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ValidateMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45985,7 +45985,7 @@ paths:
                     	}
 
                     	params = &sdk.GetValidationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetValidationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -46054,7 +46054,7 @@ paths:
                     	}
 
                     	params = &sdk.ResetMaintenanceWindowApiParams{}
-                    	httpResp, err := sdk.MaintenanceWindowsApi.
+                    	httpResp, err := client.MaintenanceWindowsApi.
                     		ResetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -46123,7 +46123,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		GetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -46200,7 +46200,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		UpdateMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -46273,7 +46273,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleMaintenanceAutoDeferApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		ToggleMaintenanceAutoDeferWithParams(ctx, params).
                     		Execute()
                     }
@@ -46346,7 +46346,7 @@ paths:
                     	}
 
                     	params = &sdk.DeferMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		DeferMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -46420,7 +46420,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedSlowMsApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetManagedSlowMsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46490,7 +46490,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableSlowOperationThresholdingApiParams{}
-                    	httpResp, err := sdk.PerformanceAdvisorApi.
+                    	httpResp, err := client.PerformanceAdvisorApi.
                     		DisableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -46560,7 +46560,7 @@ paths:
                     	}
 
                     	params = &sdk.EnableSlowOperationThresholdingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		EnableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -46675,7 +46675,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLTSVersionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLTSVersionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46760,7 +46760,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46845,7 +46845,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -46930,7 +46930,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringConnectionApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47010,7 +47010,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47101,7 +47101,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47178,7 +47178,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelinesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelinesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47257,7 +47257,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		CreatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47341,7 +47341,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47421,7 +47421,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47511,7 +47511,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		UpdatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47598,7 +47598,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSchedulesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47689,7 +47689,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47770,7 +47770,7 @@ paths:
                     	}
 
                     	params = &sdk.PausePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		PausePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47855,7 +47855,7 @@ paths:
                     	}
 
                     	params = &sdk.ResumePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ResumePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47950,7 +47950,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineRunsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineRunsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48041,7 +48041,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineRunDatasetApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineRunDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -48131,7 +48131,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineRunApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineRunWithParams(ctx, params).
                     		Execute()
                     }
@@ -48219,7 +48219,7 @@ paths:
                     	}
 
                     	params = &sdk.TriggerSnapshotIngestionApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		TriggerSnapshotIngestionWithParams(ctx, params).
                     		Execute()
                     }
@@ -48306,7 +48306,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPrivateEndpointServicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ListPrivateEndpointServicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -48396,7 +48396,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointServiceApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -48487,7 +48487,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -48590,7 +48590,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -48691,7 +48691,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -48789,7 +48789,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -48869,7 +48869,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -48945,7 +48945,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -49023,7 +49023,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -49108,7 +49108,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		ListServerlessPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -49199,7 +49199,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		CreateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49291,7 +49291,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		DeleteServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49378,7 +49378,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		GetServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49472,7 +49472,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		UpdateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49550,7 +49550,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -49632,7 +49632,7 @@ paths:
                     	}
 
                     	params = &sdk.DisablePeeringApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		DisablePeeringWithParams(ctx, params).
                     		Execute()
                     }
@@ -49713,7 +49713,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDataFederationPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListDataFederationPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -49810,7 +49810,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49895,7 +49895,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDataFederationPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49977,7 +49977,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -50050,7 +50050,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasProcessesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListAtlasProcessesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50128,7 +50128,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetAtlasProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -50209,7 +50209,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50293,7 +50293,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -50403,7 +50403,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50484,7 +50484,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskPartitionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskPartitionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50567,7 +50567,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50693,7 +50693,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50930,7 +50930,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51028,7 +51028,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueryNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueryNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51143,7 +51143,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51265,7 +51265,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSuggestedIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSuggestedIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51339,7 +51339,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePushBasedLogConfigurationApiParams{}
-                    	httpResp, err := sdk.Push - BasedLogExportApi.
+                    	httpResp, err := client.Push - BasedLogExportApi.
                     		DeletePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51412,7 +51412,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		GetPushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51493,7 +51493,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		UpdatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51578,7 +51578,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		CreatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51664,7 +51664,7 @@ paths:
                     	}
 
                     	params = &sdk.LoadSampleDatasetApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		LoadSampleDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -51746,7 +51746,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSampleDatasetLoadStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetSampleDatasetLoadStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -51819,7 +51819,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		ListServerlessInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51899,7 +51899,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		CreateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -51987,7 +51987,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52078,7 +52078,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -52172,7 +52172,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -52256,7 +52256,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52346,7 +52346,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -52425,7 +52425,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52508,7 +52508,7 @@ paths:
                     	}
 
                     	params = &sdk.SetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		SetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52595,7 +52595,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessInstanceApiParams{}
-                    	httpResp, err := sdk.ServerlessInstancesApi.
+                    	httpResp, err := client.ServerlessInstancesApi.
                     		DeleteServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52677,7 +52677,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		GetServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52764,7 +52764,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		UpdateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52842,7 +52842,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52922,7 +52922,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52998,7 +52998,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53076,7 +53076,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -53160,7 +53160,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamInstanceApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -53243,7 +53243,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -53331,7 +53331,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -53436,7 +53436,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadStreamTenantAuditLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		DownloadStreamTenantAuditLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53516,7 +53516,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53602,7 +53602,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -53692,7 +53692,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamConnectionApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -53774,7 +53774,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -53868,7 +53868,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -53951,7 +53951,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListProjectTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54038,7 +54038,7 @@ paths:
                     	}
 
                     	params = &sdk.AddAllTeamsToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddAllTeamsToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -54127,7 +54127,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveProjectTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -54221,7 +54221,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateTeamRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		UpdateTeamRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54295,7 +54295,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -54376,7 +54376,7 @@ paths:
                     	}
 
                     	params = &sdk.SaveLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		SaveLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -54452,7 +54452,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableCustomerManagedX509ApiParams{}
-                    	httpResp, err := sdk.X509AuthenticationApi.
+                    	httpResp, err := client.X509AuthenticationApi.
                     		DisableCustomerManagedX509WithParams(ctx, params).
                     		Execute()
                     }
@@ -54522,7 +54522,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLDAPConfigurationApiParams{}
-                    	httpResp, err := sdk.LDAPConfigurationApi.
+                    	httpResp, err := client.LDAPConfigurationApi.
                     		DeleteLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -54601,7 +54601,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		VerifyLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -54684,7 +54684,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -54769,7 +54769,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -54850,7 +54850,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectUserApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		RemoveProjectUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -54940,7 +54940,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55027,7 +55027,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -55110,7 +55110,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55193,7 +55193,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55279,7 +55279,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55354,7 +55354,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55436,7 +55436,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		RenameOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55516,7 +55516,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -55595,7 +55595,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -55681,7 +55681,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -55762,7 +55762,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -55852,7 +55852,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -55941,7 +55941,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeyAccessListsEntriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeyAccessListsEntriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -56035,7 +56035,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -56133,7 +56133,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyAccessListEntryApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyAccessListEntryWithParams(ctx, params).
                     		Execute()
                     }
@@ -56224,7 +56224,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -56302,7 +56302,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -56394,7 +56394,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcess_1WithParams(ctx, params).
                     		Execute()
                     }
@@ -56499,7 +56499,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListOrganizationEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56589,7 +56589,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetOrganizationEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -56663,7 +56663,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetFederationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56753,7 +56753,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56835,7 +56835,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56915,7 +56915,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -56999,7 +56999,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57083,7 +57083,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationInvitationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57164,7 +57164,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57253,7 +57253,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -57391,7 +57391,7 @@ paths:
                     	}
 
                     	params = &sdk.ListInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -57478,7 +57478,7 @@ paths:
                     	}
 
                     	params = &sdk.GetInvoiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		GetInvoiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57566,7 +57566,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadInvoiceCSVApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		DownloadInvoiceCSVWithParams(ctx, params).
                     		Execute()
                     }
@@ -57638,7 +57638,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPendingInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListPendingInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -57712,7 +57712,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSourceProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ListSourceProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57783,7 +57783,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLinkTokenApiParams{}
-                    	httpResp, err := sdk.CloudMigrationServiceApi.
+                    	httpResp, err := client.CloudMigrationServiceApi.
                     		DeleteLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -57861,7 +57861,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLinkTokenApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreateLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -57939,7 +57939,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58019,7 +58019,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58103,7 +58103,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListOrganizationTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58188,7 +58188,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		CreateTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -58278,7 +58278,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		DeleteTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -58363,7 +58363,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -58457,7 +58457,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		RenameTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -58551,7 +58551,7 @@ paths:
                     	}
 
                     	params = &sdk.ListTeamUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListTeamUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -58647,7 +58647,7 @@ paths:
                     	}
 
                     	params = &sdk.AddTeamUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -58744,7 +58744,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveTeamUserApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -58827,7 +58827,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -58904,7 +58904,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -58988,7 +58988,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveOrganizationUserApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		RemoveOrganizationUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -59078,7 +59078,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -59165,7 +59165,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		CreateUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -59249,7 +59249,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -59327,7 +59327,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserByUsernameApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserByUsernameWithParams(ctx, params).
                     		Execute()
                     }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.json
@@ -252,7 +252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -319,7 +319,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -392,7 +392,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -465,7 +465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -529,7 +529,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -605,7 +605,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -688,7 +688,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -769,7 +769,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -861,7 +861,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -934,7 +934,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1016,7 +1016,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1099,7 +1099,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1183,7 +1183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1278,7 +1278,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1386,7 +1386,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1470,7 +1470,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1561,7 +1561,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1632,7 +1632,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1708,7 +1708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1804,7 +1804,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1888,7 +1888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1958,7 +1958,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2026,7 +2026,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2111,7 +2111,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2197,7 +2197,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2277,7 +2277,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2375,7 +2375,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2460,7 +2460,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := sdk.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2546,7 +2546,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2633,7 +2633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2709,7 +2709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2788,7 +2788,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2868,7 +2868,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := sdk.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2949,7 +2949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3041,7 +3041,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3136,7 +3136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3228,7 +3228,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3320,7 +3320,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3402,7 +3402,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3497,7 +3497,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3589,7 +3589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3669,7 +3669,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3745,7 +3745,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3831,7 +3831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3931,7 +3931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4022,7 +4022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4089,7 +4089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4168,7 +4168,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4235,7 +4235,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4311,7 +4311,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4388,7 +4388,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4474,7 +4474,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4558,7 +4558,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4637,7 +4637,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4708,7 +4708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4800,7 +4800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4867,7 +4867,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4947,7 +4947,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5038,7 +5038,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := sdk.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5117,7 +5117,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5215,7 +5215,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5301,7 +5301,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5391,7 +5391,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5487,7 +5487,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5577,7 +5577,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5667,7 +5667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5760,7 +5760,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := sdk.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5844,7 +5844,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5943,7 +5943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6032,7 +6032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6126,7 +6126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6211,7 +6211,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6299,7 +6299,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6396,7 +6396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6490,7 +6490,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6579,7 +6579,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6659,7 +6659,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6738,7 +6738,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6831,7 +6831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6923,7 +6923,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7014,7 +7014,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7105,7 +7105,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7197,7 +7197,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7279,7 +7279,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7373,7 +7373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7465,7 +7465,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7568,7 +7568,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7670,7 +7670,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7769,7 +7769,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7851,7 +7851,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7945,7 +7945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8027,7 +8027,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8121,7 +8121,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8210,7 +8210,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8308,7 +8308,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8409,7 +8409,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8515,7 +8515,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8615,7 +8615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8710,7 +8710,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8822,7 +8822,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8907,7 +8907,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8992,7 +8992,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9089,7 +9089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9193,7 +9193,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9293,7 +9293,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9479,7 +9479,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9571,7 +9571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9672,7 +9672,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9791,7 +9791,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9889,7 +9889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := sdk.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9988,7 +9988,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10101,7 +10101,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10190,7 +10190,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10277,7 +10277,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10372,7 +10372,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10459,7 +10459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10560,7 +10560,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10637,7 +10637,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10740,7 +10740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10832,7 +10832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10927,7 +10927,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11010,7 +11010,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11092,7 +11092,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11188,7 +11188,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11284,7 +11284,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11365,7 +11365,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11454,7 +11454,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11557,7 +11557,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11652,7 +11652,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := sdk.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11742,7 +11742,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11843,7 +11843,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11922,7 +11922,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12049,7 +12049,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12143,7 +12143,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12231,7 +12231,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12307,7 +12307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12396,7 +12396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12474,7 +12474,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12575,7 +12575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12645,7 +12645,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12733,7 +12733,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12815,7 +12815,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12892,7 +12892,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12989,7 +12989,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13072,7 +13072,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13157,7 +13157,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13233,7 +13233,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13310,7 +13310,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13407,7 +13407,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13489,7 +13489,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13577,7 +13577,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13666,7 +13666,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13769,7 +13769,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13875,7 +13875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13951,7 +13951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14191,7 +14191,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14283,7 +14283,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := sdk.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14370,7 +14370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14477,7 +14477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14565,7 +14565,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14667,7 +14667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14800,7 +14800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14930,7 +14930,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14997,7 +14997,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15082,7 +15082,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15161,7 +15161,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15249,7 +15249,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15351,7 +15351,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15440,7 +15440,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15583,7 +15583,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15674,7 +15674,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15744,7 +15744,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15860,7 +15860,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15979,7 +15979,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16090,7 +16090,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16172,7 +16172,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16267,7 +16267,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16360,7 +16360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16476,7 +16476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16589,7 +16589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16669,7 +16669,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16753,7 +16753,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16831,7 +16831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16909,7 +16909,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16991,7 +16991,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17084,7 +17084,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17155,7 +17155,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17234,7 +17234,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17331,7 +17331,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17429,7 +17429,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17538,7 +17538,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17628,7 +17628,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17719,7 +17719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17806,7 +17806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17882,7 +17882,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17958,7 +17958,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18022,7 +18022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := sdk.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18087,7 +18087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18163,7 +18163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18227,7 +18227,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18291,7 +18291,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18358,7 +18358,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18425,7 +18425,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := sdk.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18492,7 +18492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18620,7 +18620,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18713,7 +18713,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18802,7 +18802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18884,7 +18884,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18964,7 +18964,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19061,7 +19061,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19131,7 +19131,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19210,7 +19210,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19289,7 +19289,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19369,7 +19369,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19463,7 +19463,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19548,7 +19548,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19649,7 +19649,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19731,7 +19731,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19813,7 +19813,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19914,7 +19914,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20009,7 +20009,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20102,7 +20102,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20195,7 +20195,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20277,7 +20277,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20347,7 +20347,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20426,7 +20426,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20507,7 +20507,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20598,7 +20598,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20688,7 +20688,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20776,7 +20776,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20875,7 +20875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20960,7 +20960,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21054,7 +21054,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21149,7 +21149,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21263,7 +21263,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21367,7 +21367,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21472,7 +21472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21544,7 +21544,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21628,7 +21628,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21710,7 +21710,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21789,7 +21789,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21871,7 +21871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21954,7 +21954,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22030,7 +22030,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22108,7 +22108,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22195,7 +22195,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22282,7 +22282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22408,7 +22408,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22495,7 +22495,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22579,7 +22579,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22714,7 +22714,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22956,7 +22956,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23052,7 +23052,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23172,7 +23172,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23308,7 +23308,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23381,7 +23381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := sdk.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23452,7 +23452,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23535,7 +23535,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23618,7 +23618,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23700,7 +23700,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23776,7 +23776,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23852,7 +23852,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23934,7 +23934,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24025,7 +24025,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24122,7 +24122,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24216,7 +24216,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24307,7 +24307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24399,7 +24399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24478,7 +24478,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24561,7 +24561,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24646,7 +24646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := sdk.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24729,7 +24729,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24820,7 +24820,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24896,7 +24896,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24976,7 +24976,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25056,7 +25056,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := sdk.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25133,7 +25133,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25224,7 +25224,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25317,7 +25317,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25390,7 +25390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25472,7 +25472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25545,7 +25545,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25624,7 +25624,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25706,7 +25706,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25791,7 +25791,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25885,7 +25885,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25994,7 +25994,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26079,7 +26079,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26170,7 +26170,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26261,7 +26261,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26344,7 +26344,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26447,7 +26447,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26532,7 +26532,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26624,7 +26624,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26710,7 +26710,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26811,7 +26811,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26878,7 +26878,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26957,7 +26957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27021,7 +27021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := sdk.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27088,7 +27088,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := sdk.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27169,7 +27169,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27248,7 +27248,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27342,7 +27342,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27424,7 +27424,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27520,7 +27520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27610,7 +27610,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27695,7 +27695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27771,7 +27771,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27845,7 +27845,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27930,7 +27930,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28010,7 +28010,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28090,7 +28090,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28173,7 +28173,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28254,7 +28254,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28349,7 +28349,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28441,7 +28441,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28547,7 +28547,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28647,7 +28647,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28742,7 +28742,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28820,7 +28820,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28911,7 +28911,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29026,7 +29026,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29117,7 +29117,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29190,7 +29190,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29280,7 +29280,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29365,7 +29365,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29447,7 +29447,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29529,7 +29529,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29611,7 +29611,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29691,7 +29691,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29785,7 +29785,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29943,7 +29943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30013,7 +30013,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30101,7 +30101,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30182,7 +30182,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30255,7 +30255,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30322,7 +30322,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := sdk.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30401,7 +30401,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30477,7 +30477,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30556,7 +30556,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30632,7 +30632,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30709,7 +30709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30800,7 +30800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30885,7 +30885,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30975,7 +30975,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31060,7 +31060,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31133,7 +31133,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31215,7 +31215,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31301,7 +31301,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31390,7 +31390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31476,7 +31476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31565,7 +31565,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31652,7 +31652,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31753,7 +31753,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31851,7 +31851,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31955,7 +31955,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32053,7 +32053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32135,7 +32135,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32220,7 +32220,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32316,7 +32316,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32394,7 +32394,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32471,7 +32471,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32550,7 +32550,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231001001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-10-01.yaml
@@ -29105,7 +29105,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSystemStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		GetSystemStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -29176,7 +29176,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).
                     		Execute()
                     }
@@ -29248,7 +29248,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersForAllProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersForAllProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -29320,7 +29320,7 @@ paths:
                     	}
 
                     	params = &sdk.ListEventTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListEventTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -29390,7 +29390,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederationAppApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteFederationAppWithParams(ctx, params).
                     		Execute()
                     }
@@ -29465,7 +29465,7 @@ paths:
                     	}
 
                     	params = &sdk.ListConnectedOrgConfigsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListConnectedOrgConfigsWithParams(ctx, params).
                     		Execute()
                     }
@@ -29548,7 +29548,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveConnectedOrgConfigApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RemoveConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -29630,7 +29630,7 @@ paths:
                     	}
 
                     	params = &sdk.GetConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -29719,7 +29719,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -29797,7 +29797,7 @@ paths:
                     	}
 
                     	params = &sdk.ListRoleMappingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListRoleMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -29877,7 +29877,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -29963,7 +29963,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteRoleMappingApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30046,7 +30046,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30136,7 +30136,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30237,7 +30237,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIdentityProvidersApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListIdentityProvidersWithParams(ctx, params).
                     		Execute()
                     }
@@ -30320,7 +30320,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -30411,7 +30411,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -30489,7 +30489,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderMetadataApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderMetadataWithParams(ctx, params).
                     		Execute()
                     }
@@ -30563,7 +30563,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30654,7 +30654,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30730,7 +30730,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30801,7 +30801,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30883,7 +30883,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -30969,7 +30969,7 @@ paths:
                     	}
 
                     	params = &sdk.AddUserToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		AddUserToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31049,7 +31049,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectIpAccessListsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		ListProjectIpAccessListsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31137,7 +31137,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectIpAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		CreateProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -31229,7 +31229,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectIpAccessListApiParams{}
-                    	httpResp, err := sdk.ProjectIPAccessListApi.
+                    	httpResp, err := client.ProjectIPAccessListApi.
                     		DeleteProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -31313,7 +31313,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpListWithParams(ctx, params).
                     		Execute()
                     }
@@ -31397,7 +31397,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpAccessListStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpAccessListStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -31473,7 +31473,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31554,7 +31554,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		CreateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31641,7 +31641,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAlertConfigurationApiParams{}
-                    	httpResp, err := sdk.AlertConfigurationsApi.
+                    	httpResp, err := client.AlertConfigurationsApi.
                     		DeleteAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31725,7 +31725,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		GetAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31818,7 +31818,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ToggleAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -31917,7 +31917,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		UpdateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32009,7 +32009,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsByAlertConfigurationIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsByAlertConfigurationIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -32096,7 +32096,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32180,7 +32180,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		GetAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -32273,7 +32273,7 @@ paths:
                     	}
 
                     	params = &sdk.AcknowledgeAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		AcknowledgeAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -32365,7 +32365,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsByAlertIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsByAlertIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -32441,7 +32441,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListProjectApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -32517,7 +32517,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -32605,7 +32605,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		RemoveProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -32695,7 +32695,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -32786,7 +32786,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		AddProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -32860,7 +32860,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		GetAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32938,7 +32938,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		UpdateAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33012,7 +33012,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		GetAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -33088,7 +33088,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		ToggleAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -33166,7 +33166,7 @@ paths:
                     	}
 
                     	params = &sdk.ListExportBucketsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListExportBucketsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33250,7 +33250,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -33338,7 +33338,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteExportBucketApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -33419,7 +33419,7 @@ paths:
                     	}
 
                     	params = &sdk.GetExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -33492,7 +33492,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33579,7 +33579,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33653,7 +33653,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderAccessRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		ListCloudProviderAccessRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -33732,7 +33732,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		CreateCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33823,7 +33823,7 @@ paths:
                     	}
 
                     	params = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}
-                    	httpResp, err := sdk.CloudProviderAccessApi.
+                    	httpResp, err := client.CloudProviderAccessApi.
                     		DeauthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33902,7 +33902,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		GetCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -33994,7 +33994,7 @@ paths:
                     	}
 
                     	params = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		AuthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34078,7 +34078,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersWithParams(ctx, params).
                     		Execute()
                     }
@@ -34164,7 +34164,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		CreateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -34257,7 +34257,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteClusterApiParams{}
-                    	httpResp, err := sdk.ClustersApi.
+                    	httpResp, err := client.ClustersApi.
                     		DeleteClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -34340,7 +34340,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -34433,7 +34433,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -34520,7 +34520,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupExportJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupExportJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34610,7 +34610,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34698,7 +34698,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34780,7 +34780,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34874,7 +34874,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -34968,7 +34968,7 @@ paths:
                     	}
 
                     	params = &sdk.CancelBackupRestoreJobApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		CancelBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -35055,7 +35055,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -35136,7 +35136,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllBackupSchedulesApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteAllBackupSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -35216,7 +35216,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35308,7 +35308,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35397,7 +35397,7 @@ paths:
                     	}
 
                     	params = &sdk.ListReplicaSetBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListReplicaSetBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35487,7 +35487,7 @@ paths:
                     	}
 
                     	params = &sdk.TakeSnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		TakeSnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -35581,7 +35581,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteReplicaSetBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35670,7 +35670,7 @@ paths:
                     	}
 
                     	params = &sdk.GetReplicaSetBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35766,7 +35766,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateSnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateSnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -35858,7 +35858,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteShardedClusterBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -35947,7 +35947,7 @@ paths:
                     	}
 
                     	params = &sdk.GetShardedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -36028,7 +36028,7 @@ paths:
                     	}
 
                     	params = &sdk.ListShardedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListShardedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36122,7 +36122,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		DownloadSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -36218,7 +36218,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		CreateSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36303,7 +36303,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		ListSharedClusterBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36393,7 +36393,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		GetSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36474,7 +36474,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		ListSharedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36564,7 +36564,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		GetSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -36647,7 +36647,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupCheckpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupCheckpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36740,7 +36740,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupCheckpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupCheckpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -36834,7 +36834,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -36936,7 +36936,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -37031,7 +37031,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -37123,7 +37123,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -37226,7 +37226,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -37314,7 +37314,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		GetManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -37398,7 +37398,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllCustomZoneMappingsApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteAllCustomZoneMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37490,7 +37490,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomZoneMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateCustomZoneMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -37590,7 +37590,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteManagedNamespaceApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -37684,7 +37684,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -37843,7 +37843,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRollingIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.RollingIndexApi.
+                    	sdkResp, httpResp, err := client.RollingIndexApi.
                     		CreateRollingIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -37932,7 +37932,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOnlineArchivesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		ListOnlineArchivesWithParams(ctx, params).
                     		Execute()
                     }
@@ -38026,7 +38026,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		CreateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -38123,7 +38123,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOnlineArchiveApiParams{}
-                    	httpResp, err := sdk.OnlineArchiveApi.
+                    	httpResp, err := client.OnlineArchiveApi.
                     		DeleteOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -38217,7 +38217,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		GetOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -38320,7 +38320,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		UpdateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -38433,7 +38433,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		DownloadOnlineArchiveQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38519,7 +38519,7 @@ paths:
                     	}
 
                     	params = &sdk.EndOutageSimulationApiParams{}
-                    	httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	httpResp, err := client.ClusterOutageSimulationApi.
                     		EndOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38604,7 +38604,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		GetOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38694,7 +38694,7 @@ paths:
                     	}
 
                     	params = &sdk.StartOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		StartOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38783,7 +38783,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38878,7 +38878,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -38960,7 +38960,7 @@ paths:
                     	}
 
                     	params = &sdk.TestFailoverApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		TestFailoverWithParams(ctx, params).
                     		Execute()
                     }
@@ -39060,7 +39060,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39148,7 +39148,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		CreateLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -39246,7 +39246,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -39328,7 +39328,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchDeploymentApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -39410,7 +39410,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -39501,7 +39501,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -39596,7 +39596,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -39684,7 +39684,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -39773,7 +39773,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -39870,7 +39870,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacySnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacySnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39961,7 +39961,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLegacySnapshotApiParams{}
-                    	httpResp, err := sdk.LegacyBackupApi.
+                    	httpResp, err := client.LegacyBackupApi.
                     		DeleteLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -40049,7 +40049,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -40144,7 +40144,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -40227,7 +40227,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -40341,7 +40341,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40426,7 +40426,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderRegionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListCloudProviderRegionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40511,7 +40511,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -40600,7 +40600,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterToServerlessApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterToServerlessWithParams(ctx, params).
                     		Execute()
                     }
@@ -40690,7 +40690,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainerByCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainerByCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -40774,7 +40774,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40864,7 +40864,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringContainerApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -40943,7 +40943,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -41037,7 +41037,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -41114,7 +41114,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainersApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainersWithParams(ctx, params).
                     		Execute()
                     }
@@ -41186,7 +41186,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCustomDatabaseRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		ListCustomDatabaseRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -41270,7 +41270,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		CreateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41354,7 +41354,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteCustomDatabaseRoleApiParams{}
-                    	httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	httpResp, err := client.CustomDatabaseRolesApi.
                     		DeleteCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41431,7 +41431,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		GetCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41521,7 +41521,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		UpdateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41606,7 +41606,7 @@ paths:
                     	}
 
                     	params = &sdk.ListFederatedDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListFederatedDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -41688,7 +41688,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41768,7 +41768,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederatedDatabaseApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41846,7 +41846,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -41936,7 +41936,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		UpdateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -42020,7 +42020,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -42114,7 +42114,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -42208,7 +42208,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -42312,7 +42312,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOneDataFederationQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateOneDataFederationQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -42416,7 +42416,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		DownloadFederatedDatabaseQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -42489,7 +42489,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		ListDatabaseUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -42664,7 +42664,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		CreateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42768,7 +42768,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDatabaseUserApiParams{}
-                    	httpResp, err := sdk.DatabaseUsersApi.
+                    	httpResp, err := client.DatabaseUsersApi.
                     		DeleteDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42865,7 +42865,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		GetDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -42975,7 +42975,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		UpdateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -43060,7 +43060,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUserCertificatesApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		ListDatabaseUserCertificatesWithParams(ctx, params).
                     		Execute()
                     }
@@ -43159,7 +43159,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserCertificateApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		CreateDatabaseUserCertificateWithParams(ctx, params).
                     		Execute()
                     }
@@ -43279,7 +43279,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByClusterNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByClusterNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -43392,7 +43392,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByHostnameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByHostnameWithParams(ctx, params).
                     		Execute()
                     }
@@ -43465,7 +43465,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -43559,7 +43559,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		UpdateEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -43641,7 +43641,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -43725,7 +43725,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		CreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -43823,7 +43823,7 @@ paths:
                     	}
 
                     	params = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}
-                    	httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43909,7 +43909,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -44036,7 +44036,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListProjectEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44126,7 +44126,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetProjectEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -44198,7 +44198,7 @@ paths:
                     	}
 
                     	params = &sdk.ListMetricTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListMetricTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -44300,7 +44300,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44401,7 +44401,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44501,7 +44501,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44578,7 +44578,7 @@ paths:
                     	}
 
                     	params = &sdk.ListThirdPartyIntegrationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		ListThirdPartyIntegrationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44670,7 +44670,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteThirdPartyIntegrationApiParams{}
-                    	httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	httpResp, err := client.Third - PartyIntegrationsApi.
                     		DeleteThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44761,7 +44761,7 @@ paths:
                     	}
 
                     	params = &sdk.GetThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		GetThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44864,7 +44864,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		CreateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -44969,7 +44969,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		UpdateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45052,7 +45052,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45134,7 +45134,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45216,7 +45216,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45300,7 +45300,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectInvitationApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45382,7 +45382,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -45472,7 +45472,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -45549,7 +45549,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ReturnAllIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -45627,7 +45627,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45737,7 +45737,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectLimitApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45848,7 +45848,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45969,7 +45969,7 @@ paths:
                     	}
 
                     	params = &sdk.SetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		SetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -46066,7 +46066,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreatePushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46146,7 +46146,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetPushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46221,7 +46221,7 @@ paths:
                     	}
 
                     	params = &sdk.CutoverMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CutoverMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46311,7 +46311,7 @@ paths:
                     	}
 
                     	params = &sdk.ValidateMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ValidateMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46401,7 +46401,7 @@ paths:
                     	}
 
                     	params = &sdk.GetValidationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetValidationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -46470,7 +46470,7 @@ paths:
                     	}
 
                     	params = &sdk.ResetMaintenanceWindowApiParams{}
-                    	httpResp, err := sdk.MaintenanceWindowsApi.
+                    	httpResp, err := client.MaintenanceWindowsApi.
                     		ResetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -46539,7 +46539,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		GetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -46616,7 +46616,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		UpdateMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -46689,7 +46689,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleMaintenanceAutoDeferApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		ToggleMaintenanceAutoDeferWithParams(ctx, params).
                     		Execute()
                     }
@@ -46762,7 +46762,7 @@ paths:
                     	}
 
                     	params = &sdk.DeferMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		DeferMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -46836,7 +46836,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedSlowMsApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetManagedSlowMsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46906,7 +46906,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableSlowOperationThresholdingApiParams{}
-                    	httpResp, err := sdk.PerformanceAdvisorApi.
+                    	httpResp, err := client.PerformanceAdvisorApi.
                     		DisableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -46976,7 +46976,7 @@ paths:
                     	}
 
                     	params = &sdk.EnableSlowOperationThresholdingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		EnableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -47091,7 +47091,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLTSVersionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLTSVersionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47176,7 +47176,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47261,7 +47261,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47346,7 +47346,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringConnectionApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47426,7 +47426,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47517,7 +47517,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47594,7 +47594,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelinesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelinesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47673,7 +47673,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		CreatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47757,7 +47757,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47837,7 +47837,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -47927,7 +47927,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		UpdatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -48014,7 +48014,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSchedulesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -48105,7 +48105,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48186,7 +48186,7 @@ paths:
                     	}
 
                     	params = &sdk.PausePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		PausePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -48271,7 +48271,7 @@ paths:
                     	}
 
                     	params = &sdk.ResumePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ResumePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -48366,7 +48366,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineRunsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineRunsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48457,7 +48457,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineRunDatasetApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineRunDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -48547,7 +48547,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineRunApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineRunWithParams(ctx, params).
                     		Execute()
                     }
@@ -48635,7 +48635,7 @@ paths:
                     	}
 
                     	params = &sdk.TriggerSnapshotIngestionApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		TriggerSnapshotIngestionWithParams(ctx, params).
                     		Execute()
                     }
@@ -48722,7 +48722,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPrivateEndpointServicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ListPrivateEndpointServicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -48812,7 +48812,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointServiceApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -48903,7 +48903,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -49006,7 +49006,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49107,7 +49107,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49205,7 +49205,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49285,7 +49285,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -49361,7 +49361,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -49439,7 +49439,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -49524,7 +49524,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		ListServerlessPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -49615,7 +49615,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		CreateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49707,7 +49707,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		DeleteServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49794,7 +49794,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		GetServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49888,7 +49888,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		UpdateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -49966,7 +49966,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -50048,7 +50048,7 @@ paths:
                     	}
 
                     	params = &sdk.DisablePeeringApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		DisablePeeringWithParams(ctx, params).
                     		Execute()
                     }
@@ -50129,7 +50129,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDataFederationPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListDataFederationPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50226,7 +50226,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -50311,7 +50311,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDataFederationPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -50393,7 +50393,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -50466,7 +50466,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasProcessesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListAtlasProcessesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50544,7 +50544,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetAtlasProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -50625,7 +50625,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50709,7 +50709,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -50819,7 +50819,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50900,7 +50900,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskPartitionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskPartitionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50983,7 +50983,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51109,7 +51109,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51346,7 +51346,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51444,7 +51444,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueryNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueryNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51559,7 +51559,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51681,7 +51681,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSuggestedIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSuggestedIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51755,7 +51755,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePushBasedLogConfigurationApiParams{}
-                    	httpResp, err := sdk.Push - BasedLogExportApi.
+                    	httpResp, err := client.Push - BasedLogExportApi.
                     		DeletePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51828,7 +51828,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		GetPushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51909,7 +51909,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		UpdatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -51994,7 +51994,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		CreatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -52080,7 +52080,7 @@ paths:
                     	}
 
                     	params = &sdk.LoadSampleDatasetApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		LoadSampleDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -52162,7 +52162,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSampleDatasetLoadStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetSampleDatasetLoadStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -52235,7 +52235,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		ListServerlessInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -52315,7 +52315,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		CreateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52403,7 +52403,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52494,7 +52494,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -52588,7 +52588,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -52672,7 +52672,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52762,7 +52762,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -52841,7 +52841,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52924,7 +52924,7 @@ paths:
                     	}
 
                     	params = &sdk.SetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		SetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -53011,7 +53011,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessInstanceApiParams{}
-                    	httpResp, err := sdk.ServerlessInstancesApi.
+                    	httpResp, err := client.ServerlessInstancesApi.
                     		DeleteServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -53093,7 +53093,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		GetServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -53180,7 +53180,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		UpdateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -53258,7 +53258,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		ListProjectServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53337,7 +53337,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		CreateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -53420,7 +53420,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectServiceAccountApiParams{}
-                    	httpResp, err := sdk.GroupsApi.
+                    	httpResp, err := client.GroupsApi.
                     		DeleteProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -53497,7 +53497,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		GetProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -53583,7 +53583,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		UpdateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -53675,7 +53675,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		AddProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -53753,7 +53753,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53833,7 +53833,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53909,7 +53909,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53987,7 +53987,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -54071,7 +54071,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamInstanceApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -54154,7 +54154,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -54242,7 +54242,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -54347,7 +54347,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadStreamTenantAuditLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		DownloadStreamTenantAuditLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54427,7 +54427,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54513,7 +54513,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -54603,7 +54603,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamConnectionApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -54685,7 +54685,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -54779,7 +54779,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -54862,7 +54862,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListProjectTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54949,7 +54949,7 @@ paths:
                     	}
 
                     	params = &sdk.AddAllTeamsToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddAllTeamsToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -55038,7 +55038,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveProjectTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -55132,7 +55132,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateTeamRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		UpdateTeamRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55206,7 +55206,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55287,7 +55287,7 @@ paths:
                     	}
 
                     	params = &sdk.SaveLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		SaveLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55363,7 +55363,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableCustomerManagedX509ApiParams{}
-                    	httpResp, err := sdk.X509AuthenticationApi.
+                    	httpResp, err := client.X509AuthenticationApi.
                     		DisableCustomerManagedX509WithParams(ctx, params).
                     		Execute()
                     }
@@ -55433,7 +55433,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLDAPConfigurationApiParams{}
-                    	httpResp, err := sdk.LDAPConfigurationApi.
+                    	httpResp, err := client.LDAPConfigurationApi.
                     		DeleteLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55512,7 +55512,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		VerifyLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55595,7 +55595,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -55680,7 +55680,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -55761,7 +55761,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectUserApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		RemoveProjectUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -55851,7 +55851,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55938,7 +55938,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -56021,7 +56021,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56104,7 +56104,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -56190,7 +56190,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -56265,7 +56265,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -56347,7 +56347,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		RenameOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -56427,7 +56427,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -56506,7 +56506,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -56592,7 +56592,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -56673,7 +56673,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -56763,7 +56763,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -56852,7 +56852,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeyAccessListsEntriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeyAccessListsEntriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -56946,7 +56946,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -57044,7 +57044,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyAccessListEntryApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyAccessListEntryWithParams(ctx, params).
                     		Execute()
                     }
@@ -57135,7 +57135,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -57213,7 +57213,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -57305,7 +57305,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcess_1WithParams(ctx, params).
                     		Execute()
                     }
@@ -57410,7 +57410,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListOrganizationEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57500,7 +57500,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetOrganizationEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -57574,7 +57574,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetFederationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57664,7 +57664,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57746,7 +57746,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57826,7 +57826,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57910,7 +57910,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57994,7 +57994,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationInvitationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -58075,7 +58075,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -58164,7 +58164,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -58302,7 +58302,7 @@ paths:
                     	}
 
                     	params = &sdk.ListInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -58389,7 +58389,7 @@ paths:
                     	}
 
                     	params = &sdk.GetInvoiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		GetInvoiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -58477,7 +58477,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadInvoiceCSVApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		DownloadInvoiceCSVWithParams(ctx, params).
                     		Execute()
                     }
@@ -58549,7 +58549,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPendingInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListPendingInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -58623,7 +58623,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSourceProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ListSourceProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58694,7 +58694,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLinkTokenApiParams{}
-                    	httpResp, err := sdk.CloudMigrationServiceApi.
+                    	httpResp, err := client.CloudMigrationServiceApi.
                     		DeleteLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -58772,7 +58772,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLinkTokenApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreateLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -58850,7 +58850,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58928,7 +58928,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -59008,7 +59008,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -59085,7 +59085,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -59171,7 +59171,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -59255,7 +59255,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59340,7 +59340,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountSecretApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -59426,7 +59426,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountSecretApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -59500,7 +59500,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59580,7 +59580,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59664,7 +59664,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListOrganizationTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59749,7 +59749,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		CreateTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -59839,7 +59839,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		DeleteTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -59924,7 +59924,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -60018,7 +60018,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		RenameTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -60112,7 +60112,7 @@ paths:
                     	}
 
                     	params = &sdk.ListTeamUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListTeamUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -60208,7 +60208,7 @@ paths:
                     	}
 
                     	params = &sdk.AddTeamUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -60305,7 +60305,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveTeamUserApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -60388,7 +60388,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -60465,7 +60465,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -60549,7 +60549,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveOrganizationUserApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		RemoveOrganizationUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -60639,7 +60639,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -60726,7 +60726,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		CreateUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -60810,7 +60810,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -60888,7 +60888,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserByUsernameApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserByUsernameWithParams(ctx, params).
                     		Execute()
                     }

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.json
@@ -256,7 +256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -323,7 +323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -396,7 +396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -469,7 +469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -533,7 +533,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -609,7 +609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -692,7 +692,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -773,7 +773,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -865,7 +865,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -938,7 +938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1020,7 +1020,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1103,7 +1103,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1187,7 +1187,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1282,7 +1282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1390,7 +1390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1472,7 +1472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1549,7 +1549,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1630,7 +1630,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1719,7 +1719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1796,7 +1796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1866,7 +1866,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1942,7 +1942,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2038,7 +2038,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2122,7 +2122,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2192,7 +2192,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2260,7 +2260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2345,7 +2345,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2431,7 +2431,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2511,7 +2511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2609,7 +2609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2694,7 +2694,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := sdk.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2780,7 +2780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2867,7 +2867,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2943,7 +2943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3022,7 +3022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3102,7 +3102,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := sdk.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3183,7 +3183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3275,7 +3275,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3370,7 +3370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3462,7 +3462,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3554,7 +3554,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3636,7 +3636,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3731,7 +3731,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3823,7 +3823,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3903,7 +3903,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3979,7 +3979,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4065,7 +4065,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4165,7 +4165,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4256,7 +4256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4323,7 +4323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4402,7 +4402,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4469,7 +4469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4545,7 +4545,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4622,7 +4622,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4708,7 +4708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4792,7 +4792,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4871,7 +4871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4942,7 +4942,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5034,7 +5034,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5101,7 +5101,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5181,7 +5181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5272,7 +5272,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := sdk.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5351,7 +5351,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5449,7 +5449,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5535,7 +5535,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5625,7 +5625,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5721,7 +5721,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5811,7 +5811,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5901,7 +5901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5994,7 +5994,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := sdk.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6078,7 +6078,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6177,7 +6177,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6266,7 +6266,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6360,7 +6360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6445,7 +6445,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6533,7 +6533,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6630,7 +6630,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6724,7 +6724,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6813,7 +6813,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6893,7 +6893,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6972,7 +6972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7065,7 +7065,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7157,7 +7157,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7248,7 +7248,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7339,7 +7339,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7431,7 +7431,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7513,7 +7513,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7607,7 +7607,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7699,7 +7699,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7802,7 +7802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7904,7 +7904,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8003,7 +8003,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8085,7 +8085,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8179,7 +8179,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8261,7 +8261,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8355,7 +8355,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8444,7 +8444,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8542,7 +8542,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8624,7 +8624,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8726,7 +8726,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8828,7 +8828,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8921,7 +8921,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9022,7 +9022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9128,7 +9128,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9228,7 +9228,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9323,7 +9323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9435,7 +9435,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9520,7 +9520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9605,7 +9605,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9702,7 +9702,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9806,7 +9806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9906,7 +9906,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10092,7 +10092,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10184,7 +10184,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10285,7 +10285,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10404,7 +10404,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10502,7 +10502,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := sdk.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10601,7 +10601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10714,7 +10714,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10803,7 +10803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10890,7 +10890,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10985,7 +10985,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11072,7 +11072,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11173,7 +11173,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11250,7 +11250,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11353,7 +11353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11445,7 +11445,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11540,7 +11540,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11623,7 +11623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11705,7 +11705,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11801,7 +11801,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11897,7 +11897,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11978,7 +11978,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12067,7 +12067,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12170,7 +12170,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12265,7 +12265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := sdk.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12355,7 +12355,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12456,7 +12456,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12535,7 +12535,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12634,7 +12634,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12786,7 +12786,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12913,7 +12913,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12983,7 +12983,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13077,7 +13077,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13165,7 +13165,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13241,7 +13241,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13330,7 +13330,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13408,7 +13408,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13509,7 +13509,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13579,7 +13579,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13667,7 +13667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13749,7 +13749,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13826,7 +13826,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13923,7 +13923,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14006,7 +14006,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14091,7 +14091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14167,7 +14167,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14244,7 +14244,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14341,7 +14341,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14423,7 +14423,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14511,7 +14511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14600,7 +14600,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14703,7 +14703,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14809,7 +14809,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14885,7 +14885,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15125,7 +15125,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15217,7 +15217,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := sdk.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15304,7 +15304,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15411,7 +15411,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15499,7 +15499,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15601,7 +15601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15734,7 +15734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15864,7 +15864,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15931,7 +15931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16016,7 +16016,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16095,7 +16095,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16183,7 +16183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16285,7 +16285,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16374,7 +16374,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16517,7 +16517,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16608,7 +16608,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16678,7 +16678,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16794,7 +16794,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16913,7 +16913,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17024,7 +17024,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17106,7 +17106,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17201,7 +17201,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17294,7 +17294,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17410,7 +17410,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17523,7 +17523,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17603,7 +17603,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17687,7 +17687,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17765,7 +17765,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17843,7 +17843,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17925,7 +17925,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18018,7 +18018,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18089,7 +18089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18168,7 +18168,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18265,7 +18265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18363,7 +18363,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18472,7 +18472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18562,7 +18562,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18653,7 +18653,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18740,7 +18740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18816,7 +18816,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18892,7 +18892,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18956,7 +18956,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := sdk.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19021,7 +19021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19097,7 +19097,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19161,7 +19161,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19225,7 +19225,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19292,7 +19292,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19359,7 +19359,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := sdk.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19426,7 +19426,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19554,7 +19554,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19647,7 +19647,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19736,7 +19736,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19818,7 +19818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19898,7 +19898,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19995,7 +19995,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20065,7 +20065,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20144,7 +20144,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20223,7 +20223,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20303,7 +20303,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20397,7 +20397,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20482,7 +20482,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20583,7 +20583,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20665,7 +20665,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20747,7 +20747,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20848,7 +20848,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20943,7 +20943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21036,7 +21036,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21129,7 +21129,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21211,7 +21211,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21281,7 +21281,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21360,7 +21360,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21441,7 +21441,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21532,7 +21532,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21622,7 +21622,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21710,7 +21710,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21809,7 +21809,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21894,7 +21894,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21988,7 +21988,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22083,7 +22083,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22197,7 +22197,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22301,7 +22301,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22406,7 +22406,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22478,7 +22478,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22562,7 +22562,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22644,7 +22644,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22723,7 +22723,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22805,7 +22805,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22888,7 +22888,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22964,7 +22964,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23042,7 +23042,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23118,7 +23118,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23205,7 +23205,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23292,7 +23292,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23418,7 +23418,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23505,7 +23505,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23589,7 +23589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23724,7 +23724,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23966,7 +23966,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24062,7 +24062,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24182,7 +24182,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24318,7 +24318,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24445,7 +24445,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24518,7 +24518,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := sdk.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24589,7 +24589,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24672,7 +24672,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24755,7 +24755,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24837,7 +24837,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24913,7 +24913,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24989,7 +24989,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25071,7 +25071,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25162,7 +25162,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25259,7 +25259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25353,7 +25353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25444,7 +25444,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25536,7 +25536,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25615,7 +25615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25698,7 +25698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25783,7 +25783,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := sdk.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25866,7 +25866,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25957,7 +25957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26033,7 +26033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26113,7 +26113,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26193,7 +26193,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := sdk.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26270,7 +26270,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26361,7 +26361,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26454,7 +26454,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26527,7 +26527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26609,7 +26609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26682,7 +26682,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26761,7 +26761,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26843,7 +26843,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26928,7 +26928,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27022,7 +27022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27131,7 +27131,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27216,7 +27216,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27307,7 +27307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27398,7 +27398,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27481,7 +27481,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27584,7 +27584,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27669,7 +27669,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27761,7 +27761,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27847,7 +27847,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27948,7 +27948,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28015,7 +28015,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28094,7 +28094,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28158,7 +28158,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := sdk.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28225,7 +28225,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := sdk.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28306,7 +28306,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28385,7 +28385,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28479,7 +28479,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28561,7 +28561,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28657,7 +28657,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28747,7 +28747,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28832,7 +28832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28908,7 +28908,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28982,7 +28982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29067,7 +29067,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29147,7 +29147,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29227,7 +29227,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29310,7 +29310,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29391,7 +29391,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29486,7 +29486,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29578,7 +29578,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29684,7 +29684,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29784,7 +29784,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29879,7 +29879,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29957,7 +29957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30048,7 +30048,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30163,7 +30163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30254,7 +30254,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30327,7 +30327,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30417,7 +30417,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30502,7 +30502,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30584,7 +30584,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30666,7 +30666,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30748,7 +30748,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30828,7 +30828,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30922,7 +30922,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31080,7 +31080,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31150,7 +31150,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31238,7 +31238,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31319,7 +31319,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31392,7 +31392,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31459,7 +31459,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := sdk.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31538,7 +31538,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31614,7 +31614,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31693,7 +31693,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31769,7 +31769,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31846,7 +31846,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31937,7 +31937,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32022,7 +32022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32112,7 +32112,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32197,7 +32197,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32270,7 +32270,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32352,7 +32352,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32438,7 +32438,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32527,7 +32527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32613,7 +32613,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32702,7 +32702,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32789,7 +32789,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32890,7 +32890,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32988,7 +32988,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33092,7 +33092,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33190,7 +33190,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33272,7 +33272,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33357,7 +33357,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33453,7 +33453,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33506,7 +33506,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33584,7 +33584,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33661,7 +33661,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33740,7 +33740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20231115001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2023-11-15.yaml
@@ -29626,7 +29626,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSystemStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		GetSystemStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -29697,7 +29697,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).
                     		Execute()
                     }
@@ -29769,7 +29769,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersForAllProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersForAllProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -29841,7 +29841,7 @@ paths:
                     	}
 
                     	params = &sdk.ListEventTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListEventTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -29911,7 +29911,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederationAppApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteFederationAppWithParams(ctx, params).
                     		Execute()
                     }
@@ -29986,7 +29986,7 @@ paths:
                     	}
 
                     	params = &sdk.ListConnectedOrgConfigsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListConnectedOrgConfigsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30069,7 +30069,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveConnectedOrgConfigApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RemoveConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30151,7 +30151,7 @@ paths:
                     	}
 
                     	params = &sdk.GetConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30240,7 +30240,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30318,7 +30318,7 @@ paths:
                     	}
 
                     	params = &sdk.ListRoleMappingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListRoleMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30398,7 +30398,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30484,7 +30484,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteRoleMappingApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30567,7 +30567,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30657,7 +30657,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30758,7 +30758,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIdentityProvidersApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListIdentityProvidersWithParams(ctx, params).
                     		Execute()
                     }
@@ -30842,7 +30842,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -30924,7 +30924,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteIdentityProviderApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31005,7 +31005,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31094,7 +31094,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31176,7 +31176,7 @@ paths:
                     	}
 
                     	params = &sdk.RevokeJwksFromIdentityProviderApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RevokeJwksFromIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31249,7 +31249,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderMetadataApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderMetadataWithParams(ctx, params).
                     		Execute()
                     }
@@ -31323,7 +31323,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31414,7 +31414,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31490,7 +31490,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31561,7 +31561,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31643,7 +31643,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31729,7 +31729,7 @@ paths:
                     	}
 
                     	params = &sdk.AddUserToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		AddUserToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31809,7 +31809,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectIpAccessListsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		ListProjectIpAccessListsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31897,7 +31897,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectIpAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		CreateProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -31989,7 +31989,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectIpAccessListApiParams{}
-                    	httpResp, err := sdk.ProjectIPAccessListApi.
+                    	httpResp, err := client.ProjectIPAccessListApi.
                     		DeleteProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32073,7 +32073,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32157,7 +32157,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpAccessListStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpAccessListStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -32233,7 +32233,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32314,7 +32314,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		CreateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32401,7 +32401,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAlertConfigurationApiParams{}
-                    	httpResp, err := sdk.AlertConfigurationsApi.
+                    	httpResp, err := client.AlertConfigurationsApi.
                     		DeleteAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32485,7 +32485,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		GetAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32578,7 +32578,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ToggleAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32677,7 +32677,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		UpdateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32769,7 +32769,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsByAlertConfigurationIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsByAlertConfigurationIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -32856,7 +32856,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32940,7 +32940,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		GetAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -33033,7 +33033,7 @@ paths:
                     	}
 
                     	params = &sdk.AcknowledgeAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		AcknowledgeAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -33125,7 +33125,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsByAlertIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsByAlertIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -33201,7 +33201,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListProjectApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -33277,7 +33277,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -33365,7 +33365,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		RemoveProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -33455,7 +33455,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -33546,7 +33546,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		AddProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -33620,7 +33620,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		GetAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33698,7 +33698,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		UpdateAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33772,7 +33772,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		GetAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -33848,7 +33848,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		ToggleAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -33926,7 +33926,7 @@ paths:
                     	}
 
                     	params = &sdk.ListExportBucketsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListExportBucketsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34010,7 +34010,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34098,7 +34098,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteExportBucketApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34179,7 +34179,7 @@ paths:
                     	}
 
                     	params = &sdk.GetExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34252,7 +34252,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34339,7 +34339,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34413,7 +34413,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderAccessRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		ListCloudProviderAccessRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -34492,7 +34492,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		CreateCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34583,7 +34583,7 @@ paths:
                     	}
 
                     	params = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}
-                    	httpResp, err := sdk.CloudProviderAccessApi.
+                    	httpResp, err := client.CloudProviderAccessApi.
                     		DeauthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34662,7 +34662,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		GetCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34754,7 +34754,7 @@ paths:
                     	}
 
                     	params = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		AuthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34838,7 +34838,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersWithParams(ctx, params).
                     		Execute()
                     }
@@ -34924,7 +34924,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		CreateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35017,7 +35017,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteClusterApiParams{}
-                    	httpResp, err := sdk.ClustersApi.
+                    	httpResp, err := client.ClustersApi.
                     		DeleteClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35100,7 +35100,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35193,7 +35193,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35331,7 +35331,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35422,7 +35422,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35504,7 +35504,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupExportJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupExportJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35594,7 +35594,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -35682,7 +35682,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -35764,7 +35764,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35858,7 +35858,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -35952,7 +35952,7 @@ paths:
                     	}
 
                     	params = &sdk.CancelBackupRestoreJobApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		CancelBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36039,7 +36039,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36120,7 +36120,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllBackupSchedulesApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteAllBackupSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -36200,7 +36200,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -36292,7 +36292,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -36381,7 +36381,7 @@ paths:
                     	}
 
                     	params = &sdk.ListReplicaSetBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListReplicaSetBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36471,7 +36471,7 @@ paths:
                     	}
 
                     	params = &sdk.TakeSnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		TakeSnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -36565,7 +36565,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteReplicaSetBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -36654,7 +36654,7 @@ paths:
                     	}
 
                     	params = &sdk.GetReplicaSetBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -36750,7 +36750,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateSnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateSnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -36842,7 +36842,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteShardedClusterBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -36931,7 +36931,7 @@ paths:
                     	}
 
                     	params = &sdk.GetShardedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37012,7 +37012,7 @@ paths:
                     	}
 
                     	params = &sdk.ListShardedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListShardedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37106,7 +37106,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		DownloadSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37202,7 +37202,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		CreateSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -37287,7 +37287,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		ListSharedClusterBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37377,7 +37377,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		GetSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -37458,7 +37458,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		ListSharedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37548,7 +37548,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		GetSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37631,7 +37631,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupCheckpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupCheckpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37724,7 +37724,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupCheckpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupCheckpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -37806,7 +37806,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPinnedNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetPinnedNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -37901,7 +37901,7 @@ paths:
                     	}
 
                     	params = &sdk.PinNamespacesPatchApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		PinNamespacesPatchWithParams(ctx, params).
                     		Execute()
                     }
@@ -38000,7 +38000,7 @@ paths:
                     	}
 
                     	params = &sdk.PinNamespacesPutApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		PinNamespacesPutWithParams(ctx, params).
                     		Execute()
                     }
@@ -38093,7 +38093,7 @@ paths:
                     	}
 
                     	params = &sdk.UnpinNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		UnpinNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -38191,7 +38191,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38293,7 +38293,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38388,7 +38388,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38480,7 +38480,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38583,7 +38583,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38671,7 +38671,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		GetManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -38755,7 +38755,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllCustomZoneMappingsApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteAllCustomZoneMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38847,7 +38847,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomZoneMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateCustomZoneMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -38947,7 +38947,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteManagedNamespaceApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39041,7 +39041,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39200,7 +39200,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRollingIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.RollingIndexApi.
+                    	sdkResp, httpResp, err := client.RollingIndexApi.
                     		CreateRollingIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -39289,7 +39289,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOnlineArchivesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		ListOnlineArchivesWithParams(ctx, params).
                     		Execute()
                     }
@@ -39383,7 +39383,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		CreateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -39480,7 +39480,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOnlineArchiveApiParams{}
-                    	httpResp, err := sdk.OnlineArchiveApi.
+                    	httpResp, err := client.OnlineArchiveApi.
                     		DeleteOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -39574,7 +39574,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		GetOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -39677,7 +39677,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		UpdateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -39790,7 +39790,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		DownloadOnlineArchiveQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39876,7 +39876,7 @@ paths:
                     	}
 
                     	params = &sdk.EndOutageSimulationApiParams{}
-                    	httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	httpResp, err := client.ClusterOutageSimulationApi.
                     		EndOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -39961,7 +39961,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		GetOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40051,7 +40051,7 @@ paths:
                     	}
 
                     	params = &sdk.StartOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		StartOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40140,7 +40140,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40235,7 +40235,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40317,7 +40317,7 @@ paths:
                     	}
 
                     	params = &sdk.TestFailoverApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		TestFailoverWithParams(ctx, params).
                     		Execute()
                     }
@@ -40417,7 +40417,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40505,7 +40505,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		CreateLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -40603,7 +40603,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -40685,7 +40685,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchDeploymentApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -40767,7 +40767,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -40858,7 +40858,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -40953,7 +40953,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41041,7 +41041,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41130,7 +41130,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -41227,7 +41227,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacySnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacySnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -41318,7 +41318,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLegacySnapshotApiParams{}
-                    	httpResp, err := sdk.LegacyBackupApi.
+                    	httpResp, err := client.LegacyBackupApi.
                     		DeleteLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -41406,7 +41406,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -41501,7 +41501,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -41584,7 +41584,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -41698,7 +41698,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -41783,7 +41783,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderRegionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListCloudProviderRegionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -41868,7 +41868,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -41957,7 +41957,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterToServerlessApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterToServerlessWithParams(ctx, params).
                     		Execute()
                     }
@@ -42034,7 +42034,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -42120,7 +42120,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainerByCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainerByCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -42204,7 +42204,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -42294,7 +42294,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringContainerApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -42373,7 +42373,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -42467,7 +42467,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -42544,7 +42544,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainersApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainersWithParams(ctx, params).
                     		Execute()
                     }
@@ -42616,7 +42616,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCustomDatabaseRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		ListCustomDatabaseRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -42700,7 +42700,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		CreateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -42784,7 +42784,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteCustomDatabaseRoleApiParams{}
-                    	httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	httpResp, err := client.CustomDatabaseRolesApi.
                     		DeleteCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -42861,7 +42861,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		GetCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -42951,7 +42951,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		UpdateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -43036,7 +43036,7 @@ paths:
                     	}
 
                     	params = &sdk.ListFederatedDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListFederatedDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -43118,7 +43118,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -43198,7 +43198,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederatedDatabaseApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -43276,7 +43276,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -43366,7 +43366,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		UpdateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -43450,7 +43450,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43544,7 +43544,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -43638,7 +43638,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -43742,7 +43742,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOneDataFederationQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateOneDataFederationQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -43846,7 +43846,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		DownloadFederatedDatabaseQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43919,7 +43919,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		ListDatabaseUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -44094,7 +44094,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		CreateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -44198,7 +44198,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDatabaseUserApiParams{}
-                    	httpResp, err := sdk.DatabaseUsersApi.
+                    	httpResp, err := client.DatabaseUsersApi.
                     		DeleteDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -44295,7 +44295,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		GetDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -44405,7 +44405,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		UpdateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -44490,7 +44490,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUserCertificatesApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		ListDatabaseUserCertificatesWithParams(ctx, params).
                     		Execute()
                     }
@@ -44589,7 +44589,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserCertificateApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		CreateDatabaseUserCertificateWithParams(ctx, params).
                     		Execute()
                     }
@@ -44709,7 +44709,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByClusterNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByClusterNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -44822,7 +44822,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByHostnameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByHostnameWithParams(ctx, params).
                     		Execute()
                     }
@@ -44895,7 +44895,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -44989,7 +44989,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		UpdateEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -45071,7 +45071,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -45155,7 +45155,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		CreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -45253,7 +45253,7 @@ paths:
                     	}
 
                     	params = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}
-                    	httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).
                     		Execute()
                     }
@@ -45339,7 +45339,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -45466,7 +45466,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListProjectEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45556,7 +45556,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetProjectEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -45628,7 +45628,7 @@ paths:
                     	}
 
                     	params = &sdk.ListMetricTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListMetricTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -45730,7 +45730,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45831,7 +45831,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45931,7 +45931,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46008,7 +46008,7 @@ paths:
                     	}
 
                     	params = &sdk.ListThirdPartyIntegrationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		ListThirdPartyIntegrationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46100,7 +46100,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteThirdPartyIntegrationApiParams{}
-                    	httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	httpResp, err := client.Third - PartyIntegrationsApi.
                     		DeleteThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46191,7 +46191,7 @@ paths:
                     	}
 
                     	params = &sdk.GetThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		GetThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46294,7 +46294,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		CreateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46399,7 +46399,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		UpdateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46482,7 +46482,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46564,7 +46564,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46646,7 +46646,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46730,7 +46730,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectInvitationApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46812,7 +46812,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -46902,7 +46902,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -46979,7 +46979,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ReturnAllIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47057,7 +47057,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47167,7 +47167,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectLimitApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -47278,7 +47278,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -47399,7 +47399,7 @@ paths:
                     	}
 
                     	params = &sdk.SetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		SetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -47496,7 +47496,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreatePushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47576,7 +47576,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetPushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47651,7 +47651,7 @@ paths:
                     	}
 
                     	params = &sdk.CutoverMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CutoverMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47741,7 +47741,7 @@ paths:
                     	}
 
                     	params = &sdk.ValidateMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ValidateMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47831,7 +47831,7 @@ paths:
                     	}
 
                     	params = &sdk.GetValidationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetValidationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -47900,7 +47900,7 @@ paths:
                     	}
 
                     	params = &sdk.ResetMaintenanceWindowApiParams{}
-                    	httpResp, err := sdk.MaintenanceWindowsApi.
+                    	httpResp, err := client.MaintenanceWindowsApi.
                     		ResetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -47969,7 +47969,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		GetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -48046,7 +48046,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		UpdateMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -48119,7 +48119,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleMaintenanceAutoDeferApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		ToggleMaintenanceAutoDeferWithParams(ctx, params).
                     		Execute()
                     }
@@ -48192,7 +48192,7 @@ paths:
                     	}
 
                     	params = &sdk.DeferMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		DeferMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -48266,7 +48266,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedSlowMsApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetManagedSlowMsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48336,7 +48336,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableSlowOperationThresholdingApiParams{}
-                    	httpResp, err := sdk.PerformanceAdvisorApi.
+                    	httpResp, err := client.PerformanceAdvisorApi.
                     		DisableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -48406,7 +48406,7 @@ paths:
                     	}
 
                     	params = &sdk.EnableSlowOperationThresholdingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		EnableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -48521,7 +48521,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLTSVersionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLTSVersionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48606,7 +48606,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48691,7 +48691,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -48776,7 +48776,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringConnectionApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -48856,7 +48856,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -48947,7 +48947,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -49024,7 +49024,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelinesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelinesWithParams(ctx, params).
                     		Execute()
                     }
@@ -49103,7 +49103,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		CreatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -49187,7 +49187,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -49267,7 +49267,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -49357,7 +49357,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		UpdatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -49444,7 +49444,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSchedulesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -49535,7 +49535,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -49616,7 +49616,7 @@ paths:
                     	}
 
                     	params = &sdk.PausePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		PausePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -49701,7 +49701,7 @@ paths:
                     	}
 
                     	params = &sdk.ResumePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ResumePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -49796,7 +49796,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineRunsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineRunsWithParams(ctx, params).
                     		Execute()
                     }
@@ -49887,7 +49887,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineRunDatasetApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineRunDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -49977,7 +49977,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineRunApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineRunWithParams(ctx, params).
                     		Execute()
                     }
@@ -50065,7 +50065,7 @@ paths:
                     	}
 
                     	params = &sdk.TriggerSnapshotIngestionApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		TriggerSnapshotIngestionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50152,7 +50152,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPrivateEndpointServicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ListPrivateEndpointServicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50242,7 +50242,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointServiceApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -50333,7 +50333,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -50436,7 +50436,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -50537,7 +50537,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -50635,7 +50635,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -50715,7 +50715,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -50791,7 +50791,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -50869,7 +50869,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -50954,7 +50954,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		ListServerlessPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51045,7 +51045,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		CreateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -51137,7 +51137,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		DeleteServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -51224,7 +51224,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		GetServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -51318,7 +51318,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		UpdateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -51396,7 +51396,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -51478,7 +51478,7 @@ paths:
                     	}
 
                     	params = &sdk.DisablePeeringApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		DisablePeeringWithParams(ctx, params).
                     		Execute()
                     }
@@ -51559,7 +51559,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDataFederationPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListDataFederationPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51656,7 +51656,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -51741,7 +51741,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDataFederationPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -51823,7 +51823,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -51896,7 +51896,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasProcessesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListAtlasProcessesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51974,7 +51974,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetAtlasProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -52087,7 +52087,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52160,7 +52160,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespacesForHostWithParams(ctx, params).
                     		Execute()
                     }
@@ -52241,7 +52241,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -52325,7 +52325,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -52435,7 +52435,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52516,7 +52516,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskPartitionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskPartitionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52599,7 +52599,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52725,7 +52725,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52962,7 +52962,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53060,7 +53060,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueryNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueryNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53175,7 +53175,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53297,7 +53297,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSuggestedIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSuggestedIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53371,7 +53371,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePushBasedLogConfigurationApiParams{}
-                    	httpResp, err := sdk.Push - BasedLogExportApi.
+                    	httpResp, err := client.Push - BasedLogExportApi.
                     		DeletePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53444,7 +53444,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		GetPushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53525,7 +53525,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		UpdatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53610,7 +53610,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		CreatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -53696,7 +53696,7 @@ paths:
                     	}
 
                     	params = &sdk.LoadSampleDatasetApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		LoadSampleDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -53778,7 +53778,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSampleDatasetLoadStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetSampleDatasetLoadStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -53851,7 +53851,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		ListServerlessInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53931,7 +53931,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		CreateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -54019,7 +54019,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54110,7 +54110,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -54204,7 +54204,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -54288,7 +54288,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54378,7 +54378,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -54457,7 +54457,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -54540,7 +54540,7 @@ paths:
                     	}
 
                     	params = &sdk.SetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		SetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -54627,7 +54627,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessInstanceApiParams{}
-                    	httpResp, err := sdk.ServerlessInstancesApi.
+                    	httpResp, err := client.ServerlessInstancesApi.
                     		DeleteServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -54709,7 +54709,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		GetServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -54796,7 +54796,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		UpdateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -54874,7 +54874,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		ListProjectServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54953,7 +54953,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		CreateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -55036,7 +55036,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectServiceAccountApiParams{}
-                    	httpResp, err := sdk.GroupsApi.
+                    	httpResp, err := client.GroupsApi.
                     		DeleteProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -55113,7 +55113,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		GetProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -55199,7 +55199,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		UpdateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -55291,7 +55291,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		AddProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -55369,7 +55369,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55449,7 +55449,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55525,7 +55525,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55603,7 +55603,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -55687,7 +55687,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamInstanceApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -55770,7 +55770,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -55858,7 +55858,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -55963,7 +55963,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadStreamTenantAuditLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		DownloadStreamTenantAuditLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56043,7 +56043,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56129,7 +56129,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -56219,7 +56219,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamConnectionApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -56301,7 +56301,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -56395,7 +56395,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -56478,7 +56478,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListProjectTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56565,7 +56565,7 @@ paths:
                     	}
 
                     	params = &sdk.AddAllTeamsToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddAllTeamsToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -56654,7 +56654,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveProjectTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -56748,7 +56748,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateTeamRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		UpdateTeamRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -56822,7 +56822,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -56903,7 +56903,7 @@ paths:
                     	}
 
                     	params = &sdk.SaveLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		SaveLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -56979,7 +56979,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableCustomerManagedX509ApiParams{}
-                    	httpResp, err := sdk.X509AuthenticationApi.
+                    	httpResp, err := client.X509AuthenticationApi.
                     		DisableCustomerManagedX509WithParams(ctx, params).
                     		Execute()
                     }
@@ -57049,7 +57049,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLDAPConfigurationApiParams{}
-                    	httpResp, err := sdk.LDAPConfigurationApi.
+                    	httpResp, err := client.LDAPConfigurationApi.
                     		DeleteLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57128,7 +57128,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		VerifyLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57211,7 +57211,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -57296,7 +57296,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -57377,7 +57377,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectUserApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		RemoveProjectUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -57467,7 +57467,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -57554,7 +57554,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -57637,7 +57637,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57720,7 +57720,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57806,7 +57806,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57881,7 +57881,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -57963,7 +57963,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		RenameOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -58043,7 +58043,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -58122,7 +58122,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -58208,7 +58208,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -58289,7 +58289,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -58379,7 +58379,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -58468,7 +58468,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeyAccessListsEntriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeyAccessListsEntriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -58562,7 +58562,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -58660,7 +58660,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyAccessListEntryApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyAccessListEntryWithParams(ctx, params).
                     		Execute()
                     }
@@ -58751,7 +58751,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -58829,7 +58829,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -58921,7 +58921,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcess_1WithParams(ctx, params).
                     		Execute()
                     }
@@ -59026,7 +59026,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListOrganizationEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59116,7 +59116,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetOrganizationEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -59190,7 +59190,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetFederationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59280,7 +59280,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59362,7 +59362,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59442,7 +59442,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59526,7 +59526,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59610,7 +59610,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationInvitationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59691,7 +59691,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59780,7 +59780,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -59918,7 +59918,7 @@ paths:
                     	}
 
                     	params = &sdk.ListInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -60005,7 +60005,7 @@ paths:
                     	}
 
                     	params = &sdk.GetInvoiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		GetInvoiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -60093,7 +60093,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadInvoiceCSVApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		DownloadInvoiceCSVWithParams(ctx, params).
                     		Execute()
                     }
@@ -60165,7 +60165,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPendingInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListPendingInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -60239,7 +60239,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSourceProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ListSourceProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -60310,7 +60310,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLinkTokenApiParams{}
-                    	httpResp, err := sdk.CloudMigrationServiceApi.
+                    	httpResp, err := client.CloudMigrationServiceApi.
                     		DeleteLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -60388,7 +60388,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLinkTokenApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreateLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -60466,7 +60466,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -60544,7 +60544,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -60624,7 +60624,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -60701,7 +60701,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -60787,7 +60787,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -60871,7 +60871,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -60956,7 +60956,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountSecretApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -61042,7 +61042,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountSecretApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -61116,7 +61116,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61196,7 +61196,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61280,7 +61280,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListOrganizationTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61365,7 +61365,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		CreateTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -61455,7 +61455,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		DeleteTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -61540,7 +61540,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -61634,7 +61634,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		RenameTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -61728,7 +61728,7 @@ paths:
                     	}
 
                     	params = &sdk.ListTeamUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListTeamUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -61824,7 +61824,7 @@ paths:
                     	}
 
                     	params = &sdk.AddTeamUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -61921,7 +61921,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveTeamUserApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -62004,7 +62004,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -62081,7 +62081,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -62165,7 +62165,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveOrganizationUserApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		RemoveOrganizationUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -62255,7 +62255,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -62323,7 +62323,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		ReturnAllControlPlaneIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -62406,7 +62406,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		CreateUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -62490,7 +62490,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -62568,7 +62568,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserByUsernameApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserByUsernameWithParams(ctx, params).
                     		Execute()
                     }

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.json
@@ -256,7 +256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -323,7 +323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -396,7 +396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -469,7 +469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -533,7 +533,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -609,7 +609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -692,7 +692,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -773,7 +773,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -865,7 +865,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -938,7 +938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1020,7 +1020,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1103,7 +1103,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1187,7 +1187,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1282,7 +1282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1390,7 +1390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1472,7 +1472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1549,7 +1549,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1630,7 +1630,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1719,7 +1719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1796,7 +1796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1866,7 +1866,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1942,7 +1942,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2038,7 +2038,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2122,7 +2122,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2192,7 +2192,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2260,7 +2260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2345,7 +2345,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2431,7 +2431,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2511,7 +2511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2609,7 +2609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2694,7 +2694,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := sdk.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2780,7 +2780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2867,7 +2867,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2943,7 +2943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3022,7 +3022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3102,7 +3102,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := sdk.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3183,7 +3183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3275,7 +3275,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3370,7 +3370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3462,7 +3462,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3554,7 +3554,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3636,7 +3636,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3730,7 +3730,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3821,7 +3821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3901,7 +3901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3977,7 +3977,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4063,7 +4063,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4163,7 +4163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4254,7 +4254,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4321,7 +4321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4400,7 +4400,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4467,7 +4467,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4543,7 +4543,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4619,7 +4619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4756,7 +4756,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4839,7 +4839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4951,7 +4951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5021,7 +5021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5113,7 +5113,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5180,7 +5180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5260,7 +5260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5351,7 +5351,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := sdk.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5430,7 +5430,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5528,7 +5528,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5614,7 +5614,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5704,7 +5704,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5800,7 +5800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5890,7 +5890,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5980,7 +5980,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6073,7 +6073,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := sdk.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6157,7 +6157,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6256,7 +6256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6345,7 +6345,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6439,7 +6439,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6524,7 +6524,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6612,7 +6612,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6709,7 +6709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6803,7 +6803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6892,7 +6892,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6972,7 +6972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7051,7 +7051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7144,7 +7144,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7236,7 +7236,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7327,7 +7327,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7418,7 +7418,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7510,7 +7510,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7592,7 +7592,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7686,7 +7686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7778,7 +7778,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7881,7 +7881,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7983,7 +7983,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8082,7 +8082,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8164,7 +8164,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8258,7 +8258,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8340,7 +8340,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8434,7 +8434,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8523,7 +8523,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8621,7 +8621,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8703,7 +8703,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8805,7 +8805,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8907,7 +8907,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9000,7 +9000,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9101,7 +9101,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9207,7 +9207,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9307,7 +9307,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9402,7 +9402,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9514,7 +9514,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9599,7 +9599,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9684,7 +9684,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9781,7 +9781,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9885,7 +9885,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9985,7 +9985,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10171,7 +10171,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10263,7 +10263,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10364,7 +10364,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10483,7 +10483,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10581,7 +10581,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := sdk.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10680,7 +10680,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10793,7 +10793,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10882,7 +10882,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10969,7 +10969,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11064,7 +11064,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11151,7 +11151,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11252,7 +11252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11329,7 +11329,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11432,7 +11432,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11524,7 +11524,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11619,7 +11619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11704,7 +11704,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11784,7 +11784,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11878,7 +11878,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11972,7 +11972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12071,7 +12071,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12169,7 +12169,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12286,7 +12286,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12399,7 +12399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12510,7 +12510,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12635,7 +12635,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12733,7 +12733,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12839,7 +12839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12949,7 +12949,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13029,7 +13029,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13118,7 +13118,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13221,7 +13221,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13316,7 +13316,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := sdk.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13406,7 +13406,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13507,7 +13507,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13586,7 +13586,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13685,7 +13685,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13837,7 +13837,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13936,7 +13936,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14027,7 +14027,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14154,7 +14154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14224,7 +14224,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14318,7 +14318,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14406,7 +14406,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14482,7 +14482,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14571,7 +14571,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14649,7 +14649,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14750,7 +14750,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14820,7 +14820,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14908,7 +14908,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14990,7 +14990,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15067,7 +15067,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15164,7 +15164,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15247,7 +15247,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15332,7 +15332,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15408,7 +15408,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15485,7 +15485,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15582,7 +15582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15664,7 +15664,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15752,7 +15752,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15841,7 +15841,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15944,7 +15944,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16050,7 +16050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16126,7 +16126,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16366,7 +16366,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16458,7 +16458,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := sdk.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16545,7 +16545,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16652,7 +16652,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16740,7 +16740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16842,7 +16842,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16975,7 +16975,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17105,7 +17105,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17172,7 +17172,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17257,7 +17257,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17336,7 +17336,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17424,7 +17424,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17526,7 +17526,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17615,7 +17615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17758,7 +17758,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17849,7 +17849,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17919,7 +17919,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18035,7 +18035,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18154,7 +18154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18265,7 +18265,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18347,7 +18347,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18442,7 +18442,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18535,7 +18535,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18651,7 +18651,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18764,7 +18764,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18844,7 +18844,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18928,7 +18928,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19006,7 +19006,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19084,7 +19084,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19166,7 +19166,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19259,7 +19259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19330,7 +19330,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19409,7 +19409,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19506,7 +19506,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19604,7 +19604,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19713,7 +19713,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19801,7 +19801,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19889,7 +19889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19975,7 +19975,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20051,7 +20051,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20127,7 +20127,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20191,7 +20191,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := sdk.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20256,7 +20256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20332,7 +20332,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20396,7 +20396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20460,7 +20460,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20527,7 +20527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20594,7 +20594,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := sdk.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20661,7 +20661,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20789,7 +20789,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20882,7 +20882,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20971,7 +20971,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21053,7 +21053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21133,7 +21133,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21230,7 +21230,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21300,7 +21300,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21379,7 +21379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21458,7 +21458,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21538,7 +21538,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21632,7 +21632,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21717,7 +21717,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21818,7 +21818,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21900,7 +21900,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21982,7 +21982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22083,7 +22083,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22178,7 +22178,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22271,7 +22271,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22364,7 +22364,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22446,7 +22446,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22516,7 +22516,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22595,7 +22595,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22676,7 +22676,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22767,7 +22767,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22857,7 +22857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22945,7 +22945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23044,7 +23044,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23129,7 +23129,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23223,7 +23223,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23318,7 +23318,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23432,7 +23432,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23536,7 +23536,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23641,7 +23641,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23713,7 +23713,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23797,7 +23797,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23879,7 +23879,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23958,7 +23958,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24040,7 +24040,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24123,7 +24123,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24199,7 +24199,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24277,7 +24277,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24353,7 +24353,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24440,7 +24440,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24527,7 +24527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24653,7 +24653,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24740,7 +24740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24824,7 +24824,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24959,7 +24959,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25201,7 +25201,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25297,7 +25297,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25417,7 +25417,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25553,7 +25553,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25680,7 +25680,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25753,7 +25753,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := sdk.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25824,7 +25824,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25907,7 +25907,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25990,7 +25990,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26072,7 +26072,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26148,7 +26148,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26224,7 +26224,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26306,7 +26306,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26397,7 +26397,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26494,7 +26494,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26588,7 +26588,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26679,7 +26679,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26771,7 +26771,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26850,7 +26850,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26933,7 +26933,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27018,7 +27018,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := sdk.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27101,7 +27101,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27192,7 +27192,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27268,7 +27268,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27348,7 +27348,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27428,7 +27428,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := sdk.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27505,7 +27505,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27596,7 +27596,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27689,7 +27689,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27762,7 +27762,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27844,7 +27844,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27917,7 +27917,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27996,7 +27996,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28078,7 +28078,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28163,7 +28163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28257,7 +28257,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28366,7 +28366,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28451,7 +28451,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28542,7 +28542,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28633,7 +28633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28716,7 +28716,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28819,7 +28819,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28912,7 +28912,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29000,7 +29000,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29089,7 +29089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29180,7 +29180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29271,7 +29271,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29362,7 +29362,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29447,7 +29447,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29539,7 +29539,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29625,7 +29625,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29726,7 +29726,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29793,7 +29793,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29872,7 +29872,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29936,7 +29936,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := sdk.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30003,7 +30003,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := sdk.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30084,7 +30084,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30163,7 +30163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30257,7 +30257,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30339,7 +30339,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30435,7 +30435,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30510,7 +30510,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30600,7 +30600,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30685,7 +30685,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30761,7 +30761,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30835,7 +30835,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30920,7 +30920,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31000,7 +31000,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31080,7 +31080,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31163,7 +31163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31244,7 +31244,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31339,7 +31339,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31431,7 +31431,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31537,7 +31537,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31637,7 +31637,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31732,7 +31732,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31810,7 +31810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31901,7 +31901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32016,7 +32016,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32107,7 +32107,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32180,7 +32180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32270,7 +32270,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32355,7 +32355,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32437,7 +32437,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32519,7 +32519,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32601,7 +32601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32681,7 +32681,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32775,7 +32775,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32933,7 +32933,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33003,7 +33003,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33091,7 +33091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33172,7 +33172,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33245,7 +33245,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33312,7 +33312,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := sdk.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33391,7 +33391,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33467,7 +33467,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33546,7 +33546,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33622,7 +33622,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33699,7 +33699,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33790,7 +33790,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33875,7 +33875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33965,7 +33965,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34050,7 +34050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34123,7 +34123,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34205,7 +34205,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34291,7 +34291,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34380,7 +34380,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34466,7 +34466,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34555,7 +34555,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34642,7 +34642,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34743,7 +34743,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34841,7 +34841,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34945,7 +34945,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35043,7 +35043,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35125,7 +35125,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35210,7 +35210,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35306,7 +35306,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35359,7 +35359,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35437,7 +35437,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35514,7 +35514,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35593,7 +35593,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240530001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-05-30.yaml
@@ -29893,7 +29893,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSystemStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		GetSystemStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -29964,7 +29964,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).
                     		Execute()
                     }
@@ -30036,7 +30036,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersForAllProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersForAllProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30108,7 +30108,7 @@ paths:
                     	}
 
                     	params = &sdk.ListEventTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListEventTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -30178,7 +30178,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederationAppApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteFederationAppWithParams(ctx, params).
                     		Execute()
                     }
@@ -30253,7 +30253,7 @@ paths:
                     	}
 
                     	params = &sdk.ListConnectedOrgConfigsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListConnectedOrgConfigsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30336,7 +30336,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveConnectedOrgConfigApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RemoveConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30418,7 +30418,7 @@ paths:
                     	}
 
                     	params = &sdk.GetConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30507,7 +30507,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30585,7 +30585,7 @@ paths:
                     	}
 
                     	params = &sdk.ListRoleMappingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListRoleMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30665,7 +30665,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30751,7 +30751,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteRoleMappingApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30834,7 +30834,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -30924,7 +30924,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31025,7 +31025,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIdentityProvidersApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListIdentityProvidersWithParams(ctx, params).
                     		Execute()
                     }
@@ -31109,7 +31109,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31191,7 +31191,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteIdentityProviderApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31272,7 +31272,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31361,7 +31361,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31443,7 +31443,7 @@ paths:
                     	}
 
                     	params = &sdk.RevokeJwksFromIdentityProviderApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RevokeJwksFromIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31516,7 +31516,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderMetadataApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderMetadataWithParams(ctx, params).
                     		Execute()
                     }
@@ -31590,7 +31590,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31681,7 +31681,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31757,7 +31757,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31828,7 +31828,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31910,7 +31910,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -31996,7 +31996,7 @@ paths:
                     	}
 
                     	params = &sdk.AddUserToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		AddUserToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32076,7 +32076,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectIpAccessListsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		ListProjectIpAccessListsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32164,7 +32164,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectIpAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		CreateProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32256,7 +32256,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectIpAccessListApiParams{}
-                    	httpResp, err := sdk.ProjectIPAccessListApi.
+                    	httpResp, err := client.ProjectIPAccessListApi.
                     		DeleteProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32340,7 +32340,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32424,7 +32424,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpAccessListStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpAccessListStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -32500,7 +32500,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32581,7 +32581,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		CreateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32668,7 +32668,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAlertConfigurationApiParams{}
-                    	httpResp, err := sdk.AlertConfigurationsApi.
+                    	httpResp, err := client.AlertConfigurationsApi.
                     		DeleteAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32752,7 +32752,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		GetAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32845,7 +32845,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ToggleAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32944,7 +32944,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		UpdateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33036,7 +33036,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsByAlertConfigurationIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsByAlertConfigurationIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -33123,7 +33123,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33207,7 +33207,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		GetAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -33299,7 +33299,7 @@ paths:
                     	}
 
                     	params = &sdk.AcknowledgeAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		AcknowledgeAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -33390,7 +33390,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsByAlertIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsByAlertIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -33466,7 +33466,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListProjectApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -33542,7 +33542,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -33630,7 +33630,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		RemoveProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -33720,7 +33720,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -33811,7 +33811,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		AddProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -33885,7 +33885,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		GetAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33963,7 +33963,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		UpdateAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -34037,7 +34037,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		GetAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -34113,7 +34113,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		ToggleAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -34190,7 +34190,7 @@ paths:
                     	}
 
                     	params = &sdk.ListExportBucketsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListExportBucketsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34309,7 +34309,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34396,7 +34396,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteExportBucketApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34499,7 +34499,7 @@ paths:
                     	}
 
                     	params = &sdk.GetExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34571,7 +34571,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34658,7 +34658,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34732,7 +34732,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderAccessRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		ListCloudProviderAccessRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -34811,7 +34811,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		CreateCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34902,7 +34902,7 @@ paths:
                     	}
 
                     	params = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}
-                    	httpResp, err := sdk.CloudProviderAccessApi.
+                    	httpResp, err := client.CloudProviderAccessApi.
                     		DeauthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -34981,7 +34981,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		GetCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35073,7 +35073,7 @@ paths:
                     	}
 
                     	params = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		AuthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35157,7 +35157,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersWithParams(ctx, params).
                     		Execute()
                     }
@@ -35243,7 +35243,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		CreateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35336,7 +35336,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteClusterApiParams{}
-                    	httpResp, err := sdk.ClustersApi.
+                    	httpResp, err := client.ClustersApi.
                     		DeleteClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35419,7 +35419,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35512,7 +35512,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35650,7 +35650,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35741,7 +35741,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35823,7 +35823,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupExportJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupExportJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35913,7 +35913,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36001,7 +36001,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36083,7 +36083,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36177,7 +36177,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36271,7 +36271,7 @@ paths:
                     	}
 
                     	params = &sdk.CancelBackupRestoreJobApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		CancelBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36358,7 +36358,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36439,7 +36439,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllBackupSchedulesApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteAllBackupSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -36519,7 +36519,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -36611,7 +36611,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -36700,7 +36700,7 @@ paths:
                     	}
 
                     	params = &sdk.ListReplicaSetBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListReplicaSetBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36790,7 +36790,7 @@ paths:
                     	}
 
                     	params = &sdk.TakeSnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		TakeSnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -36884,7 +36884,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteReplicaSetBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -36973,7 +36973,7 @@ paths:
                     	}
 
                     	params = &sdk.GetReplicaSetBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37069,7 +37069,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateSnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateSnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -37161,7 +37161,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteShardedClusterBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37250,7 +37250,7 @@ paths:
                     	}
 
                     	params = &sdk.GetShardedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37331,7 +37331,7 @@ paths:
                     	}
 
                     	params = &sdk.ListShardedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListShardedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37425,7 +37425,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		DownloadSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37521,7 +37521,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		CreateSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -37606,7 +37606,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		ListSharedClusterBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37696,7 +37696,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		GetSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -37777,7 +37777,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		ListSharedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37867,7 +37867,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		GetSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37950,7 +37950,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupCheckpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupCheckpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38043,7 +38043,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupCheckpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupCheckpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -38125,7 +38125,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPinnedNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetPinnedNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -38220,7 +38220,7 @@ paths:
                     	}
 
                     	params = &sdk.PinNamespacesPatchApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		PinNamespacesPatchWithParams(ctx, params).
                     		Execute()
                     }
@@ -38319,7 +38319,7 @@ paths:
                     	}
 
                     	params = &sdk.PinNamespacesPutApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		PinNamespacesPutWithParams(ctx, params).
                     		Execute()
                     }
@@ -38412,7 +38412,7 @@ paths:
                     	}
 
                     	params = &sdk.UnpinNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		UnpinNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -38510,7 +38510,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38612,7 +38612,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38707,7 +38707,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38799,7 +38799,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38902,7 +38902,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -38990,7 +38990,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		GetManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39074,7 +39074,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllCustomZoneMappingsApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteAllCustomZoneMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39166,7 +39166,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomZoneMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateCustomZoneMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -39266,7 +39266,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteManagedNamespaceApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39360,7 +39360,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39519,7 +39519,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRollingIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.RollingIndexApi.
+                    	sdkResp, httpResp, err := client.RollingIndexApi.
                     		CreateRollingIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -39608,7 +39608,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOnlineArchivesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		ListOnlineArchivesWithParams(ctx, params).
                     		Execute()
                     }
@@ -39702,7 +39702,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		CreateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -39799,7 +39799,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOnlineArchiveApiParams{}
-                    	httpResp, err := sdk.OnlineArchiveApi.
+                    	httpResp, err := client.OnlineArchiveApi.
                     		DeleteOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -39893,7 +39893,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		GetOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -39996,7 +39996,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		UpdateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40109,7 +40109,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		DownloadOnlineArchiveQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40195,7 +40195,7 @@ paths:
                     	}
 
                     	params = &sdk.EndOutageSimulationApiParams{}
-                    	httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	httpResp, err := client.ClusterOutageSimulationApi.
                     		EndOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40280,7 +40280,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		GetOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40370,7 +40370,7 @@ paths:
                     	}
 
                     	params = &sdk.StartOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		StartOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40459,7 +40459,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40554,7 +40554,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40636,7 +40636,7 @@ paths:
                     	}
 
                     	params = &sdk.TestFailoverApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		TestFailoverWithParams(ctx, params).
                     		Execute()
                     }
@@ -40736,7 +40736,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40824,7 +40824,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		CreateLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -40922,7 +40922,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -41005,7 +41005,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchDeploymentApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41085,7 +41085,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41174,7 +41174,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41267,7 +41267,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41363,7 +41363,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -41455,7 +41455,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -41563,7 +41563,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -41665,7 +41665,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexByNameApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -41766,7 +41766,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -41876,7 +41876,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -41973,7 +41973,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42071,7 +42071,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42172,7 +42172,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42259,7 +42259,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -42348,7 +42348,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -42445,7 +42445,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacySnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacySnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -42536,7 +42536,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLegacySnapshotApiParams{}
-                    	httpResp, err := sdk.LegacyBackupApi.
+                    	httpResp, err := client.LegacyBackupApi.
                     		DeleteLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -42624,7 +42624,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -42719,7 +42719,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -42802,7 +42802,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -42894,7 +42894,7 @@ paths:
                     	}
 
                     	params = &sdk.PinFeatureCompatibilityVersionApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		PinFeatureCompatibilityVersionWithParams(ctx, params).
                     		Execute()
                     }
@@ -42985,7 +42985,7 @@ paths:
                     	}
 
                     	params = &sdk.UnpinFeatureCompatibilityVersionApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UnpinFeatureCompatibilityVersionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43103,7 +43103,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43188,7 +43188,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderRegionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListCloudProviderRegionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43273,7 +43273,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -43362,7 +43362,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterToServerlessApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterToServerlessWithParams(ctx, params).
                     		Execute()
                     }
@@ -43439,7 +43439,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43525,7 +43525,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainerByCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainerByCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -43609,7 +43609,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -43699,7 +43699,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringContainerApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -43778,7 +43778,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -43872,7 +43872,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -43949,7 +43949,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainersApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainersWithParams(ctx, params).
                     		Execute()
                     }
@@ -44021,7 +44021,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCustomDatabaseRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		ListCustomDatabaseRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -44105,7 +44105,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		CreateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44189,7 +44189,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteCustomDatabaseRoleApiParams{}
-                    	httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	httpResp, err := client.CustomDatabaseRolesApi.
                     		DeleteCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44266,7 +44266,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		GetCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44356,7 +44356,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		UpdateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44441,7 +44441,7 @@ paths:
                     	}
 
                     	params = &sdk.ListFederatedDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListFederatedDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -44523,7 +44523,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -44603,7 +44603,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederatedDatabaseApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -44681,7 +44681,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -44771,7 +44771,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		UpdateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -44855,7 +44855,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44949,7 +44949,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45043,7 +45043,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45147,7 +45147,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOneDataFederationQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateOneDataFederationQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45251,7 +45251,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		DownloadFederatedDatabaseQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45324,7 +45324,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		ListDatabaseUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -45499,7 +45499,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		CreateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -45603,7 +45603,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDatabaseUserApiParams{}
-                    	httpResp, err := sdk.DatabaseUsersApi.
+                    	httpResp, err := client.DatabaseUsersApi.
                     		DeleteDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -45700,7 +45700,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		GetDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -45810,7 +45810,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		UpdateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -45895,7 +45895,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUserCertificatesApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		ListDatabaseUserCertificatesWithParams(ctx, params).
                     		Execute()
                     }
@@ -45994,7 +45994,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserCertificateApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		CreateDatabaseUserCertificateWithParams(ctx, params).
                     		Execute()
                     }
@@ -46114,7 +46114,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByClusterNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByClusterNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -46227,7 +46227,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByHostnameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByHostnameWithParams(ctx, params).
                     		Execute()
                     }
@@ -46300,7 +46300,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -46394,7 +46394,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		UpdateEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -46476,7 +46476,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -46560,7 +46560,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		CreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -46658,7 +46658,7 @@ paths:
                     	}
 
                     	params = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}
-                    	httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).
                     		Execute()
                     }
@@ -46744,7 +46744,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -46871,7 +46871,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListProjectEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46961,7 +46961,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetProjectEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -47033,7 +47033,7 @@ paths:
                     	}
 
                     	params = &sdk.ListMetricTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListMetricTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47135,7 +47135,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47236,7 +47236,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47336,7 +47336,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47413,7 +47413,7 @@ paths:
                     	}
 
                     	params = &sdk.ListThirdPartyIntegrationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		ListThirdPartyIntegrationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47505,7 +47505,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteThirdPartyIntegrationApiParams{}
-                    	httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	httpResp, err := client.Third - PartyIntegrationsApi.
                     		DeleteThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47596,7 +47596,7 @@ paths:
                     	}
 
                     	params = &sdk.GetThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		GetThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47699,7 +47699,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		CreateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47804,7 +47804,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		UpdateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47887,7 +47887,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47969,7 +47969,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48051,7 +48051,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48135,7 +48135,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectInvitationApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48217,7 +48217,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48307,7 +48307,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -48384,7 +48384,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ReturnAllIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -48462,7 +48462,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48572,7 +48572,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectLimitApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -48683,7 +48683,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -48804,7 +48804,7 @@ paths:
                     	}
 
                     	params = &sdk.SetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		SetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -48899,7 +48899,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreatePushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48978,7 +48978,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetPushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49053,7 +49053,7 @@ paths:
                     	}
 
                     	params = &sdk.CutoverMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CutoverMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49141,7 +49141,7 @@ paths:
                     	}
 
                     	params = &sdk.ValidateMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ValidateMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49230,7 +49230,7 @@ paths:
                     	}
 
                     	params = &sdk.GetValidationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetValidationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -49299,7 +49299,7 @@ paths:
                     	}
 
                     	params = &sdk.ResetMaintenanceWindowApiParams{}
-                    	httpResp, err := sdk.MaintenanceWindowsApi.
+                    	httpResp, err := client.MaintenanceWindowsApi.
                     		ResetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -49368,7 +49368,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		GetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -49445,7 +49445,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		UpdateMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -49518,7 +49518,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleMaintenanceAutoDeferApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		ToggleMaintenanceAutoDeferWithParams(ctx, params).
                     		Execute()
                     }
@@ -49591,7 +49591,7 @@ paths:
                     	}
 
                     	params = &sdk.DeferMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		DeferMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -49665,7 +49665,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedSlowMsApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetManagedSlowMsWithParams(ctx, params).
                     		Execute()
                     }
@@ -49735,7 +49735,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableSlowOperationThresholdingApiParams{}
-                    	httpResp, err := sdk.PerformanceAdvisorApi.
+                    	httpResp, err := client.PerformanceAdvisorApi.
                     		DisableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -49805,7 +49805,7 @@ paths:
                     	}
 
                     	params = &sdk.EnableSlowOperationThresholdingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		EnableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -49920,7 +49920,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLTSVersionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLTSVersionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50005,7 +50005,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50090,7 +50090,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50175,7 +50175,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringConnectionApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50255,7 +50255,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50346,7 +50346,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50423,7 +50423,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelinesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelinesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50502,7 +50502,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		CreatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -50586,7 +50586,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -50666,7 +50666,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -50756,7 +50756,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		UpdatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -50843,7 +50843,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSchedulesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50934,7 +50934,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51015,7 +51015,7 @@ paths:
                     	}
 
                     	params = &sdk.PausePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		PausePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51100,7 +51100,7 @@ paths:
                     	}
 
                     	params = &sdk.ResumePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ResumePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51195,7 +51195,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineRunsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineRunsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51286,7 +51286,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineRunDatasetApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineRunDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -51376,7 +51376,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineRunApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineRunWithParams(ctx, params).
                     		Execute()
                     }
@@ -51464,7 +51464,7 @@ paths:
                     	}
 
                     	params = &sdk.TriggerSnapshotIngestionApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		TriggerSnapshotIngestionWithParams(ctx, params).
                     		Execute()
                     }
@@ -51551,7 +51551,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPrivateEndpointServicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ListPrivateEndpointServicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51641,7 +51641,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointServiceApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -51732,7 +51732,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -51835,7 +51835,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -51936,7 +51936,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52034,7 +52034,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52114,7 +52114,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52190,7 +52190,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52268,7 +52268,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52353,7 +52353,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		ListServerlessPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52444,7 +52444,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		CreateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52536,7 +52536,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		DeleteServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52623,7 +52623,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		GetServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52717,7 +52717,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		UpdateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52795,7 +52795,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -52877,7 +52877,7 @@ paths:
                     	}
 
                     	params = &sdk.DisablePeeringApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		DisablePeeringWithParams(ctx, params).
                     		Execute()
                     }
@@ -52958,7 +52958,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDataFederationPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListDataFederationPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53055,7 +53055,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53140,7 +53140,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDataFederationPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53222,7 +53222,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53295,7 +53295,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasProcessesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListAtlasProcessesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53373,7 +53373,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetAtlasProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -53486,7 +53486,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53559,7 +53559,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespacesForHostWithParams(ctx, params).
                     		Execute()
                     }
@@ -53640,7 +53640,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53724,7 +53724,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -53834,7 +53834,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53915,7 +53915,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskPartitionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskPartitionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53998,7 +53998,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54124,7 +54124,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54361,7 +54361,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54459,7 +54459,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueryNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueryNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54574,7 +54574,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54696,7 +54696,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSuggestedIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSuggestedIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54770,7 +54770,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePushBasedLogConfigurationApiParams{}
-                    	httpResp, err := sdk.Push - BasedLogExportApi.
+                    	httpResp, err := client.Push - BasedLogExportApi.
                     		DeletePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -54843,7 +54843,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		GetPushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -54924,7 +54924,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		UpdatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55009,7 +55009,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		CreatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55095,7 +55095,7 @@ paths:
                     	}
 
                     	params = &sdk.LoadSampleDatasetApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		LoadSampleDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -55177,7 +55177,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSampleDatasetLoadStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetSampleDatasetLoadStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -55250,7 +55250,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		ListServerlessInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55330,7 +55330,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		CreateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -55418,7 +55418,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55509,7 +55509,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -55603,7 +55603,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -55687,7 +55687,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55777,7 +55777,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -55856,7 +55856,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -55939,7 +55939,7 @@ paths:
                     	}
 
                     	params = &sdk.SetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		SetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -56026,7 +56026,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessInstanceApiParams{}
-                    	httpResp, err := sdk.ServerlessInstancesApi.
+                    	httpResp, err := client.ServerlessInstancesApi.
                     		DeleteServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56108,7 +56108,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		GetServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56195,7 +56195,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		UpdateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56273,7 +56273,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		ListProjectServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56352,7 +56352,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		CreateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -56435,7 +56435,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectServiceAccountApiParams{}
-                    	httpResp, err := sdk.GroupsApi.
+                    	httpResp, err := client.GroupsApi.
                     		DeleteProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -56512,7 +56512,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		GetProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -56598,7 +56598,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		UpdateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -56690,7 +56690,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		AddProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -56768,7 +56768,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56848,7 +56848,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56924,7 +56924,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -57002,7 +57002,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57086,7 +57086,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamInstanceApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57169,7 +57169,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57257,7 +57257,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57362,7 +57362,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadStreamTenantAuditLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		DownloadStreamTenantAuditLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57442,7 +57442,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57528,7 +57528,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -57618,7 +57618,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamConnectionApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -57700,7 +57700,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -57794,7 +57794,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -57885,7 +57885,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -57973,7 +57973,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamProcessorApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58058,7 +58058,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58144,7 +58144,7 @@ paths:
                     	}
 
                     	params = &sdk.StartStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		StartStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58234,7 +58234,7 @@ paths:
                     	}
 
                     	params = &sdk.StopStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		StopStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58321,7 +58321,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamProcessorsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamProcessorsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58400,7 +58400,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListProjectTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58487,7 +58487,7 @@ paths:
                     	}
 
                     	params = &sdk.AddAllTeamsToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddAllTeamsToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -58576,7 +58576,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveProjectTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -58670,7 +58670,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateTeamRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		UpdateTeamRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -58744,7 +58744,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -58825,7 +58825,7 @@ paths:
                     	}
 
                     	params = &sdk.SaveLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		SaveLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -58901,7 +58901,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableCustomerManagedX509ApiParams{}
-                    	httpResp, err := sdk.X509AuthenticationApi.
+                    	httpResp, err := client.X509AuthenticationApi.
                     		DisableCustomerManagedX509WithParams(ctx, params).
                     		Execute()
                     }
@@ -58971,7 +58971,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLDAPConfigurationApiParams{}
-                    	httpResp, err := sdk.LDAPConfigurationApi.
+                    	httpResp, err := client.LDAPConfigurationApi.
                     		DeleteLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59050,7 +59050,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		VerifyLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59133,7 +59133,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -59218,7 +59218,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -59299,7 +59299,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectUserApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		RemoveProjectUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -59389,7 +59389,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -59469,7 +59469,7 @@ paths:
                     	}
 
                     	params = &sdk.MigrateProjectToAnotherOrgApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		MigrateProjectToAnotherOrgWithParams(ctx, params).
                     		Execute()
                     }
@@ -59556,7 +59556,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -59639,7 +59639,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59722,7 +59722,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59808,7 +59808,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59883,7 +59883,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59965,7 +59965,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		RenameOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -60045,7 +60045,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -60124,7 +60124,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -60210,7 +60210,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -60291,7 +60291,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -60381,7 +60381,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -60470,7 +60470,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeyAccessListsEntriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeyAccessListsEntriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -60564,7 +60564,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -60662,7 +60662,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyAccessListEntryApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyAccessListEntryWithParams(ctx, params).
                     		Execute()
                     }
@@ -60753,7 +60753,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -60831,7 +60831,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -60923,7 +60923,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcess_1WithParams(ctx, params).
                     		Execute()
                     }
@@ -61028,7 +61028,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListOrganizationEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61118,7 +61118,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetOrganizationEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -61192,7 +61192,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetFederationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61282,7 +61282,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61364,7 +61364,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61444,7 +61444,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61528,7 +61528,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61612,7 +61612,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationInvitationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61693,7 +61693,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61782,7 +61782,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -61920,7 +61920,7 @@ paths:
                     	}
 
                     	params = &sdk.ListInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -62007,7 +62007,7 @@ paths:
                     	}
 
                     	params = &sdk.GetInvoiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		GetInvoiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -62095,7 +62095,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadInvoiceCSVApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		DownloadInvoiceCSVWithParams(ctx, params).
                     		Execute()
                     }
@@ -62167,7 +62167,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPendingInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListPendingInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -62241,7 +62241,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSourceProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ListSourceProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62312,7 +62312,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLinkTokenApiParams{}
-                    	httpResp, err := sdk.CloudMigrationServiceApi.
+                    	httpResp, err := client.CloudMigrationServiceApi.
                     		DeleteLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -62390,7 +62390,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLinkTokenApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreateLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -62468,7 +62468,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62546,7 +62546,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -62626,7 +62626,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -62703,7 +62703,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -62789,7 +62789,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -62873,7 +62873,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62958,7 +62958,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountSecretApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -63044,7 +63044,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountSecretApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -63118,7 +63118,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63198,7 +63198,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63282,7 +63282,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListOrganizationTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63367,7 +63367,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		CreateTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -63457,7 +63457,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		DeleteTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -63542,7 +63542,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -63636,7 +63636,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		RenameTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -63730,7 +63730,7 @@ paths:
                     	}
 
                     	params = &sdk.ListTeamUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListTeamUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -63826,7 +63826,7 @@ paths:
                     	}
 
                     	params = &sdk.AddTeamUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -63923,7 +63923,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveTeamUserApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64006,7 +64006,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -64083,7 +64083,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -64167,7 +64167,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveOrganizationUserApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		RemoveOrganizationUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64257,7 +64257,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -64325,7 +64325,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		ReturnAllControlPlaneIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -64408,7 +64408,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		CreateUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64492,7 +64492,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64570,7 +64570,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserByUsernameApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserByUsernameWithParams(ctx, params).
                     		Execute()
                     }

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.json
@@ -256,7 +256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -323,7 +323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -396,7 +396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -469,7 +469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -533,7 +533,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -609,7 +609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -692,7 +692,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -773,7 +773,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -865,7 +865,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -938,7 +938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1020,7 +1020,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1103,7 +1103,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1187,7 +1187,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1282,7 +1282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1390,7 +1390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1472,7 +1472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1549,7 +1549,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1630,7 +1630,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1719,7 +1719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1796,7 +1796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1866,7 +1866,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1942,7 +1942,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2038,7 +2038,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2122,7 +2122,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2192,7 +2192,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2260,7 +2260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2345,7 +2345,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2431,7 +2431,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2511,7 +2511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2609,7 +2609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2694,7 +2694,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := sdk.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2780,7 +2780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2867,7 +2867,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2943,7 +2943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3022,7 +3022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3102,7 +3102,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := sdk.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3183,7 +3183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3275,7 +3275,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3370,7 +3370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3462,7 +3462,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3554,7 +3554,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3636,7 +3636,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3730,7 +3730,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3821,7 +3821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3901,7 +3901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3977,7 +3977,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4063,7 +4063,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4163,7 +4163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4254,7 +4254,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4321,7 +4321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4400,7 +4400,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4467,7 +4467,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4543,7 +4543,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4619,7 +4619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4756,7 +4756,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4839,7 +4839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4951,7 +4951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5021,7 +5021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5113,7 +5113,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5180,7 +5180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5260,7 +5260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5351,7 +5351,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := sdk.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5430,7 +5430,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5528,7 +5528,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5613,7 +5613,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5708,7 +5708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5803,7 +5803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5893,7 +5893,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5983,7 +5983,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6076,7 +6076,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := sdk.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6159,7 +6159,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6257,7 +6257,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6345,7 +6345,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6439,7 +6439,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6524,7 +6524,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6612,7 +6612,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6709,7 +6709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6803,7 +6803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6892,7 +6892,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6971,7 +6971,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7048,7 +7048,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7139,7 +7139,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7230,7 +7230,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7321,7 +7321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7412,7 +7412,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7504,7 +7504,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7586,7 +7586,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7680,7 +7680,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7772,7 +7772,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7875,7 +7875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7977,7 +7977,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8076,7 +8076,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8158,7 +8158,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8252,7 +8252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8334,7 +8334,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8428,7 +8428,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8517,7 +8517,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8615,7 +8615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8697,7 +8697,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8799,7 +8799,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8901,7 +8901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8994,7 +8994,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9095,7 +9095,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9201,7 +9201,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9301,7 +9301,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9396,7 +9396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9508,7 +9508,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9592,7 +9592,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9675,7 +9675,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9771,7 +9771,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9873,7 +9873,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9972,7 +9972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10157,7 +10157,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10249,7 +10249,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10350,7 +10350,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10469,7 +10469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10567,7 +10567,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := sdk.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10666,7 +10666,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10779,7 +10779,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10868,7 +10868,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10955,7 +10955,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11050,7 +11050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11136,7 +11136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11235,7 +11235,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11311,7 +11311,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11414,7 +11414,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11506,7 +11506,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11601,7 +11601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11686,7 +11686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11766,7 +11766,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11860,7 +11860,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11954,7 +11954,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12053,7 +12053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12151,7 +12151,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12268,7 +12268,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12381,7 +12381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12492,7 +12492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12617,7 +12617,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12715,7 +12715,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12821,7 +12821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12931,7 +12931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13011,7 +13011,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13100,7 +13100,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13203,7 +13203,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13298,7 +13298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := sdk.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13388,7 +13388,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13489,7 +13489,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13568,7 +13568,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13667,7 +13667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13819,7 +13819,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13918,7 +13918,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14009,7 +14009,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14136,7 +14136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14206,7 +14206,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14300,7 +14300,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14388,7 +14388,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14464,7 +14464,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14553,7 +14553,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14631,7 +14631,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14732,7 +14732,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14802,7 +14802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14890,7 +14890,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14972,7 +14972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15049,7 +15049,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15146,7 +15146,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15229,7 +15229,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15314,7 +15314,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15390,7 +15390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15467,7 +15467,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15564,7 +15564,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15646,7 +15646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15734,7 +15734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15823,7 +15823,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15926,7 +15926,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16032,7 +16032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16108,7 +16108,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16348,7 +16348,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16440,7 +16440,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := sdk.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16527,7 +16527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16634,7 +16634,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16722,7 +16722,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16824,7 +16824,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16957,7 +16957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17087,7 +17087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17154,7 +17154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17239,7 +17239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17318,7 +17318,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17406,7 +17406,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17508,7 +17508,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17597,7 +17597,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17740,7 +17740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17831,7 +17831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17901,7 +17901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18017,7 +18017,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18136,7 +18136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18247,7 +18247,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18329,7 +18329,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18424,7 +18424,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18517,7 +18517,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18633,7 +18633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18746,7 +18746,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18826,7 +18826,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18910,7 +18910,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18988,7 +18988,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19066,7 +19066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19148,7 +19148,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19241,7 +19241,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19312,7 +19312,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19391,7 +19391,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19488,7 +19488,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19586,7 +19586,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19695,7 +19695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19783,7 +19783,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19871,7 +19871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19957,7 +19957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20033,7 +20033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20109,7 +20109,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20173,7 +20173,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := sdk.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20238,7 +20238,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20314,7 +20314,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20378,7 +20378,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20442,7 +20442,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20509,7 +20509,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20576,7 +20576,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := sdk.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20643,7 +20643,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20771,7 +20771,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20864,7 +20864,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20953,7 +20953,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21035,7 +21035,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21115,7 +21115,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21212,7 +21212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21282,7 +21282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21361,7 +21361,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21440,7 +21440,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21520,7 +21520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21614,7 +21614,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21699,7 +21699,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21800,7 +21800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21882,7 +21882,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21964,7 +21964,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22065,7 +22065,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22160,7 +22160,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22253,7 +22253,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22346,7 +22346,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22428,7 +22428,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22498,7 +22498,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22577,7 +22577,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22658,7 +22658,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22749,7 +22749,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22839,7 +22839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22927,7 +22927,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23026,7 +23026,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23111,7 +23111,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23205,7 +23205,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23300,7 +23300,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23414,7 +23414,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23518,7 +23518,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23623,7 +23623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23695,7 +23695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23779,7 +23779,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23861,7 +23861,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23940,7 +23940,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24022,7 +24022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24105,7 +24105,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24181,7 +24181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24259,7 +24259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24335,7 +24335,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24422,7 +24422,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24509,7 +24509,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24635,7 +24635,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24722,7 +24722,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24806,7 +24806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24941,7 +24941,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25183,7 +25183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25279,7 +25279,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25399,7 +25399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25535,7 +25535,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25662,7 +25662,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25735,7 +25735,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := sdk.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25806,7 +25806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25889,7 +25889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25972,7 +25972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26054,7 +26054,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26130,7 +26130,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26206,7 +26206,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26288,7 +26288,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26379,7 +26379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26476,7 +26476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26570,7 +26570,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26661,7 +26661,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26753,7 +26753,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26832,7 +26832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26915,7 +26915,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27000,7 +27000,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := sdk.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27083,7 +27083,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27174,7 +27174,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27250,7 +27250,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27330,7 +27330,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27410,7 +27410,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := sdk.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27487,7 +27487,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27578,7 +27578,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27671,7 +27671,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27744,7 +27744,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27826,7 +27826,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27899,7 +27899,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27978,7 +27978,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28060,7 +28060,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28145,7 +28145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28239,7 +28239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28348,7 +28348,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28433,7 +28433,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28524,7 +28524,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28615,7 +28615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28698,7 +28698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28801,7 +28801,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28894,7 +28894,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28982,7 +28982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29071,7 +29071,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29162,7 +29162,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29253,7 +29253,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29344,7 +29344,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29429,7 +29429,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29521,7 +29521,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29607,7 +29607,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29708,7 +29708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29775,7 +29775,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29854,7 +29854,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29918,7 +29918,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := sdk.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29985,7 +29985,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := sdk.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30066,7 +30066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30145,7 +30145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30239,7 +30239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30321,7 +30321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30417,7 +30417,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30492,7 +30492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30582,7 +30582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30667,7 +30667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30743,7 +30743,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30817,7 +30817,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30902,7 +30902,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30982,7 +30982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31062,7 +31062,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31145,7 +31145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31226,7 +31226,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31321,7 +31321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31413,7 +31413,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31519,7 +31519,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31619,7 +31619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31714,7 +31714,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31792,7 +31792,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31883,7 +31883,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31998,7 +31998,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32089,7 +32089,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32162,7 +32162,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32252,7 +32252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32337,7 +32337,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32419,7 +32419,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32501,7 +32501,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32583,7 +32583,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32663,7 +32663,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32757,7 +32757,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32915,7 +32915,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32985,7 +32985,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33073,7 +33073,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33154,7 +33154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33227,7 +33227,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33294,7 +33294,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := sdk.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33373,7 +33373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33449,7 +33449,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33528,7 +33528,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33604,7 +33604,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33681,7 +33681,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33772,7 +33772,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33857,7 +33857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33947,7 +33947,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34032,7 +34032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34105,7 +34105,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34187,7 +34187,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34273,7 +34273,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34362,7 +34362,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34448,7 +34448,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34537,7 +34537,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34624,7 +34624,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34725,7 +34725,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34823,7 +34823,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34927,7 +34927,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35025,7 +35025,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35107,7 +35107,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35192,7 +35192,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35288,7 +35288,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35341,7 +35341,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35419,7 +35419,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35496,7 +35496,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35575,7 +35575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20240805001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2024-08-05.yaml
@@ -30171,7 +30171,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSystemStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		GetSystemStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -30242,7 +30242,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).
                     		Execute()
                     }
@@ -30314,7 +30314,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersForAllProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersForAllProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30386,7 +30386,7 @@ paths:
                     	}
 
                     	params = &sdk.ListEventTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListEventTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -30456,7 +30456,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederationAppApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteFederationAppWithParams(ctx, params).
                     		Execute()
                     }
@@ -30531,7 +30531,7 @@ paths:
                     	}
 
                     	params = &sdk.ListConnectedOrgConfigsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListConnectedOrgConfigsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30614,7 +30614,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveConnectedOrgConfigApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RemoveConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30696,7 +30696,7 @@ paths:
                     	}
 
                     	params = &sdk.GetConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30785,7 +30785,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -30863,7 +30863,7 @@ paths:
                     	}
 
                     	params = &sdk.ListRoleMappingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListRoleMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30943,7 +30943,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31029,7 +31029,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteRoleMappingApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31112,7 +31112,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31202,7 +31202,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31303,7 +31303,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIdentityProvidersApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListIdentityProvidersWithParams(ctx, params).
                     		Execute()
                     }
@@ -31387,7 +31387,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31469,7 +31469,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteIdentityProviderApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31550,7 +31550,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31639,7 +31639,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31721,7 +31721,7 @@ paths:
                     	}
 
                     	params = &sdk.RevokeJwksFromIdentityProviderApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RevokeJwksFromIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31794,7 +31794,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderMetadataApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderMetadataWithParams(ctx, params).
                     		Execute()
                     }
@@ -31868,7 +31868,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31959,7 +31959,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32035,7 +32035,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32106,7 +32106,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32188,7 +32188,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32274,7 +32274,7 @@ paths:
                     	}
 
                     	params = &sdk.AddUserToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		AddUserToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32354,7 +32354,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectIpAccessListsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		ListProjectIpAccessListsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32442,7 +32442,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectIpAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		CreateProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32534,7 +32534,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectIpAccessListApiParams{}
-                    	httpResp, err := sdk.ProjectIPAccessListApi.
+                    	httpResp, err := client.ProjectIPAccessListApi.
                     		DeleteProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32618,7 +32618,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32702,7 +32702,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpAccessListStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpAccessListStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -32778,7 +32778,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32859,7 +32859,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		CreateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -32946,7 +32946,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAlertConfigurationApiParams{}
-                    	httpResp, err := sdk.AlertConfigurationsApi.
+                    	httpResp, err := client.AlertConfigurationsApi.
                     		DeleteAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33030,7 +33030,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		GetAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33123,7 +33123,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ToggleAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33222,7 +33222,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		UpdateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33314,7 +33314,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsByAlertConfigurationIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsByAlertConfigurationIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -33401,7 +33401,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33485,7 +33485,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		GetAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -33577,7 +33577,7 @@ paths:
                     	}
 
                     	params = &sdk.AcknowledgeAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		AcknowledgeAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -33668,7 +33668,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsByAlertIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsByAlertIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -33744,7 +33744,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListProjectApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -33820,7 +33820,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -33908,7 +33908,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		RemoveProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -33998,7 +33998,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -34089,7 +34089,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		AddProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -34163,7 +34163,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		GetAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -34241,7 +34241,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		UpdateAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -34315,7 +34315,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		GetAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -34391,7 +34391,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		ToggleAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -34468,7 +34468,7 @@ paths:
                     	}
 
                     	params = &sdk.ListExportBucketsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListExportBucketsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34587,7 +34587,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34674,7 +34674,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteExportBucketApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34777,7 +34777,7 @@ paths:
                     	}
 
                     	params = &sdk.GetExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -34849,7 +34849,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34936,7 +34936,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35010,7 +35010,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderAccessRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		ListCloudProviderAccessRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -35089,7 +35089,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		CreateCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35180,7 +35180,7 @@ paths:
                     	}
 
                     	params = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}
-                    	httpResp, err := sdk.CloudProviderAccessApi.
+                    	httpResp, err := client.CloudProviderAccessApi.
                     		DeauthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35259,7 +35259,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		GetCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35351,7 +35351,7 @@ paths:
                     	}
 
                     	params = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		AuthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35434,7 +35434,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersWithParams(ctx, params).
                     		Execute()
                     }
@@ -35646,7 +35646,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		CreateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35738,7 +35738,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteClusterApiParams{}
-                    	httpResp, err := sdk.ClustersApi.
+                    	httpResp, err := client.ClustersApi.
                     		DeleteClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35820,7 +35820,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -35912,7 +35912,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -36049,7 +36049,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36140,7 +36140,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -36222,7 +36222,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupExportJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupExportJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36312,7 +36312,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36400,7 +36400,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36482,7 +36482,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36576,7 +36576,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36670,7 +36670,7 @@ paths:
                     	}
 
                     	params = &sdk.CancelBackupRestoreJobApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		CancelBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36757,7 +36757,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36837,7 +36837,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllBackupSchedulesApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteAllBackupSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -36915,7 +36915,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -37005,7 +37005,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -37093,7 +37093,7 @@ paths:
                     	}
 
                     	params = &sdk.ListReplicaSetBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListReplicaSetBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37183,7 +37183,7 @@ paths:
                     	}
 
                     	params = &sdk.TakeSnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		TakeSnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -37277,7 +37277,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteReplicaSetBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37366,7 +37366,7 @@ paths:
                     	}
 
                     	params = &sdk.GetReplicaSetBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37462,7 +37462,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateSnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateSnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -37554,7 +37554,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteShardedClusterBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37643,7 +37643,7 @@ paths:
                     	}
 
                     	params = &sdk.GetShardedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37724,7 +37724,7 @@ paths:
                     	}
 
                     	params = &sdk.ListShardedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListShardedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37818,7 +37818,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		DownloadSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37914,7 +37914,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		CreateSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -37999,7 +37999,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		ListSharedClusterBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38089,7 +38089,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		GetSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -38170,7 +38170,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		ListSharedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38260,7 +38260,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		GetSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -38343,7 +38343,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupCheckpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupCheckpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38436,7 +38436,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupCheckpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupCheckpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -38518,7 +38518,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPinnedNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetPinnedNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -38613,7 +38613,7 @@ paths:
                     	}
 
                     	params = &sdk.PinNamespacesPatchApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		PinNamespacesPatchWithParams(ctx, params).
                     		Execute()
                     }
@@ -38712,7 +38712,7 @@ paths:
                     	}
 
                     	params = &sdk.PinNamespacesPutApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		PinNamespacesPutWithParams(ctx, params).
                     		Execute()
                     }
@@ -38805,7 +38805,7 @@ paths:
                     	}
 
                     	params = &sdk.UnpinNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		UnpinNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -38903,7 +38903,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39005,7 +39005,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39100,7 +39100,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39192,7 +39192,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39295,7 +39295,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39382,7 +39382,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		GetManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39464,7 +39464,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllCustomZoneMappingsApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteAllCustomZoneMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39555,7 +39555,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomZoneMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateCustomZoneMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -39653,7 +39653,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteManagedNamespaceApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39746,7 +39746,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39904,7 +39904,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRollingIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.RollingIndexApi.
+                    	sdkResp, httpResp, err := client.RollingIndexApi.
                     		CreateRollingIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -39993,7 +39993,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOnlineArchivesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		ListOnlineArchivesWithParams(ctx, params).
                     		Execute()
                     }
@@ -40087,7 +40087,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		CreateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40184,7 +40184,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOnlineArchiveApiParams{}
-                    	httpResp, err := sdk.OnlineArchiveApi.
+                    	httpResp, err := client.OnlineArchiveApi.
                     		DeleteOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40278,7 +40278,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		GetOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40381,7 +40381,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		UpdateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40494,7 +40494,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		DownloadOnlineArchiveQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40580,7 +40580,7 @@ paths:
                     	}
 
                     	params = &sdk.EndOutageSimulationApiParams{}
-                    	httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	httpResp, err := client.ClusterOutageSimulationApi.
                     		EndOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40665,7 +40665,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		GetOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40755,7 +40755,7 @@ paths:
                     	}
 
                     	params = &sdk.StartOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		StartOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40843,7 +40843,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -40936,7 +40936,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -41017,7 +41017,7 @@ paths:
                     	}
 
                     	params = &sdk.TestFailoverApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		TestFailoverWithParams(ctx, params).
                     		Execute()
                     }
@@ -41117,7 +41117,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -41205,7 +41205,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		CreateLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -41303,7 +41303,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -41386,7 +41386,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchDeploymentApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41466,7 +41466,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41555,7 +41555,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41648,7 +41648,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41744,7 +41744,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -41836,7 +41836,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -41944,7 +41944,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -42046,7 +42046,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexByNameApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42147,7 +42147,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42257,7 +42257,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42354,7 +42354,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42452,7 +42452,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42553,7 +42553,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42640,7 +42640,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -42729,7 +42729,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -42826,7 +42826,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacySnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacySnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -42917,7 +42917,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLegacySnapshotApiParams{}
-                    	httpResp, err := sdk.LegacyBackupApi.
+                    	httpResp, err := client.LegacyBackupApi.
                     		DeleteLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -43005,7 +43005,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -43100,7 +43100,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43183,7 +43183,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -43275,7 +43275,7 @@ paths:
                     	}
 
                     	params = &sdk.PinFeatureCompatibilityVersionApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		PinFeatureCompatibilityVersionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43366,7 +43366,7 @@ paths:
                     	}
 
                     	params = &sdk.UnpinFeatureCompatibilityVersionApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UnpinFeatureCompatibilityVersionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43484,7 +43484,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43569,7 +43569,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderRegionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListCloudProviderRegionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43654,7 +43654,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -43743,7 +43743,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterToServerlessApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterToServerlessWithParams(ctx, params).
                     		Execute()
                     }
@@ -43820,7 +43820,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43906,7 +43906,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainerByCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainerByCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -43990,7 +43990,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -44080,7 +44080,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringContainerApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -44159,7 +44159,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -44253,7 +44253,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -44330,7 +44330,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainersApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainersWithParams(ctx, params).
                     		Execute()
                     }
@@ -44402,7 +44402,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCustomDatabaseRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		ListCustomDatabaseRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -44486,7 +44486,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		CreateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44570,7 +44570,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteCustomDatabaseRoleApiParams{}
-                    	httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	httpResp, err := client.CustomDatabaseRolesApi.
                     		DeleteCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44647,7 +44647,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		GetCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44737,7 +44737,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		UpdateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44822,7 +44822,7 @@ paths:
                     	}
 
                     	params = &sdk.ListFederatedDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListFederatedDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -44904,7 +44904,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -44984,7 +44984,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederatedDatabaseApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -45062,7 +45062,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -45152,7 +45152,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		UpdateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -45236,7 +45236,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45330,7 +45330,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45424,7 +45424,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45528,7 +45528,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOneDataFederationQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateOneDataFederationQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45632,7 +45632,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		DownloadFederatedDatabaseQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45705,7 +45705,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		ListDatabaseUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -45880,7 +45880,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		CreateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -45984,7 +45984,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDatabaseUserApiParams{}
-                    	httpResp, err := sdk.DatabaseUsersApi.
+                    	httpResp, err := client.DatabaseUsersApi.
                     		DeleteDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -46081,7 +46081,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		GetDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -46191,7 +46191,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		UpdateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -46276,7 +46276,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUserCertificatesApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		ListDatabaseUserCertificatesWithParams(ctx, params).
                     		Execute()
                     }
@@ -46375,7 +46375,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserCertificateApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		CreateDatabaseUserCertificateWithParams(ctx, params).
                     		Execute()
                     }
@@ -46495,7 +46495,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByClusterNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByClusterNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -46608,7 +46608,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByHostnameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByHostnameWithParams(ctx, params).
                     		Execute()
                     }
@@ -46681,7 +46681,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -46775,7 +46775,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		UpdateEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -46857,7 +46857,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -46941,7 +46941,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		CreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -47039,7 +47039,7 @@ paths:
                     	}
 
                     	params = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}
-                    	httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47125,7 +47125,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -47252,7 +47252,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListProjectEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47342,7 +47342,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetProjectEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -47414,7 +47414,7 @@ paths:
                     	}
 
                     	params = &sdk.ListMetricTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListMetricTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47516,7 +47516,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47617,7 +47617,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47717,7 +47717,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47794,7 +47794,7 @@ paths:
                     	}
 
                     	params = &sdk.ListThirdPartyIntegrationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		ListThirdPartyIntegrationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47886,7 +47886,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteThirdPartyIntegrationApiParams{}
-                    	httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	httpResp, err := client.Third - PartyIntegrationsApi.
                     		DeleteThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -47977,7 +47977,7 @@ paths:
                     	}
 
                     	params = &sdk.GetThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		GetThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48080,7 +48080,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		CreateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48185,7 +48185,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		UpdateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48268,7 +48268,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48350,7 +48350,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48432,7 +48432,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48516,7 +48516,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectInvitationApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48598,7 +48598,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48688,7 +48688,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -48765,7 +48765,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ReturnAllIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -48843,7 +48843,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48953,7 +48953,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectLimitApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -49064,7 +49064,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -49185,7 +49185,7 @@ paths:
                     	}
 
                     	params = &sdk.SetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		SetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -49280,7 +49280,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreatePushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49359,7 +49359,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetPushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49434,7 +49434,7 @@ paths:
                     	}
 
                     	params = &sdk.CutoverMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CutoverMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49522,7 +49522,7 @@ paths:
                     	}
 
                     	params = &sdk.ValidateMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ValidateMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49611,7 +49611,7 @@ paths:
                     	}
 
                     	params = &sdk.GetValidationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetValidationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -49680,7 +49680,7 @@ paths:
                     	}
 
                     	params = &sdk.ResetMaintenanceWindowApiParams{}
-                    	httpResp, err := sdk.MaintenanceWindowsApi.
+                    	httpResp, err := client.MaintenanceWindowsApi.
                     		ResetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -49749,7 +49749,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		GetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -49826,7 +49826,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		UpdateMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -49899,7 +49899,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleMaintenanceAutoDeferApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		ToggleMaintenanceAutoDeferWithParams(ctx, params).
                     		Execute()
                     }
@@ -49972,7 +49972,7 @@ paths:
                     	}
 
                     	params = &sdk.DeferMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		DeferMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -50046,7 +50046,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedSlowMsApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetManagedSlowMsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50116,7 +50116,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableSlowOperationThresholdingApiParams{}
-                    	httpResp, err := sdk.PerformanceAdvisorApi.
+                    	httpResp, err := client.PerformanceAdvisorApi.
                     		DisableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -50186,7 +50186,7 @@ paths:
                     	}
 
                     	params = &sdk.EnableSlowOperationThresholdingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		EnableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -50301,7 +50301,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLTSVersionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLTSVersionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50386,7 +50386,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50471,7 +50471,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50556,7 +50556,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringConnectionApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50636,7 +50636,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50727,7 +50727,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50804,7 +50804,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelinesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelinesWithParams(ctx, params).
                     		Execute()
                     }
@@ -50883,7 +50883,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		CreatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -50967,7 +50967,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51047,7 +51047,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51137,7 +51137,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		UpdatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51224,7 +51224,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSchedulesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51315,7 +51315,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51396,7 +51396,7 @@ paths:
                     	}
 
                     	params = &sdk.PausePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		PausePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51481,7 +51481,7 @@ paths:
                     	}
 
                     	params = &sdk.ResumePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ResumePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51576,7 +51576,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineRunsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineRunsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51667,7 +51667,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineRunDatasetApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineRunDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -51757,7 +51757,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineRunApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineRunWithParams(ctx, params).
                     		Execute()
                     }
@@ -51845,7 +51845,7 @@ paths:
                     	}
 
                     	params = &sdk.TriggerSnapshotIngestionApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		TriggerSnapshotIngestionWithParams(ctx, params).
                     		Execute()
                     }
@@ -51932,7 +51932,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPrivateEndpointServicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ListPrivateEndpointServicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -52022,7 +52022,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointServiceApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52113,7 +52113,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52216,7 +52216,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52317,7 +52317,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52415,7 +52415,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52495,7 +52495,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52571,7 +52571,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52649,7 +52649,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -52734,7 +52734,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		ListServerlessPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52825,7 +52825,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		CreateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52917,7 +52917,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		DeleteServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53004,7 +53004,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		GetServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53098,7 +53098,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		UpdateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53176,7 +53176,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -53258,7 +53258,7 @@ paths:
                     	}
 
                     	params = &sdk.DisablePeeringApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		DisablePeeringWithParams(ctx, params).
                     		Execute()
                     }
@@ -53339,7 +53339,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDataFederationPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListDataFederationPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53436,7 +53436,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53521,7 +53521,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDataFederationPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53603,7 +53603,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53676,7 +53676,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasProcessesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListAtlasProcessesWithParams(ctx, params).
                     		Execute()
                     }
@@ -53754,7 +53754,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetAtlasProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -53867,7 +53867,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53940,7 +53940,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespacesForHostWithParams(ctx, params).
                     		Execute()
                     }
@@ -54021,7 +54021,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54105,7 +54105,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -54215,7 +54215,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54296,7 +54296,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskPartitionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskPartitionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54379,7 +54379,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54505,7 +54505,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54742,7 +54742,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54840,7 +54840,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueryNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueryNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54955,7 +54955,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55077,7 +55077,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSuggestedIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSuggestedIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55151,7 +55151,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePushBasedLogConfigurationApiParams{}
-                    	httpResp, err := sdk.Push - BasedLogExportApi.
+                    	httpResp, err := client.Push - BasedLogExportApi.
                     		DeletePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55224,7 +55224,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		GetPushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55305,7 +55305,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		UpdatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55390,7 +55390,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		CreatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55476,7 +55476,7 @@ paths:
                     	}
 
                     	params = &sdk.LoadSampleDatasetApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		LoadSampleDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -55558,7 +55558,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSampleDatasetLoadStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetSampleDatasetLoadStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -55631,7 +55631,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		ListServerlessInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55711,7 +55711,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		CreateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -55799,7 +55799,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55890,7 +55890,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -55984,7 +55984,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -56068,7 +56068,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56158,7 +56158,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -56237,7 +56237,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -56320,7 +56320,7 @@ paths:
                     	}
 
                     	params = &sdk.SetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		SetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -56407,7 +56407,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessInstanceApiParams{}
-                    	httpResp, err := sdk.ServerlessInstancesApi.
+                    	httpResp, err := client.ServerlessInstancesApi.
                     		DeleteServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56489,7 +56489,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		GetServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56576,7 +56576,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		UpdateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56654,7 +56654,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		ListProjectServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56733,7 +56733,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		CreateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -56816,7 +56816,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectServiceAccountApiParams{}
-                    	httpResp, err := sdk.GroupsApi.
+                    	httpResp, err := client.GroupsApi.
                     		DeleteProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -56893,7 +56893,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		GetProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -56979,7 +56979,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		UpdateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -57071,7 +57071,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		AddProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -57149,7 +57149,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57229,7 +57229,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57305,7 +57305,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -57383,7 +57383,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57467,7 +57467,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamInstanceApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57550,7 +57550,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57638,7 +57638,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57743,7 +57743,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadStreamTenantAuditLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		DownloadStreamTenantAuditLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57823,7 +57823,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57909,7 +57909,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -57999,7 +57999,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamConnectionApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -58081,7 +58081,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -58175,7 +58175,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -58266,7 +58266,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58354,7 +58354,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamProcessorApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58439,7 +58439,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58525,7 +58525,7 @@ paths:
                     	}
 
                     	params = &sdk.StartStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		StartStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58615,7 +58615,7 @@ paths:
                     	}
 
                     	params = &sdk.StopStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		StopStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58702,7 +58702,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamProcessorsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamProcessorsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58781,7 +58781,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListProjectTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58868,7 +58868,7 @@ paths:
                     	}
 
                     	params = &sdk.AddAllTeamsToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddAllTeamsToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -58957,7 +58957,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveProjectTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -59051,7 +59051,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateTeamRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		UpdateTeamRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -59125,7 +59125,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59206,7 +59206,7 @@ paths:
                     	}
 
                     	params = &sdk.SaveLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		SaveLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59282,7 +59282,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableCustomerManagedX509ApiParams{}
-                    	httpResp, err := sdk.X509AuthenticationApi.
+                    	httpResp, err := client.X509AuthenticationApi.
                     		DisableCustomerManagedX509WithParams(ctx, params).
                     		Execute()
                     }
@@ -59352,7 +59352,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLDAPConfigurationApiParams{}
-                    	httpResp, err := sdk.LDAPConfigurationApi.
+                    	httpResp, err := client.LDAPConfigurationApi.
                     		DeleteLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59431,7 +59431,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		VerifyLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59514,7 +59514,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -59599,7 +59599,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -59680,7 +59680,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectUserApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		RemoveProjectUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -59770,7 +59770,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -59850,7 +59850,7 @@ paths:
                     	}
 
                     	params = &sdk.MigrateProjectToAnotherOrgApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		MigrateProjectToAnotherOrgWithParams(ctx, params).
                     		Execute()
                     }
@@ -59937,7 +59937,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -60020,7 +60020,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -60103,7 +60103,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -60189,7 +60189,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -60264,7 +60264,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -60346,7 +60346,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		RenameOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -60426,7 +60426,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -60505,7 +60505,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -60591,7 +60591,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -60672,7 +60672,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -60762,7 +60762,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -60851,7 +60851,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeyAccessListsEntriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeyAccessListsEntriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -60945,7 +60945,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -61043,7 +61043,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyAccessListEntryApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyAccessListEntryWithParams(ctx, params).
                     		Execute()
                     }
@@ -61134,7 +61134,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -61212,7 +61212,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -61304,7 +61304,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcess_1WithParams(ctx, params).
                     		Execute()
                     }
@@ -61409,7 +61409,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListOrganizationEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61499,7 +61499,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetOrganizationEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -61573,7 +61573,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetFederationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61663,7 +61663,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61745,7 +61745,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -61825,7 +61825,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61909,7 +61909,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61993,7 +61993,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationInvitationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -62074,7 +62074,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -62163,7 +62163,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -62301,7 +62301,7 @@ paths:
                     	}
 
                     	params = &sdk.ListInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -62388,7 +62388,7 @@ paths:
                     	}
 
                     	params = &sdk.GetInvoiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		GetInvoiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -62476,7 +62476,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadInvoiceCSVApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		DownloadInvoiceCSVWithParams(ctx, params).
                     		Execute()
                     }
@@ -62548,7 +62548,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPendingInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListPendingInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -62622,7 +62622,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSourceProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ListSourceProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62693,7 +62693,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLinkTokenApiParams{}
-                    	httpResp, err := sdk.CloudMigrationServiceApi.
+                    	httpResp, err := client.CloudMigrationServiceApi.
                     		DeleteLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -62771,7 +62771,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLinkTokenApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreateLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -62849,7 +62849,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62927,7 +62927,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -63007,7 +63007,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -63084,7 +63084,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -63170,7 +63170,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -63254,7 +63254,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63339,7 +63339,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountSecretApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -63425,7 +63425,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountSecretApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -63499,7 +63499,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63579,7 +63579,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63663,7 +63663,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListOrganizationTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63748,7 +63748,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		CreateTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -63838,7 +63838,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		DeleteTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -63923,7 +63923,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -64017,7 +64017,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		RenameTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -64111,7 +64111,7 @@ paths:
                     	}
 
                     	params = &sdk.ListTeamUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListTeamUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -64207,7 +64207,7 @@ paths:
                     	}
 
                     	params = &sdk.AddTeamUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64304,7 +64304,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveTeamUserApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64387,7 +64387,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -64464,7 +64464,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -64548,7 +64548,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveOrganizationUserApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		RemoveOrganizationUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64638,7 +64638,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -64706,7 +64706,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		ReturnAllControlPlaneIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -64789,7 +64789,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		CreateUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64873,7 +64873,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -64951,7 +64951,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserByUsernameApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserByUsernameWithParams(ctx, params).
                     		Execute()
                     }

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.json
@@ -256,7 +256,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSystemStatusApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tGetSystemStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -323,7 +323,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -396,7 +396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersForAllProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersForAllProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -469,7 +469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListEventTypesApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListEventTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -533,7 +533,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederationAppApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteFederationAppWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -609,7 +609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListConnectedOrgConfigsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListConnectedOrgConfigsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -692,7 +692,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveConnectedOrgConfigApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRemoveConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -773,7 +773,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -865,7 +865,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateConnectedOrgConfigApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateConnectedOrgConfigWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -938,7 +938,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListRoleMappingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListRoleMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1020,7 +1020,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1103,7 +1103,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteRoleMappingApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1187,7 +1187,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1282,7 +1282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateRoleMappingApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateRoleMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1390,7 +1390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIdentityProvidersApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tListIdentityProvidersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1472,7 +1472,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tCreateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1549,7 +1549,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tDeleteIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1630,7 +1630,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1719,7 +1719,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateIdentityProviderApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tUpdateIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1796,7 +1796,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := sdk.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RevokeJwksFromIdentityProviderApiParams{}\n\thttpResp, err := client.FederatedAuthenticationApi.\n\t\tRevokeJwksFromIdentityProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1866,7 +1866,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIdentityProviderMetadataApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetIdentityProviderMetadataWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -1942,7 +1942,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2038,7 +2038,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2122,7 +2122,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectByNameApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2192,7 +2192,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2260,7 +2260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2345,7 +2345,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2431,7 +2431,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddUserToProjectApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tAddUserToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2511,7 +2511,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectIpAccessListsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tListProjectIpAccessListsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2609,7 +2609,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectIpAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tCreateProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2694,7 +2694,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := sdk.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectIpAccessListApiParams{}\n\thttpResp, err := client.ProjectIPAccessListApi.\n\t\tDeleteProjectIpAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2780,7 +2780,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpListApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2867,7 +2867,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectIpAccessListStatusApiParams{}\n\tsdkResp, httpResp, err := client.ProjectIPAccessListApi.\n\t\tGetProjectIpAccessListStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -2943,7 +2943,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3022,7 +3022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tCreateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3102,7 +3102,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := sdk.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAlertConfigurationApiParams{}\n\thttpResp, err := client.AlertConfigurationsApi.\n\t\tDeleteAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3183,7 +3183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tGetAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3275,7 +3275,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tToggleAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3370,7 +3370,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAlertConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tUpdateAlertConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3462,7 +3462,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsByAlertConfigurationIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsByAlertConfigurationIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3554,7 +3554,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertsApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tListAlertsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3636,7 +3636,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tGetAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3730,7 +3730,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AcknowledgeAlertApiParams{}\n\tsdkResp, httpResp, err := client.AlertsApi.\n\t\tAcknowledgeAlertWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3821,7 +3821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := sdk.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAlertConfigurationsByAlertIdApiParams{}\n\tsdkResp, httpResp, err := client.AlertConfigurationsApi.\n\t\tListAlertConfigurationsByAlertIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3901,7 +3901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListProjectApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -3977,7 +3977,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4063,7 +4063,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tRemoveProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4163,7 +4163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4254,7 +4254,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tAddProjectApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4321,7 +4321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tGetAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4400,7 +4400,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAuditingConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.AuditingApi.\n\t\tUpdateAuditingConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4467,7 +4467,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tGetAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4543,7 +4543,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := sdk.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleAWSCustomDNSApiParams{}\n\tsdkResp, httpResp, err := client.AWSClustersDNSApi.\n\t\tToggleAWSCustomDNSWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4619,7 +4619,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListExportBucketsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListExportBucketsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4756,7 +4756,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4839,7 +4839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteExportBucketApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -4951,7 +4951,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetExportBucketApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetExportBucketWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5021,7 +5021,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5113,7 +5113,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDataProtectionSettingsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateDataProtectionSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5180,7 +5180,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderAccessRolesApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tListCloudProviderAccessRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5260,7 +5260,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tCreateCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5351,7 +5351,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := sdk.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}\n\thttpResp, err := client.CloudProviderAccessApi.\n\t\tDeauthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5430,7 +5430,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tGetCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5528,7 +5528,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}\n\tsdkResp, httpResp, err := client.CloudProviderAccessApi.\n\t\tAuthorizeCloudProviderAccessRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5613,7 +5613,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListClustersApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListClustersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5708,7 +5708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tCreateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5803,7 +5803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCloudProviderRegionsApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tListCloudProviderRegionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5893,7 +5893,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -5983,7 +5983,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpgradeSharedClusterToServerlessApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpgradeSharedClusterToServerlessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6076,7 +6076,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := sdk.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteClusterApiParams{}\n\thttpResp, err := client.ClustersApi.\n\t\tDeleteClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6159,7 +6159,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6257,7 +6257,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6345,7 +6345,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupExportJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupExportJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6439,7 +6439,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6524,7 +6524,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupExportJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupExportJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6612,7 +6612,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6709,7 +6709,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6803,7 +6803,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CancelBackupRestoreJobApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tCancelBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6892,7 +6892,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -6971,7 +6971,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllBackupSchedulesApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteAllBackupSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7048,7 +7048,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7139,7 +7139,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateBackupScheduleApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateBackupScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7230,7 +7230,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListReplicaSetBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListReplicaSetBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7321,7 +7321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TakeSnapshotApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tTakeSnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7412,7 +7412,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteShardedClusterBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7504,7 +7504,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetShardedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetShardedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7586,7 +7586,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListShardedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListShardedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7680,7 +7680,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := sdk.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteReplicaSetBackupApiParams{}\n\thttpResp, err := client.CloudBackupsApi.\n\t\tDeleteReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7772,7 +7772,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetReplicaSetBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetReplicaSetBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7875,7 +7875,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateSnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tUpdateSnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -7977,7 +7977,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tDownloadSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8076,7 +8076,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tCreateSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8158,7 +8158,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tListSharedClusterBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8252,7 +8252,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.\n\t\tGetSharedClusterBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8334,7 +8334,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSharedClusterBackupsApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tListSharedClusterBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8428,7 +8428,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSharedClusterBackupApiParams{}\n\tsdkResp, httpResp, err := client.Shared - TierSnapshotsApi.\n\t\tGetSharedClusterBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8517,7 +8517,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupCheckpointsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupCheckpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8615,7 +8615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupCheckpointApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupCheckpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8697,7 +8697,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPinnedNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetPinnedNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8799,7 +8799,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPatchApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPatchWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8901,7 +8901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinNamespacesPutApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tPinNamespacesPutWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -8994,7 +8994,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tUnpinNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9095,7 +9095,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9201,7 +9201,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9301,7 +9301,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9396,7 +9396,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9508,7 +9508,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9592,7 +9592,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tGetManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9675,7 +9675,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAllCustomZoneMappingsApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteAllCustomZoneMappingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9771,7 +9771,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomZoneMappingApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateCustomZoneMappingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9873,7 +9873,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := sdk.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteManagedNamespaceApiParams{}\n\thttpResp, err := client.GlobalClustersApi.\n\t\tDeleteManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -9972,7 +9972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := sdk.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateManagedNamespaceApiParams{}\n\tsdkResp, httpResp, err := client.GlobalClustersApi.\n\t\tCreateManagedNamespaceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10157,7 +10157,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateRollingIndexApiParams{}\n\tsdkResp, httpResp, err := client.RollingIndexApi.\n\t\tCreateRollingIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10249,7 +10249,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOnlineArchivesApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tListOnlineArchivesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10350,7 +10350,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tCreateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10469,7 +10469,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tDownloadOnlineArchiveQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10567,7 +10567,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := sdk.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOnlineArchiveApiParams{}\n\thttpResp, err := client.OnlineArchiveApi.\n\t\tDeleteOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10666,7 +10666,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tGetOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10779,7 +10779,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := sdk.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOnlineArchiveApiParams{}\n\tsdkResp, httpResp, err := client.OnlineArchiveApi.\n\t\tUpdateOnlineArchiveWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10868,7 +10868,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EndOutageSimulationApiParams{}\n\thttpResp, err := client.ClusterOutageSimulationApi.\n\t\tEndOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -10955,7 +10955,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tGetOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11050,7 +11050,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartOutageSimulationApiParams{}\n\tsdkResp, httpResp, err := client.ClusterOutageSimulationApi.\n\t\tStartOutageSimulationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11136,7 +11136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11235,7 +11235,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateClusterAdvancedConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUpdateClusterAdvancedConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11311,7 +11311,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TestFailoverApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tTestFailoverWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11414,7 +11414,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacyBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacyBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11506,7 +11506,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tCreateLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11601,7 +11601,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacyBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacyBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11686,7 +11686,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchDeploymentApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11766,7 +11766,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11860,7 +11860,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -11954,7 +11954,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchDeploymentApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchDeploymentWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12053,7 +12053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesClusterApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12151,7 +12151,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tCreateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12268,7 +12268,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasSearchIndexesApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tListAtlasSearchIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12381,7 +12381,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexByNameApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12492,7 +12492,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12617,7 +12617,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexByNameApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12715,7 +12715,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := sdk.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteAtlasSearchIndexApiParams{}\n\thttpResp, err := client.AtlasSearchApi.\n\t\tDeleteAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12821,7 +12821,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tGetAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -12931,7 +12931,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := sdk.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateAtlasSearchIndexApiParams{}\n\tsdkResp, httpResp, err := client.AtlasSearchApi.\n\t\tUpdateAtlasSearchIndexWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13011,7 +13011,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13100,7 +13100,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotScheduleApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotScheduleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13203,7 +13203,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListLegacySnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tListLegacySnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13298,7 +13298,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := sdk.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLegacySnapshotApiParams{}\n\thttpResp, err := client.LegacyBackupApi.\n\t\tDeleteLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13388,7 +13388,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLegacySnapshotApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tGetLegacySnapshotWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13489,7 +13489,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := sdk.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateLegacySnapshotRetentionApiParams{}\n\tsdkResp, httpResp, err := client.LegacyBackupApi.\n\t\tUpdateLegacySnapshotRetentionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13568,7 +13568,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetClusterStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetClusterStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13667,7 +13667,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13819,7 +13819,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -13918,7 +13918,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tPinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14009,7 +14009,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UnpinFeatureCompatibilityVersionApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tUnpinFeatureCompatibilityVersionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14136,7 +14136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostLogsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14206,7 +14206,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14300,7 +14300,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainerByCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainerByCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14388,7 +14388,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14464,7 +14464,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringContainersApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringContainersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14553,7 +14553,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringContainerApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14631,7 +14631,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14732,7 +14732,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringContainerApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringContainerWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14802,7 +14802,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListCustomDatabaseRolesApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tListCustomDatabaseRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14890,7 +14890,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tCreateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -14972,7 +14972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteCustomDatabaseRoleApiParams{}\n\thttpResp, err := client.CustomDatabaseRolesApi.\n\t\tDeleteCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15049,7 +15049,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tGetCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15146,7 +15146,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateCustomDatabaseRoleApiParams{}\n\tsdkResp, httpResp, err := client.CustomDatabaseRolesApi.\n\t\tUpdateCustomDatabaseRoleWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15229,7 +15229,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListFederatedDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListFederatedDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15314,7 +15314,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15390,7 +15390,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteFederatedDatabaseApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15467,7 +15467,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15564,7 +15564,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateFederatedDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tUpdateFederatedDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15646,7 +15646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15734,7 +15734,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15823,7 +15823,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tReturnFederatedDatabaseQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -15926,7 +15926,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOneDataFederationQueryLimitApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateOneDataFederationQueryLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16032,7 +16032,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tDownloadFederatedDatabaseQueryLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16108,7 +16108,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUsersApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tListDatabaseUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16348,7 +16348,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tCreateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16440,7 +16440,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := sdk.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDatabaseUserApiParams{}\n\thttpResp, err := client.DatabaseUsersApi.\n\t\tDeleteDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16527,7 +16527,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tGetDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16634,7 +16634,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := sdk.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateDatabaseUserApiParams{}\n\tsdkResp, httpResp, err := client.DatabaseUsersApi.\n\t\tUpdateDatabaseUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16722,7 +16722,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabaseUserCertificatesApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tListDatabaseUserCertificatesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16824,7 +16824,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := sdk.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDatabaseUserCertificateApiParams{}\n\tsdkResp, httpResp, err := client.X509AuthenticationApi.\n\t\tCreateDatabaseUserCertificateWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -16957,7 +16957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByClusterNameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByClusterNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17087,7 +17087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := sdk.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAccessLogsByHostnameApiParams{}\n\tsdkResp, httpResp, err := client.AccessTrackingApi.\n\t\tListAccessLogsByHostnameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17154,7 +17154,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17239,7 +17239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateEncryptionAtRestApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tUpdateEncryptionAtRestWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17318,7 +17318,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17406,7 +17406,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tCreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17508,7 +17508,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}\n\thttpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tRequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17597,7 +17597,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.\n\t\tGetEncryptionAtRestPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17740,7 +17740,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListProjectEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17831,7 +17831,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetProjectEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -17901,7 +17901,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListMetricTypesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListMetricTypesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18017,7 +18017,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18136,7 +18136,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetIndexMetricsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetIndexMetricsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18247,7 +18247,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18329,7 +18329,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListThirdPartyIntegrationsApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tListThirdPartyIntegrationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18424,7 +18424,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteThirdPartyIntegrationApiParams{}\n\thttpResp, err := client.Third - PartyIntegrationsApi.\n\t\tDeleteThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18517,7 +18517,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tGetThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18633,7 +18633,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tCreateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18746,7 +18746,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateThirdPartyIntegrationApiParams{}\n\tsdkResp, httpResp, err := client.Third - PartyIntegrationsApi.\n\t\tUpdateThirdPartyIntegrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18826,7 +18826,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18910,7 +18910,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -18988,7 +18988,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tCreateProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19066,7 +19066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectInvitationApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19148,7 +19148,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectInvitationApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19241,7 +19241,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19312,7 +19312,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tReturnAllIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19391,7 +19391,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectLimitsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectLimitsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19488,7 +19488,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectLimitApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tDeleteProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19586,7 +19586,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19695,7 +19695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetProjectLimitApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tSetProjectLimitWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19783,7 +19783,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreatePushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19871,7 +19871,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ValidateMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tValidateMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -19957,7 +19957,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetValidationStatusApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetValidationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20033,7 +20033,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tGetPushMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20109,7 +20109,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CutoverMigrationApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCutoverMigrationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20173,7 +20173,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := sdk.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResetMaintenanceWindowApiParams{}\n\thttpResp, err := client.MaintenanceWindowsApi.\n\t\tResetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20238,7 +20238,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tGetMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20314,7 +20314,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tUpdateMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20378,7 +20378,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleMaintenanceAutoDeferApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tToggleMaintenanceAutoDeferWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20442,7 +20442,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := sdk.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeferMaintenanceWindowApiParams{}\n\tsdkResp, httpResp, err := client.MaintenanceWindowsApi.\n\t\tDeferMaintenanceWindowWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20509,7 +20509,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetManagedSlowMsApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetManagedSlowMsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20576,7 +20576,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := sdk.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableSlowOperationThresholdingApiParams{}\n\thttpResp, err := client.PerformanceAdvisorApi.\n\t\tDisableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20643,7 +20643,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.EnableSlowOperationThresholdingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tEnableSlowOperationThresholdingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20771,7 +20771,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectLTSVersionsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectLTSVersionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20864,7 +20864,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPeeringConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tListPeeringConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -20953,7 +20953,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tCreatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21035,7 +21035,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := sdk.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePeeringConnectionApiParams{}\n\thttpResp, err := client.NetworkPeeringApi.\n\t\tDeletePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21115,7 +21115,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tGetPeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21212,7 +21212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePeeringConnectionApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tUpdatePeeringConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21282,7 +21282,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelinesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelinesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21361,7 +21361,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tCreatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21440,7 +21440,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21520,7 +21520,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21614,7 +21614,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tUpdatePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21699,7 +21699,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSchedulesApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSchedulesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21800,7 +21800,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineSnapshotsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineSnapshotsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21882,7 +21882,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.PausePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tPausePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -21964,7 +21964,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ResumePipelineApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tResumePipelineWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22065,7 +22065,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPipelineRunsApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tListPipelineRunsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22160,7 +22160,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := sdk.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePipelineRunDatasetApiParams{}\n\thttpResp, err := client.DataLakePipelinesApi.\n\t\tDeletePipelineRunDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22253,7 +22253,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPipelineRunApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tGetPipelineRunWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22346,7 +22346,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := sdk.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.TriggerSnapshotIngestionApiParams{}\n\tsdkResp, httpResp, err := client.DataLakePipelinesApi.\n\t\tTriggerSnapshotIngestionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22428,7 +22428,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22498,7 +22498,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22577,7 +22577,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22658,7 +22658,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tListServerlessPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22749,7 +22749,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tCreateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22839,7 +22839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessPrivateEndpointApiParams{}\n\thttpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tDeleteServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -22927,7 +22927,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tGetServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23026,7 +23026,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.\n\t\tUpdateServerlessPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23111,7 +23111,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPrivateEndpointServicesApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tListPrivateEndpointServicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23205,7 +23205,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointServiceApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23300,7 +23300,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointServiceApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointServiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23414,7 +23414,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tCreatePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23518,7 +23518,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePrivateEndpointApiParams{}\n\thttpResp, err := client.PrivateEndpointServicesApi.\n\t\tDeletePrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23623,7 +23623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.PrivateEndpointServicesApi.\n\t\tGetPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23695,7 +23695,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tVerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23779,7 +23779,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := sdk.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisablePeeringApiParams{}\n\tsdkResp, httpResp, err := client.NetworkPeeringApi.\n\t\tDisablePeeringWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23861,7 +23861,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDataFederationPrivateEndpointsApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tListDataFederationPrivateEndpointsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -23940,7 +23940,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tCreateDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24022,7 +24022,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := sdk.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteDataFederationPrivateEndpointApiParams{}\n\thttpResp, err := client.DataFederationApi.\n\t\tDeleteDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24105,7 +24105,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := sdk.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDataFederationPrivateEndpointApiParams{}\n\tsdkResp, httpResp, err := client.DataFederationApi.\n\t\tGetDataFederationPrivateEndpointWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24181,7 +24181,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListAtlasProcessesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListAtlasProcessesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24259,7 +24259,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetAtlasProcessApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetAtlasProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24335,7 +24335,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespacesForHostWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24422,7 +24422,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDatabasesApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDatabasesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24509,7 +24509,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24635,7 +24635,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDatabaseMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDatabaseMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24722,7 +24722,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskPartitionsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskPartitionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24806,7 +24806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tListDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -24941,7 +24941,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetDiskMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetDiskMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25183,7 +25183,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.MonitoringandLogsApi.\n\t\tGetHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25279,7 +25279,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueryNamespacesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueryNamespacesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25399,7 +25399,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSlowQueriesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSlowQueriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25535,7 +25535,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSuggestedIndexesApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tListSuggestedIndexesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25662,7 +25662,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}\n\tsdkResp, httpResp, err := client.CollectionLevelMetricsApi.\n\t\tGetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25735,7 +25735,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := sdk.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeletePushBasedLogConfigurationApiParams{}\n\thttpResp, err := client.Push - BasedLogExportApi.\n\t\tDeletePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25806,7 +25806,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetPushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tGetPushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25889,7 +25889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tUpdatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -25972,7 +25972,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreatePushBasedLogConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.Push - BasedLogExportApi.\n\t\tCreatePushBasedLogConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26054,7 +26054,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.LoadSampleDatasetApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tLoadSampleDatasetWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26130,7 +26130,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetSampleDatasetLoadStatusApiParams{}\n\tsdkResp, httpResp, err := client.ClustersApi.\n\t\tGetSampleDatasetLoadStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26206,7 +26206,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessInstancesApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tListServerlessInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26288,7 +26288,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tCreateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26379,7 +26379,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupRestoreJobsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupRestoreJobsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26476,7 +26476,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tCreateServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26570,7 +26570,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupRestoreJobApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupRestoreJobWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26661,7 +26661,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServerlessBackupsApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tListServerlessBackupsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26753,7 +26753,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessBackupApiParams{}\n\tsdkResp, httpResp, err := client.CloudBackupsApi.\n\t\tGetServerlessBackupWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26832,7 +26832,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tGetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -26915,7 +26915,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := sdk.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SetServerlessAutoIndexingApiParams{}\n\tsdkResp, httpResp, err := client.PerformanceAdvisorApi.\n\t\tSetServerlessAutoIndexingWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27000,7 +27000,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := sdk.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServerlessInstanceApiParams{}\n\thttpResp, err := client.ServerlessInstancesApi.\n\t\tDeleteServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27083,7 +27083,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tGetServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27174,7 +27174,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServerlessInstanceApiParams{}\n\tsdkResp, httpResp, err := client.ServerlessInstancesApi.\n\t\tUpdateServerlessInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27250,7 +27250,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tListProjectServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27330,7 +27330,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tCreateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27410,7 +27410,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := sdk.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteProjectServiceAccountApiParams{}\n\thttpResp, err := client.GroupsApi.\n\t\tDeleteProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27487,7 +27487,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tGetProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27578,7 +27578,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tUpdateProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27671,7 +27671,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddProjectServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.GroupsApi.\n\t\tAddProjectServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27744,7 +27744,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tGetProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27826,7 +27826,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectSettingsApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27899,7 +27899,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamInstancesApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -27978,7 +27978,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28060,7 +28060,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamInstanceApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28145,7 +28145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28239,7 +28239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamInstanceApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28348,7 +28348,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadStreamTenantAuditLogsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tDownloadStreamTenantAuditLogsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28433,7 +28433,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamConnectionsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamConnectionsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28524,7 +28524,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28615,7 +28615,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamConnectionApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28698,7 +28698,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28801,7 +28801,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateStreamConnectionApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tUpdateStreamConnectionWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28894,7 +28894,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tCreateStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -28982,7 +28982,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := sdk.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteStreamProcessorApiParams{}\n\thttpResp, err := client.StreamsApi.\n\t\tDeleteStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29071,7 +29071,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tGetStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29162,7 +29162,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StartStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStartStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29253,7 +29253,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.StopStreamProcessorApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tStopStreamProcessorWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29344,7 +29344,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := sdk.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListStreamProcessorsApiParams{}\n\tsdkResp, httpResp, err := client.StreamsApi.\n\t\tListStreamProcessorsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29429,7 +29429,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListProjectTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29521,7 +29521,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddAllTeamsToProjectApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddAllTeamsToProjectWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29607,7 +29607,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveProjectTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29708,7 +29708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateTeamRolesApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tUpdateTeamRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29775,7 +29775,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29854,7 +29854,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.SaveLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tSaveLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29918,7 +29918,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := sdk.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DisableCustomerManagedX509ApiParams{}\n\thttpResp, err := client.X509AuthenticationApi.\n\t\tDisableCustomerManagedX509WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -29985,7 +29985,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := sdk.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLDAPConfigurationApiParams{}\n\thttpResp, err := client.LDAPConfigurationApi.\n\t\tDeleteLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30066,7 +30066,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.VerifyLDAPConfigurationApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tVerifyLDAPConfigurationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30145,7 +30145,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := sdk.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetLDAPConfigurationStatusApiParams{}\n\tsdkResp, httpResp, err := client.LDAPConfigurationApi.\n\t\tGetLDAPConfigurationStatusWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30239,7 +30239,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListProjectUsersApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tListProjectUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30321,7 +30321,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := sdk.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveProjectUserApiParams{}\n\thttpResp, err := client.ProjectsApi.\n\t\tRemoveProjectUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30417,7 +30417,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateProjectRolesApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tUpdateProjectRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30493,7 +30493,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListUSSInstancesApiParams{}\n\tsdkResp, httpResp, err := sdk.USSInstancesApi.\n\t\tListUSSInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListUSSInstancesApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tListUSSInstancesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30575,7 +30575,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.USSInstancesApi.\n\t\tCreateUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tCreateUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30660,7 +30660,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteUSSInstanceApiParams{}\n\thttpResp, err := sdk.USSInstancesApi.\n\t\tDeleteUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteUSSInstanceApiParams{}\n\thttpResp, err := client.USSInstancesApi.\n\t\tDeleteUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30746,7 +30746,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.USSInstancesApi.\n\t\tGetUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tGetUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30837,7 +30837,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := sdk.USSInstancesApi.\n\t\tUpdateUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateUSSInstanceApiParams{}\n\tsdkResp, httpResp, err := client.USSInstancesApi.\n\t\tUpdateUSSInstanceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -30912,7 +30912,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := sdk.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.MigrateProjectToAnotherOrgApiParams{}\n\tsdkResp, httpResp, err := client.ProjectsApi.\n\t\tMigrateProjectToAnotherOrgWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31002,7 +31002,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31087,7 +31087,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31163,7 +31163,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31237,7 +31237,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31322,7 +31322,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameOrganizationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tRenameOrganizationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31402,7 +31402,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeysApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeysWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31482,7 +31482,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31565,7 +31565,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31646,7 +31646,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31741,7 +31741,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateApiKeyApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tUpdateApiKeyWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31833,7 +31833,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListApiKeyAccessListsEntriesApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tListApiKeyAccessListsEntriesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -31939,7 +31939,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tCreateApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32039,7 +32039,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteApiKeyAccessListEntryApiParams{}\n\thttpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tDeleteApiKeyAccessListEntryWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32134,7 +32134,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetApiKeyAccessListApiParams{}\n\tsdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.\n\t\tGetApiKeyAccessListWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32212,7 +32212,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcessApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcessWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32303,7 +32303,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tCreateCostExplorerQueryProcess_1WithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32418,7 +32418,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationEventsApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tListOrganizationEventsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32509,7 +32509,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := sdk.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationEventApiParams{}\n\tsdkResp, httpResp, err := client.EventsApi.\n\t\tGetOrganizationEventWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32582,7 +32582,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetFederationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.FederatedAuthenticationApi.\n\t\tGetFederationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32672,7 +32672,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32757,7 +32757,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationInvitationsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationInvitationsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32839,7 +32839,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -32921,7 +32921,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33003,7 +33003,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteOrganizationInvitationApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33083,7 +33083,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationInvitationApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationInvitationWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33177,7 +33177,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationInvitationByIdApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationInvitationByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33335,7 +33335,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33405,7 +33405,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListPendingInvoicesApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tListPendingInvoicesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33493,7 +33493,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tGetInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33574,7 +33574,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DownloadInvoiceCSVApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tDownloadInvoiceCSVWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33670,7 +33670,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.QueryLineItemsFromSingleInvoiceApiParams{}\n\tsdkResp, httpResp, err := sdk.InvoicesApi.\n\t\tQueryLineItemsFromSingleInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.QueryLineItemsFromSingleInvoiceApiParams{}\n\tsdkResp, httpResp, err := client.InvoicesApi.\n\t\tQueryLineItemsFromSingleInvoiceWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33743,7 +33743,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListSourceProjectsApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tListSourceProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33810,7 +33810,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := sdk.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteLinkTokenApiParams{}\n\thttpResp, err := client.CloudMigrationServiceApi.\n\t\tDeleteLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33889,7 +33889,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := sdk.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateLinkTokenApiParams{}\n\tsdkResp, httpResp, err := client.CloudMigrationServiceApi.\n\t\tCreateLinkTokenWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -33965,7 +33965,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34044,7 +34044,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34120,7 +34120,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34197,7 +34197,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34288,7 +34288,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateServiceAccountApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateServiceAccountWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34373,7 +34373,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListServiceAccountProjectsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListServiceAccountProjectsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34463,7 +34463,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateServiceAccountSecretApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tCreateServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34548,7 +34548,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteServiceAccountSecretApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tDeleteServiceAccountSecretWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34621,7 +34621,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tGetOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34703,7 +34703,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationSettingsApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationSettingsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34789,7 +34789,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationTeamsApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListOrganizationTeamsWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34878,7 +34878,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tCreateTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -34964,7 +34964,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByNameApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByNameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35053,7 +35053,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.DeleteTeamApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tDeleteTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35140,7 +35140,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetTeamByIdApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tGetTeamByIdWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35241,7 +35241,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RenameTeamApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tRenameTeamWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35339,7 +35339,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListTeamUsersApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tListTeamUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35443,7 +35443,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := sdk.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.AddTeamUserApiParams{}\n\tsdkResp, httpResp, err := client.TeamsApi.\n\t\tAddTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35541,7 +35541,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := sdk.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveTeamUserApiParams{}\n\thttpResp, err := client.TeamsApi.\n\t\tRemoveTeamUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35623,7 +35623,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ListOrganizationUsersApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tListOrganizationUsersWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35708,7 +35708,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := sdk.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.RemoveOrganizationUserApiParams{}\n\thttpResp, err := client.OrganizationsApi.\n\t\tRemoveOrganizationUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35804,7 +35804,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := sdk.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.UpdateOrganizationRolesApiParams{}\n\tsdkResp, httpResp, err := client.OrganizationsApi.\n\t\tUpdateOrganizationRolesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35857,7 +35857,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := sdk.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}\n\tsdkResp, httpResp, err := client.RootApi.\n\t\tReturnAllControlPlaneIPAddressesWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -35935,7 +35935,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.CreateUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tCreateUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -36012,7 +36012,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserByUsernameApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserByUsernameWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",
@@ -36091,7 +36091,7 @@
           {
             "lang": "go",
             "label": "Go",
-            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
+            "source": "import (\n\t\"os\"\n\t\"context\"\n\t\"log\"\n\tsdk \"go.mongodb.org/atlas-sdk/v20250101001/admin\"\n)\n\nfunc main() {\n\tctx := context.Background()\n\tclientID := os.Getenv(\"MONGODB_ATLAS_CLIENT_ID\")\n\tclientSecret := os.Getenv(\"MONGODB_ATLAS_CLIENT_SECRET\")\n\n\tclient, err := sdk.NewClient(\n\t\tsdk.UseOAuthAuth(clientID, clientSecret),\n\t\tsdk.UseBaseURL(url))\n\n\tif err != nil {\n\t\tlog.Fatalf(\"Error: %v\", err)\n\t}\n\n\tparams = &sdk.GetUserApiParams{}\n\tsdkResp, httpResp, err := client.MongoDBCloudUsersApi.\n\t\tGetUserWithParams(ctx, params).\n\t\tExecute()\n}"
           },
           {
             "lang": "cURL",

--- a/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
+++ b/tools/cli/test/data/split/dev/openapi-v2-2025-01-01.yaml
@@ -30583,7 +30583,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSystemStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		GetSystemStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -30654,7 +30654,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationMatchersFieldNamesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationMatchersFieldNamesWithParams(ctx, params).
                     		Execute()
                     }
@@ -30726,7 +30726,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersForAllProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersForAllProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -30798,7 +30798,7 @@ paths:
                     	}
 
                     	params = &sdk.ListEventTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListEventTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -30868,7 +30868,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederationAppApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteFederationAppWithParams(ctx, params).
                     		Execute()
                     }
@@ -30943,7 +30943,7 @@ paths:
                     	}
 
                     	params = &sdk.ListConnectedOrgConfigsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListConnectedOrgConfigsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31026,7 +31026,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveConnectedOrgConfigApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RemoveConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -31108,7 +31108,7 @@ paths:
                     	}
 
                     	params = &sdk.GetConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -31197,7 +31197,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateConnectedOrgConfigApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateConnectedOrgConfigWithParams(ctx, params).
                     		Execute()
                     }
@@ -31275,7 +31275,7 @@ paths:
                     	}
 
                     	params = &sdk.ListRoleMappingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListRoleMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -31355,7 +31355,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31441,7 +31441,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteRoleMappingApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31524,7 +31524,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31614,7 +31614,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateRoleMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateRoleMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -31715,7 +31715,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIdentityProvidersApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		ListIdentityProvidersWithParams(ctx, params).
                     		Execute()
                     }
@@ -31799,7 +31799,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		CreateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31881,7 +31881,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteIdentityProviderApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		DeleteIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -31962,7 +31962,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -32051,7 +32051,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateIdentityProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		UpdateIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -32133,7 +32133,7 @@ paths:
                     	}
 
                     	params = &sdk.RevokeJwksFromIdentityProviderApiParams{}
-                    	httpResp, err := sdk.FederatedAuthenticationApi.
+                    	httpResp, err := client.FederatedAuthenticationApi.
                     		RevokeJwksFromIdentityProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -32206,7 +32206,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIdentityProviderMetadataApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetIdentityProviderMetadataWithParams(ctx, params).
                     		Execute()
                     }
@@ -32280,7 +32280,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32371,7 +32371,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32447,7 +32447,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32518,7 +32518,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32600,7 +32600,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32686,7 +32686,7 @@ paths:
                     	}
 
                     	params = &sdk.AddUserToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		AddUserToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -32766,7 +32766,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectIpAccessListsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		ListProjectIpAccessListsWithParams(ctx, params).
                     		Execute()
                     }
@@ -32854,7 +32854,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectIpAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		CreateProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -32946,7 +32946,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectIpAccessListApiParams{}
-                    	httpResp, err := sdk.ProjectIPAccessListApi.
+                    	httpResp, err := client.ProjectIPAccessListApi.
                     		DeleteProjectIpAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -33030,7 +33030,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpListWithParams(ctx, params).
                     		Execute()
                     }
@@ -33114,7 +33114,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectIpAccessListStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectIPAccessListApi.
+                    	sdkResp, httpResp, err := client.ProjectIPAccessListApi.
                     		GetProjectIpAccessListStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -33190,7 +33190,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33271,7 +33271,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		CreateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33358,7 +33358,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAlertConfigurationApiParams{}
-                    	httpResp, err := sdk.AlertConfigurationsApi.
+                    	httpResp, err := client.AlertConfigurationsApi.
                     		DeleteAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33442,7 +33442,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		GetAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33535,7 +33535,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ToggleAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33634,7 +33634,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAlertConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		UpdateAlertConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -33726,7 +33726,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsByAlertConfigurationIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsByAlertConfigurationIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -33813,7 +33813,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertsApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		ListAlertsWithParams(ctx, params).
                     		Execute()
                     }
@@ -33897,7 +33897,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		GetAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -33989,7 +33989,7 @@ paths:
                     	}
 
                     	params = &sdk.AcknowledgeAlertApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertsApi.
+                    	sdkResp, httpResp, err := client.AlertsApi.
                     		AcknowledgeAlertWithParams(ctx, params).
                     		Execute()
                     }
@@ -34080,7 +34080,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAlertConfigurationsByAlertIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.AlertConfigurationsApi.
+                    	sdkResp, httpResp, err := client.AlertConfigurationsApi.
                     		ListAlertConfigurationsByAlertIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -34156,7 +34156,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListProjectApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -34232,7 +34232,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -34320,7 +34320,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		RemoveProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -34410,7 +34410,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -34501,7 +34501,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		AddProjectApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -34575,7 +34575,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		GetAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -34653,7 +34653,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAuditingConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.AuditingApi.
+                    	sdkResp, httpResp, err := client.AuditingApi.
                     		UpdateAuditingConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -34727,7 +34727,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		GetAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -34803,7 +34803,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleAWSCustomDNSApiParams{}
-                    	sdkResp, httpResp, err := sdk.AWSClustersDNSApi.
+                    	sdkResp, httpResp, err := client.AWSClustersDNSApi.
                     		ToggleAWSCustomDNSWithParams(ctx, params).
                     		Execute()
                     }
@@ -34880,7 +34880,7 @@ paths:
                     	}
 
                     	params = &sdk.ListExportBucketsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListExportBucketsWithParams(ctx, params).
                     		Execute()
                     }
@@ -34999,7 +34999,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -35086,7 +35086,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteExportBucketApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -35189,7 +35189,7 @@ paths:
                     	}
 
                     	params = &sdk.GetExportBucketApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetExportBucketWithParams(ctx, params).
                     		Execute()
                     }
@@ -35261,7 +35261,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35348,7 +35348,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDataProtectionSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateDataProtectionSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -35422,7 +35422,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderAccessRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		ListCloudProviderAccessRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -35501,7 +35501,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		CreateCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35592,7 +35592,7 @@ paths:
                     	}
 
                     	params = &sdk.DeauthorizeCloudProviderAccessRoleApiParams{}
-                    	httpResp, err := sdk.CloudProviderAccessApi.
+                    	httpResp, err := client.CloudProviderAccessApi.
                     		DeauthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35671,7 +35671,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		GetCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35763,7 +35763,7 @@ paths:
                     	}
 
                     	params = &sdk.AuthorizeCloudProviderAccessRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudProviderAccessApi.
+                    	sdkResp, httpResp, err := client.CloudProviderAccessApi.
                     		AuthorizeCloudProviderAccessRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -35846,7 +35846,7 @@ paths:
                     	}
 
                     	params = &sdk.ListClustersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListClustersWithParams(ctx, params).
                     		Execute()
                     }
@@ -36058,7 +36058,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		CreateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -36150,7 +36150,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteClusterApiParams{}
-                    	httpResp, err := sdk.ClustersApi.
+                    	httpResp, err := client.ClustersApi.
                     		DeleteClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -36232,7 +36232,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -36324,7 +36324,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -36461,7 +36461,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceClusterMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceClusterMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36552,7 +36552,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespacesForClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespacesForClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -36634,7 +36634,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupExportJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupExportJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36724,7 +36724,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36812,7 +36812,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupExportJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupExportJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -36894,7 +36894,7 @@ paths:
                     	}
 
                     	params = &sdk.ListBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -36988,7 +36988,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -37082,7 +37082,7 @@ paths:
                     	}
 
                     	params = &sdk.CancelBackupRestoreJobApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		CancelBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -37169,7 +37169,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -37249,7 +37249,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllBackupSchedulesApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteAllBackupSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -37327,7 +37327,7 @@ paths:
                     	}
 
                     	params = &sdk.GetBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -37417,7 +37417,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateBackupScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateBackupScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -37505,7 +37505,7 @@ paths:
                     	}
 
                     	params = &sdk.ListReplicaSetBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListReplicaSetBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -37595,7 +37595,7 @@ paths:
                     	}
 
                     	params = &sdk.TakeSnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		TakeSnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -37689,7 +37689,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteReplicaSetBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37778,7 +37778,7 @@ paths:
                     	}
 
                     	params = &sdk.GetReplicaSetBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetReplicaSetBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -37874,7 +37874,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateSnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		UpdateSnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -37966,7 +37966,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteShardedClusterBackupApiParams{}
-                    	httpResp, err := sdk.CloudBackupsApi.
+                    	httpResp, err := client.CloudBackupsApi.
                     		DeleteShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -38055,7 +38055,7 @@ paths:
                     	}
 
                     	params = &sdk.GetShardedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetShardedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -38136,7 +38136,7 @@ paths:
                     	}
 
                     	params = &sdk.ListShardedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListShardedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38230,7 +38230,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		DownloadSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -38326,7 +38326,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		CreateSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -38411,7 +38411,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		ListSharedClusterBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38501,7 +38501,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierRestoreJobsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierRestoreJobsApi.
                     		GetSharedClusterBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -38582,7 +38582,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSharedClusterBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		ListSharedClusterBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38672,7 +38672,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSharedClusterBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.Shared - TierSnapshotsApi.
+                    	sdkResp, httpResp, err := client.Shared - TierSnapshotsApi.
                     		GetSharedClusterBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -38755,7 +38755,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupCheckpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupCheckpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -38848,7 +38848,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupCheckpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupCheckpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -38930,7 +38930,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPinnedNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetPinnedNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -39025,7 +39025,7 @@ paths:
                     	}
 
                     	params = &sdk.PinNamespacesPatchApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		PinNamespacesPatchWithParams(ctx, params).
                     		Execute()
                     }
@@ -39124,7 +39124,7 @@ paths:
                     	}
 
                     	params = &sdk.PinNamespacesPutApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		PinNamespacesPutWithParams(ctx, params).
                     		Execute()
                     }
@@ -39217,7 +39217,7 @@ paths:
                     	}
 
                     	params = &sdk.UnpinNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		UnpinNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -39315,7 +39315,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39417,7 +39417,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39512,7 +39512,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexDeprecatedApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39604,7 +39604,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39707,7 +39707,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexDeprecatedApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexDeprecatedWithParams(ctx, params).
                     		Execute()
                     }
@@ -39794,7 +39794,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		GetManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -39876,7 +39876,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAllCustomZoneMappingsApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteAllCustomZoneMappingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -39967,7 +39967,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomZoneMappingApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateCustomZoneMappingWithParams(ctx, params).
                     		Execute()
                     }
@@ -40065,7 +40065,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteManagedNamespaceApiParams{}
-                    	httpResp, err := sdk.GlobalClustersApi.
+                    	httpResp, err := client.GlobalClustersApi.
                     		DeleteManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -40158,7 +40158,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateManagedNamespaceApiParams{}
-                    	sdkResp, httpResp, err := sdk.GlobalClustersApi.
+                    	sdkResp, httpResp, err := client.GlobalClustersApi.
                     		CreateManagedNamespaceWithParams(ctx, params).
                     		Execute()
                     }
@@ -40316,7 +40316,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateRollingIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.RollingIndexApi.
+                    	sdkResp, httpResp, err := client.RollingIndexApi.
                     		CreateRollingIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -40405,7 +40405,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOnlineArchivesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		ListOnlineArchivesWithParams(ctx, params).
                     		Execute()
                     }
@@ -40499,7 +40499,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		CreateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40596,7 +40596,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOnlineArchiveApiParams{}
-                    	httpResp, err := sdk.OnlineArchiveApi.
+                    	httpResp, err := client.OnlineArchiveApi.
                     		DeleteOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40690,7 +40690,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		GetOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40793,7 +40793,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOnlineArchiveApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		UpdateOnlineArchiveWithParams(ctx, params).
                     		Execute()
                     }
@@ -40906,7 +40906,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadOnlineArchiveQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OnlineArchiveApi.
+                    	sdkResp, httpResp, err := client.OnlineArchiveApi.
                     		DownloadOnlineArchiveQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -40992,7 +40992,7 @@ paths:
                     	}
 
                     	params = &sdk.EndOutageSimulationApiParams{}
-                    	httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	httpResp, err := client.ClusterOutageSimulationApi.
                     		EndOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -41077,7 +41077,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		GetOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -41167,7 +41167,7 @@ paths:
                     	}
 
                     	params = &sdk.StartOutageSimulationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClusterOutageSimulationApi.
+                    	sdkResp, httpResp, err := client.ClusterOutageSimulationApi.
                     		StartOutageSimulationWithParams(ctx, params).
                     		Execute()
                     }
@@ -41255,7 +41255,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -41348,7 +41348,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateClusterAdvancedConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpdateClusterAdvancedConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -41429,7 +41429,7 @@ paths:
                     	}
 
                     	params = &sdk.TestFailoverApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		TestFailoverWithParams(ctx, params).
                     		Execute()
                     }
@@ -41529,7 +41529,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacyBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacyBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -41617,7 +41617,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		CreateLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -41715,7 +41715,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacyBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacyBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -41798,7 +41798,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchDeploymentApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41878,7 +41878,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -41967,7 +41967,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -42060,7 +42060,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchDeploymentApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchDeploymentWithParams(ctx, params).
                     		Execute()
                     }
@@ -42156,7 +42156,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -42248,7 +42248,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		CreateAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42356,7 +42356,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasSearchIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		ListAtlasSearchIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -42458,7 +42458,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexByNameApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42559,7 +42559,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42669,7 +42669,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -42766,7 +42766,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteAtlasSearchIndexApiParams{}
-                    	httpResp, err := sdk.AtlasSearchApi.
+                    	httpResp, err := client.AtlasSearchApi.
                     		DeleteAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42864,7 +42864,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		GetAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -42965,7 +42965,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateAtlasSearchIndexApiParams{}
-                    	sdkResp, httpResp, err := sdk.AtlasSearchApi.
+                    	sdkResp, httpResp, err := client.AtlasSearchApi.
                     		UpdateAtlasSearchIndexWithParams(ctx, params).
                     		Execute()
                     }
@@ -43052,7 +43052,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -43141,7 +43141,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotScheduleApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotScheduleWithParams(ctx, params).
                     		Execute()
                     }
@@ -43238,7 +43238,7 @@ paths:
                     	}
 
                     	params = &sdk.ListLegacySnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		ListLegacySnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43329,7 +43329,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLegacySnapshotApiParams{}
-                    	httpResp, err := sdk.LegacyBackupApi.
+                    	httpResp, err := client.LegacyBackupApi.
                     		DeleteLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -43417,7 +43417,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLegacySnapshotApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		GetLegacySnapshotWithParams(ctx, params).
                     		Execute()
                     }
@@ -43512,7 +43512,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateLegacySnapshotRetentionApiParams{}
-                    	sdkResp, httpResp, err := sdk.LegacyBackupApi.
+                    	sdkResp, httpResp, err := client.LegacyBackupApi.
                     		UpdateLegacySnapshotRetentionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43595,7 +43595,7 @@ paths:
                     	}
 
                     	params = &sdk.GetClusterStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetClusterStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -43687,7 +43687,7 @@ paths:
                     	}
 
                     	params = &sdk.PinFeatureCompatibilityVersionApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		PinFeatureCompatibilityVersionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43778,7 +43778,7 @@ paths:
                     	}
 
                     	params = &sdk.UnpinFeatureCompatibilityVersionApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UnpinFeatureCompatibilityVersionWithParams(ctx, params).
                     		Execute()
                     }
@@ -43896,7 +43896,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -43981,7 +43981,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCloudProviderRegionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		ListCloudProviderRegionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44066,7 +44066,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterWithParams(ctx, params).
                     		Execute()
                     }
@@ -44155,7 +44155,7 @@ paths:
                     	}
 
                     	params = &sdk.UpgradeSharedClusterToServerlessApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		UpgradeSharedClusterToServerlessWithParams(ctx, params).
                     		Execute()
                     }
@@ -44232,7 +44232,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -44318,7 +44318,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainerByCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainerByCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -44402,7 +44402,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -44492,7 +44492,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringContainerApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -44571,7 +44571,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -44665,7 +44665,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringContainerApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringContainerWithParams(ctx, params).
                     		Execute()
                     }
@@ -44742,7 +44742,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringContainersApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringContainersWithParams(ctx, params).
                     		Execute()
                     }
@@ -44814,7 +44814,7 @@ paths:
                     	}
 
                     	params = &sdk.ListCustomDatabaseRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		ListCustomDatabaseRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -44898,7 +44898,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		CreateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -44982,7 +44982,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteCustomDatabaseRoleApiParams{}
-                    	httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	httpResp, err := client.CustomDatabaseRolesApi.
                     		DeleteCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -45059,7 +45059,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		GetCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -45149,7 +45149,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateCustomDatabaseRoleApiParams{}
-                    	sdkResp, httpResp, err := sdk.CustomDatabaseRolesApi.
+                    	sdkResp, httpResp, err := client.CustomDatabaseRolesApi.
                     		UpdateCustomDatabaseRoleWithParams(ctx, params).
                     		Execute()
                     }
@@ -45234,7 +45234,7 @@ paths:
                     	}
 
                     	params = &sdk.ListFederatedDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListFederatedDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -45316,7 +45316,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -45396,7 +45396,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteFederatedDatabaseApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -45474,7 +45474,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -45564,7 +45564,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateFederatedDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		UpdateFederatedDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -45648,7 +45648,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -45742,7 +45742,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOneDataFederationInstanceQueryLimitApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteOneDataFederationInstanceQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45836,7 +45836,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnFederatedDatabaseQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ReturnFederatedDatabaseQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -45940,7 +45940,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOneDataFederationQueryLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateOneDataFederationQueryLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -46044,7 +46044,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadFederatedDatabaseQueryLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		DownloadFederatedDatabaseQueryLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -46117,7 +46117,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		ListDatabaseUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -46292,7 +46292,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		CreateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -46396,7 +46396,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDatabaseUserApiParams{}
-                    	httpResp, err := sdk.DatabaseUsersApi.
+                    	httpResp, err := client.DatabaseUsersApi.
                     		DeleteDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -46493,7 +46493,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		GetDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -46603,7 +46603,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateDatabaseUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.DatabaseUsersApi.
+                    	sdkResp, httpResp, err := client.DatabaseUsersApi.
                     		UpdateDatabaseUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -46688,7 +46688,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabaseUserCertificatesApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		ListDatabaseUserCertificatesWithParams(ctx, params).
                     		Execute()
                     }
@@ -46787,7 +46787,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDatabaseUserCertificateApiParams{}
-                    	sdkResp, httpResp, err := sdk.X509AuthenticationApi.
+                    	sdkResp, httpResp, err := client.X509AuthenticationApi.
                     		CreateDatabaseUserCertificateWithParams(ctx, params).
                     		Execute()
                     }
@@ -46907,7 +46907,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByClusterNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByClusterNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -47020,7 +47020,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAccessLogsByHostnameApiParams{}
-                    	sdkResp, httpResp, err := sdk.AccessTrackingApi.
+                    	sdkResp, httpResp, err := client.AccessTrackingApi.
                     		ListAccessLogsByHostnameWithParams(ctx, params).
                     		Execute()
                     }
@@ -47093,7 +47093,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -47187,7 +47187,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateEncryptionAtRestApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		UpdateEncryptionAtRestWithParams(ctx, params).
                     		Execute()
                     }
@@ -47269,7 +47269,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointsForCloudProviderApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointsForCloudProviderWithParams(ctx, params).
                     		Execute()
                     }
@@ -47353,7 +47353,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		CreateEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -47451,7 +47451,7 @@ paths:
                     	}
 
                     	params = &sdk.RequestEncryptionAtRestPrivateEndpointDeletionApiParams{}
-                    	httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		RequestEncryptionAtRestPrivateEndpointDeletionWithParams(ctx, params).
                     		Execute()
                     }
@@ -47537,7 +47537,7 @@ paths:
                     	}
 
                     	params = &sdk.GetEncryptionAtRestPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.EncryptionatRestusingCustomerKeyManagementApi.
+                    	sdkResp, httpResp, err := client.EncryptionatRestusingCustomerKeyManagementApi.
                     		GetEncryptionAtRestPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -47664,7 +47664,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListProjectEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -47754,7 +47754,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetProjectEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -47826,7 +47826,7 @@ paths:
                     	}
 
                     	params = &sdk.ListMetricTypesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListMetricTypesWithParams(ctx, params).
                     		Execute()
                     }
@@ -47928,7 +47928,7 @@ paths:
                     	}
 
                     	params = &sdk.GetIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48029,7 +48029,7 @@ paths:
                     	}
 
                     	params = &sdk.ListIndexMetricsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListIndexMetricsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48129,7 +48129,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48206,7 +48206,7 @@ paths:
                     	}
 
                     	params = &sdk.ListThirdPartyIntegrationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		ListThirdPartyIntegrationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48298,7 +48298,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteThirdPartyIntegrationApiParams{}
-                    	httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	httpResp, err := client.Third - PartyIntegrationsApi.
                     		DeleteThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48389,7 +48389,7 @@ paths:
                     	}
 
                     	params = &sdk.GetThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		GetThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48492,7 +48492,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		CreateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48597,7 +48597,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateThirdPartyIntegrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Third - PartyIntegrationsApi.
+                    	sdkResp, httpResp, err := client.Third - PartyIntegrationsApi.
                     		UpdateThirdPartyIntegrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48680,7 +48680,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -48762,7 +48762,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48844,7 +48844,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		CreateProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -48928,7 +48928,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectInvitationApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49010,7 +49010,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49100,7 +49100,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -49177,7 +49177,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ReturnAllIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -49255,7 +49255,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectLimitsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectLimitsWithParams(ctx, params).
                     		Execute()
                     }
@@ -49365,7 +49365,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectLimitApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		DeleteProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -49476,7 +49476,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -49597,7 +49597,7 @@ paths:
                     	}
 
                     	params = &sdk.SetProjectLimitApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		SetProjectLimitWithParams(ctx, params).
                     		Execute()
                     }
@@ -49692,7 +49692,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreatePushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49771,7 +49771,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetPushMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49846,7 +49846,7 @@ paths:
                     	}
 
                     	params = &sdk.CutoverMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CutoverMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -49934,7 +49934,7 @@ paths:
                     	}
 
                     	params = &sdk.ValidateMigrationApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ValidateMigrationWithParams(ctx, params).
                     		Execute()
                     }
@@ -50023,7 +50023,7 @@ paths:
                     	}
 
                     	params = &sdk.GetValidationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		GetValidationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -50092,7 +50092,7 @@ paths:
                     	}
 
                     	params = &sdk.ResetMaintenanceWindowApiParams{}
-                    	httpResp, err := sdk.MaintenanceWindowsApi.
+                    	httpResp, err := client.MaintenanceWindowsApi.
                     		ResetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -50161,7 +50161,7 @@ paths:
                     	}
 
                     	params = &sdk.GetMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		GetMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -50238,7 +50238,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		UpdateMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -50311,7 +50311,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleMaintenanceAutoDeferApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		ToggleMaintenanceAutoDeferWithParams(ctx, params).
                     		Execute()
                     }
@@ -50384,7 +50384,7 @@ paths:
                     	}
 
                     	params = &sdk.DeferMaintenanceWindowApiParams{}
-                    	sdkResp, httpResp, err := sdk.MaintenanceWindowsApi.
+                    	sdkResp, httpResp, err := client.MaintenanceWindowsApi.
                     		DeferMaintenanceWindowWithParams(ctx, params).
                     		Execute()
                     }
@@ -50458,7 +50458,7 @@ paths:
                     	}
 
                     	params = &sdk.GetManagedSlowMsApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetManagedSlowMsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50528,7 +50528,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableSlowOperationThresholdingApiParams{}
-                    	httpResp, err := sdk.PerformanceAdvisorApi.
+                    	httpResp, err := client.PerformanceAdvisorApi.
                     		DisableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -50598,7 +50598,7 @@ paths:
                     	}
 
                     	params = &sdk.EnableSlowOperationThresholdingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		EnableSlowOperationThresholdingWithParams(ctx, params).
                     		Execute()
                     }
@@ -50713,7 +50713,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectLTSVersionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectLTSVersionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50798,7 +50798,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPeeringConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		ListPeeringConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -50883,7 +50883,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		CreatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -50968,7 +50968,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePeeringConnectionApiParams{}
-                    	httpResp, err := sdk.NetworkPeeringApi.
+                    	httpResp, err := client.NetworkPeeringApi.
                     		DeletePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -51048,7 +51048,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		GetPeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -51139,7 +51139,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePeeringConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		UpdatePeeringConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -51216,7 +51216,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelinesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelinesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51295,7 +51295,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		CreatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51379,7 +51379,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51459,7 +51459,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51549,7 +51549,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		UpdatePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51636,7 +51636,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSchedulesApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSchedulesWithParams(ctx, params).
                     		Execute()
                     }
@@ -51727,7 +51727,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineSnapshotsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineSnapshotsWithParams(ctx, params).
                     		Execute()
                     }
@@ -51808,7 +51808,7 @@ paths:
                     	}
 
                     	params = &sdk.PausePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		PausePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51893,7 +51893,7 @@ paths:
                     	}
 
                     	params = &sdk.ResumePipelineApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ResumePipelineWithParams(ctx, params).
                     		Execute()
                     }
@@ -51988,7 +51988,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPipelineRunsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		ListPipelineRunsWithParams(ctx, params).
                     		Execute()
                     }
@@ -52079,7 +52079,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePipelineRunDatasetApiParams{}
-                    	httpResp, err := sdk.DataLakePipelinesApi.
+                    	httpResp, err := client.DataLakePipelinesApi.
                     		DeletePipelineRunDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -52169,7 +52169,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPipelineRunApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		GetPipelineRunWithParams(ctx, params).
                     		Execute()
                     }
@@ -52257,7 +52257,7 @@ paths:
                     	}
 
                     	params = &sdk.TriggerSnapshotIngestionApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataLakePipelinesApi.
+                    	sdkResp, httpResp, err := client.DataLakePipelinesApi.
                     		TriggerSnapshotIngestionWithParams(ctx, params).
                     		Execute()
                     }
@@ -52344,7 +52344,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPrivateEndpointServicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ListPrivateEndpointServicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -52434,7 +52434,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointServiceApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52525,7 +52525,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52628,7 +52628,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52729,7 +52729,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePrivateEndpointApiParams{}
-                    	httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	httpResp, err := client.PrivateEndpointServicesApi.
                     		DeletePrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52827,7 +52827,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -52907,7 +52907,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePrivateEndpointServiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		CreatePrivateEndpointServiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -52983,7 +52983,7 @@ paths:
                     	}
 
                     	params = &sdk.GetRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		GetRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -53061,7 +53061,7 @@ paths:
                     	}
 
                     	params = &sdk.ToggleRegionalizedPrivateEndpointSettingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PrivateEndpointServicesApi.
+                    	sdkResp, httpResp, err := client.PrivateEndpointServicesApi.
                     		ToggleRegionalizedPrivateEndpointSettingWithParams(ctx, params).
                     		Execute()
                     }
@@ -53146,7 +53146,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		ListServerlessPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53237,7 +53237,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		CreateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53329,7 +53329,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		DeleteServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53416,7 +53416,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		GetServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53510,7 +53510,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessPrivateEndpointsApi.
+                    	sdkResp, httpResp, err := client.ServerlessPrivateEndpointsApi.
                     		UpdateServerlessPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53588,7 +53588,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyConnectViaPeeringOnlyModeForOneProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		VerifyConnectViaPeeringOnlyModeForOneProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -53670,7 +53670,7 @@ paths:
                     	}
 
                     	params = &sdk.DisablePeeringApiParams{}
-                    	sdkResp, httpResp, err := sdk.NetworkPeeringApi.
+                    	sdkResp, httpResp, err := client.NetworkPeeringApi.
                     		DisablePeeringWithParams(ctx, params).
                     		Execute()
                     }
@@ -53751,7 +53751,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDataFederationPrivateEndpointsApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		ListDataFederationPrivateEndpointsWithParams(ctx, params).
                     		Execute()
                     }
@@ -53848,7 +53848,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		CreateDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -53933,7 +53933,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteDataFederationPrivateEndpointApiParams{}
-                    	httpResp, err := sdk.DataFederationApi.
+                    	httpResp, err := client.DataFederationApi.
                     		DeleteDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -54015,7 +54015,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDataFederationPrivateEndpointApiParams{}
-                    	sdkResp, httpResp, err := sdk.DataFederationApi.
+                    	sdkResp, httpResp, err := client.DataFederationApi.
                     		GetDataFederationPrivateEndpointWithParams(ctx, params).
                     		Execute()
                     }
@@ -54088,7 +54088,7 @@ paths:
                     	}
 
                     	params = &sdk.ListAtlasProcessesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListAtlasProcessesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54166,7 +54166,7 @@ paths:
                     	}
 
                     	params = &sdk.GetAtlasProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetAtlasProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -54279,7 +54279,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespaceHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespaceHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54352,7 +54352,7 @@ paths:
                     	}
 
                     	params = &sdk.GetCollStatsLatencyNamespacesForHostApiParams{}
-                    	sdkResp, httpResp, err := sdk.CollectionLevelMetricsApi.
+                    	sdkResp, httpResp, err := client.CollectionLevelMetricsApi.
                     		GetCollStatsLatencyNamespacesForHostWithParams(ctx, params).
                     		Execute()
                     }
@@ -54433,7 +54433,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDatabasesApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDatabasesWithParams(ctx, params).
                     		Execute()
                     }
@@ -54517,7 +54517,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseWithParams(ctx, params).
                     		Execute()
                     }
@@ -54627,7 +54627,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDatabaseMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDatabaseMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54708,7 +54708,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskPartitionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskPartitionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54791,7 +54791,7 @@ paths:
                     	}
 
                     	params = &sdk.ListDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		ListDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -54917,7 +54917,7 @@ paths:
                     	}
 
                     	params = &sdk.GetDiskMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetDiskMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55154,7 +55154,7 @@ paths:
                     	}
 
                     	params = &sdk.GetHostMeasurementsApiParams{}
-                    	sdkResp, httpResp, err := sdk.MonitoringandLogsApi.
+                    	sdkResp, httpResp, err := client.MonitoringandLogsApi.
                     		GetHostMeasurementsWithParams(ctx, params).
                     		Execute()
                     }
@@ -55252,7 +55252,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueryNamespacesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueryNamespacesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55367,7 +55367,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSlowQueriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSlowQueriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55489,7 +55489,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSuggestedIndexesApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		ListSuggestedIndexesWithParams(ctx, params).
                     		Execute()
                     }
@@ -55563,7 +55563,7 @@ paths:
                     	}
 
                     	params = &sdk.DeletePushBasedLogConfigurationApiParams{}
-                    	httpResp, err := sdk.Push - BasedLogExportApi.
+                    	httpResp, err := client.Push - BasedLogExportApi.
                     		DeletePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55636,7 +55636,7 @@ paths:
                     	}
 
                     	params = &sdk.GetPushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		GetPushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55717,7 +55717,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		UpdatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55802,7 +55802,7 @@ paths:
                     	}
 
                     	params = &sdk.CreatePushBasedLogConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.Push - BasedLogExportApi.
+                    	sdkResp, httpResp, err := client.Push - BasedLogExportApi.
                     		CreatePushBasedLogConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -55888,7 +55888,7 @@ paths:
                     	}
 
                     	params = &sdk.LoadSampleDatasetApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		LoadSampleDatasetWithParams(ctx, params).
                     		Execute()
                     }
@@ -55970,7 +55970,7 @@ paths:
                     	}
 
                     	params = &sdk.GetSampleDatasetLoadStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.ClustersApi.
+                    	sdkResp, httpResp, err := client.ClustersApi.
                     		GetSampleDatasetLoadStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -56043,7 +56043,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		ListServerlessInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -56123,7 +56123,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		CreateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56211,7 +56211,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupRestoreJobsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupRestoreJobsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56302,7 +56302,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		CreateServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -56396,7 +56396,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupRestoreJobApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupRestoreJobWithParams(ctx, params).
                     		Execute()
                     }
@@ -56480,7 +56480,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServerlessBackupsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		ListServerlessBackupsWithParams(ctx, params).
                     		Execute()
                     }
@@ -56570,7 +56570,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessBackupApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudBackupsApi.
+                    	sdkResp, httpResp, err := client.CloudBackupsApi.
                     		GetServerlessBackupWithParams(ctx, params).
                     		Execute()
                     }
@@ -56649,7 +56649,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		GetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -56732,7 +56732,7 @@ paths:
                     	}
 
                     	params = &sdk.SetServerlessAutoIndexingApiParams{}
-                    	sdkResp, httpResp, err := sdk.PerformanceAdvisorApi.
+                    	sdkResp, httpResp, err := client.PerformanceAdvisorApi.
                     		SetServerlessAutoIndexingWithParams(ctx, params).
                     		Execute()
                     }
@@ -56819,7 +56819,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServerlessInstanceApiParams{}
-                    	httpResp, err := sdk.ServerlessInstancesApi.
+                    	httpResp, err := client.ServerlessInstancesApi.
                     		DeleteServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56901,7 +56901,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		GetServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -56988,7 +56988,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServerlessInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.ServerlessInstancesApi.
+                    	sdkResp, httpResp, err := client.ServerlessInstancesApi.
                     		UpdateServerlessInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57066,7 +57066,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		ListProjectServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57145,7 +57145,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		CreateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -57228,7 +57228,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteProjectServiceAccountApiParams{}
-                    	httpResp, err := sdk.GroupsApi.
+                    	httpResp, err := client.GroupsApi.
                     		DeleteProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -57305,7 +57305,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		GetProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -57391,7 +57391,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		UpdateProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -57483,7 +57483,7 @@ paths:
                     	}
 
                     	params = &sdk.AddProjectServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.GroupsApi.
+                    	sdkResp, httpResp, err := client.GroupsApi.
                     		AddProjectServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -57561,7 +57561,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57641,7 +57641,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -57717,7 +57717,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -57795,7 +57795,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57879,7 +57879,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamInstanceApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -57962,7 +57962,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -58050,7 +58050,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -58155,7 +58155,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadStreamTenantAuditLogsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		DownloadStreamTenantAuditLogsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58235,7 +58235,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamConnectionsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamConnectionsWithParams(ctx, params).
                     		Execute()
                     }
@@ -58321,7 +58321,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -58411,7 +58411,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamConnectionApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -58493,7 +58493,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -58587,7 +58587,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateStreamConnectionApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		UpdateStreamConnectionWithParams(ctx, params).
                     		Execute()
                     }
@@ -58678,7 +58678,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		CreateStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58766,7 +58766,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteStreamProcessorApiParams{}
-                    	httpResp, err := sdk.StreamsApi.
+                    	httpResp, err := client.StreamsApi.
                     		DeleteStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58851,7 +58851,7 @@ paths:
                     	}
 
                     	params = &sdk.GetStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		GetStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -58937,7 +58937,7 @@ paths:
                     	}
 
                     	params = &sdk.StartStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		StartStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -59027,7 +59027,7 @@ paths:
                     	}
 
                     	params = &sdk.StopStreamProcessorApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		StopStreamProcessorWithParams(ctx, params).
                     		Execute()
                     }
@@ -59114,7 +59114,7 @@ paths:
                     	}
 
                     	params = &sdk.ListStreamProcessorsApiParams{}
-                    	sdkResp, httpResp, err := sdk.StreamsApi.
+                    	sdkResp, httpResp, err := client.StreamsApi.
                     		ListStreamProcessorsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59193,7 +59193,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListProjectTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -59280,7 +59280,7 @@ paths:
                     	}
 
                     	params = &sdk.AddAllTeamsToProjectApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddAllTeamsToProjectWithParams(ctx, params).
                     		Execute()
                     }
@@ -59369,7 +59369,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveProjectTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -59463,7 +59463,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateTeamRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		UpdateTeamRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -59537,7 +59537,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59618,7 +59618,7 @@ paths:
                     	}
 
                     	params = &sdk.SaveLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		SaveLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59694,7 +59694,7 @@ paths:
                     	}
 
                     	params = &sdk.DisableCustomerManagedX509ApiParams{}
-                    	httpResp, err := sdk.X509AuthenticationApi.
+                    	httpResp, err := client.X509AuthenticationApi.
                     		DisableCustomerManagedX509WithParams(ctx, params).
                     		Execute()
                     }
@@ -59764,7 +59764,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLDAPConfigurationApiParams{}
-                    	httpResp, err := sdk.LDAPConfigurationApi.
+                    	httpResp, err := client.LDAPConfigurationApi.
                     		DeleteLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59843,7 +59843,7 @@ paths:
                     	}
 
                     	params = &sdk.VerifyLDAPConfigurationApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		VerifyLDAPConfigurationWithParams(ctx, params).
                     		Execute()
                     }
@@ -59926,7 +59926,7 @@ paths:
                     	}
 
                     	params = &sdk.GetLDAPConfigurationStatusApiParams{}
-                    	sdkResp, httpResp, err := sdk.LDAPConfigurationApi.
+                    	sdkResp, httpResp, err := client.LDAPConfigurationApi.
                     		GetLDAPConfigurationStatusWithParams(ctx, params).
                     		Execute()
                     }
@@ -60011,7 +60011,7 @@ paths:
                     	}
 
                     	params = &sdk.ListProjectUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		ListProjectUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -60092,7 +60092,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveProjectUserApiParams{}
-                    	httpResp, err := sdk.ProjectsApi.
+                    	httpResp, err := client.ProjectsApi.
                     		RemoveProjectUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -60182,7 +60182,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateProjectRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		UpdateProjectRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -60259,7 +60259,7 @@ paths:
                     	}
 
                     	params = &sdk.ListUSSInstancesApiParams{}
-                    	sdkResp, httpResp, err := sdk.USSInstancesApi.
+                    	sdkResp, httpResp, err := client.USSInstancesApi.
                     		ListUSSInstancesWithParams(ctx, params).
                     		Execute()
                     }
@@ -60339,7 +60339,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateUSSInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.USSInstancesApi.
+                    	sdkResp, httpResp, err := client.USSInstancesApi.
                     		CreateUSSInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -60426,7 +60426,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteUSSInstanceApiParams{}
-                    	httpResp, err := sdk.USSInstancesApi.
+                    	httpResp, err := client.USSInstancesApi.
                     		DeleteUSSInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -60510,7 +60510,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUSSInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.USSInstancesApi.
+                    	sdkResp, httpResp, err := client.USSInstancesApi.
                     		GetUSSInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -60597,7 +60597,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateUSSInstanceApiParams{}
-                    	sdkResp, httpResp, err := sdk.USSInstancesApi.
+                    	sdkResp, httpResp, err := client.USSInstancesApi.
                     		UpdateUSSInstanceWithParams(ctx, params).
                     		Execute()
                     }
@@ -60677,7 +60677,7 @@ paths:
                     	}
 
                     	params = &sdk.MigrateProjectToAnotherOrgApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		MigrateProjectToAnotherOrgWithParams(ctx, params).
                     		Execute()
                     }
@@ -60764,7 +60764,7 @@ paths:
                     	}
 
                     	params = &sdk.GetProjectByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProjectsApi.
+                    	sdkResp, httpResp, err := client.ProjectsApi.
                     		GetProjectByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -60847,7 +60847,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -60930,7 +60930,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61016,7 +61016,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61091,7 +61091,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61173,7 +61173,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameOrganizationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		RenameOrganizationWithParams(ctx, params).
                     		Execute()
                     }
@@ -61253,7 +61253,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeysApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeysWithParams(ctx, params).
                     		Execute()
                     }
@@ -61332,7 +61332,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -61418,7 +61418,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -61499,7 +61499,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -61589,7 +61589,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateApiKeyApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		UpdateApiKeyWithParams(ctx, params).
                     		Execute()
                     }
@@ -61678,7 +61678,7 @@ paths:
                     	}
 
                     	params = &sdk.ListApiKeyAccessListsEntriesApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		ListApiKeyAccessListsEntriesWithParams(ctx, params).
                     		Execute()
                     }
@@ -61772,7 +61772,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		CreateApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -61870,7 +61870,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteApiKeyAccessListEntryApiParams{}
-                    	httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	httpResp, err := client.ProgrammaticAPIKeysApi.
                     		DeleteApiKeyAccessListEntryWithParams(ctx, params).
                     		Execute()
                     }
@@ -61961,7 +61961,7 @@ paths:
                     	}
 
                     	params = &sdk.GetApiKeyAccessListApiParams{}
-                    	sdkResp, httpResp, err := sdk.ProgrammaticAPIKeysApi.
+                    	sdkResp, httpResp, err := client.ProgrammaticAPIKeysApi.
                     		GetApiKeyAccessListWithParams(ctx, params).
                     		Execute()
                     }
@@ -62039,7 +62039,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcessApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcessWithParams(ctx, params).
                     		Execute()
                     }
@@ -62131,7 +62131,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateCostExplorerQueryProcess_1ApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		CreateCostExplorerQueryProcess_1WithParams(ctx, params).
                     		Execute()
                     }
@@ -62236,7 +62236,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationEventsApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		ListOrganizationEventsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62326,7 +62326,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationEventApiParams{}
-                    	sdkResp, httpResp, err := sdk.EventsApi.
+                    	sdkResp, httpResp, err := client.EventsApi.
                     		GetOrganizationEventWithParams(ctx, params).
                     		Execute()
                     }
@@ -62400,7 +62400,7 @@ paths:
                     	}
 
                     	params = &sdk.GetFederationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.FederatedAuthenticationApi.
+                    	sdkResp, httpResp, err := client.FederatedAuthenticationApi.
                     		GetFederationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62490,7 +62490,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62572,7 +62572,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationInvitationsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationInvitationsWithParams(ctx, params).
                     		Execute()
                     }
@@ -62652,7 +62652,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -62736,7 +62736,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -62820,7 +62820,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteOrganizationInvitationApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -62901,7 +62901,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationInvitationApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationInvitationWithParams(ctx, params).
                     		Execute()
                     }
@@ -62990,7 +62990,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationInvitationByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationInvitationByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -63128,7 +63128,7 @@ paths:
                     	}
 
                     	params = &sdk.ListInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -63215,7 +63215,7 @@ paths:
                     	}
 
                     	params = &sdk.GetInvoiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		GetInvoiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -63303,7 +63303,7 @@ paths:
                     	}
 
                     	params = &sdk.DownloadInvoiceCSVApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		DownloadInvoiceCSVWithParams(ctx, params).
                     		Execute()
                     }
@@ -63392,7 +63392,7 @@ paths:
                     	}
 
                     	params = &sdk.QueryLineItemsFromSingleInvoiceApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		QueryLineItemsFromSingleInvoiceWithParams(ctx, params).
                     		Execute()
                     }
@@ -63464,7 +63464,7 @@ paths:
                     	}
 
                     	params = &sdk.ListPendingInvoicesApiParams{}
-                    	sdkResp, httpResp, err := sdk.InvoicesApi.
+                    	sdkResp, httpResp, err := client.InvoicesApi.
                     		ListPendingInvoicesWithParams(ctx, params).
                     		Execute()
                     }
@@ -63538,7 +63538,7 @@ paths:
                     	}
 
                     	params = &sdk.ListSourceProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		ListSourceProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63609,7 +63609,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteLinkTokenApiParams{}
-                    	httpResp, err := sdk.CloudMigrationServiceApi.
+                    	httpResp, err := client.CloudMigrationServiceApi.
                     		DeleteLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -63687,7 +63687,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateLinkTokenApiParams{}
-                    	sdkResp, httpResp, err := sdk.CloudMigrationServiceApi.
+                    	sdkResp, httpResp, err := client.CloudMigrationServiceApi.
                     		CreateLinkTokenWithParams(ctx, params).
                     		Execute()
                     }
@@ -63765,7 +63765,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountsWithParams(ctx, params).
                     		Execute()
                     }
@@ -63843,7 +63843,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -63923,7 +63923,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -64000,7 +64000,7 @@ paths:
                     	}
 
                     	params = &sdk.GetServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -64086,7 +64086,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateServiceAccountApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateServiceAccountWithParams(ctx, params).
                     		Execute()
                     }
@@ -64170,7 +64170,7 @@ paths:
                     	}
 
                     	params = &sdk.ListServiceAccountProjectsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListServiceAccountProjectsWithParams(ctx, params).
                     		Execute()
                     }
@@ -64255,7 +64255,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateServiceAccountSecretApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		CreateServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -64341,7 +64341,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteServiceAccountSecretApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		DeleteServiceAccountSecretWithParams(ctx, params).
                     		Execute()
                     }
@@ -64415,7 +64415,7 @@ paths:
                     	}
 
                     	params = &sdk.GetOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		GetOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -64495,7 +64495,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationSettingsApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationSettingsWithParams(ctx, params).
                     		Execute()
                     }
@@ -64579,7 +64579,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationTeamsApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListOrganizationTeamsWithParams(ctx, params).
                     		Execute()
                     }
@@ -64664,7 +64664,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		CreateTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -64754,7 +64754,7 @@ paths:
                     	}
 
                     	params = &sdk.DeleteTeamApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		DeleteTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -64839,7 +64839,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByIdApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByIdWithParams(ctx, params).
                     		Execute()
                     }
@@ -64933,7 +64933,7 @@ paths:
                     	}
 
                     	params = &sdk.RenameTeamApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		RenameTeamWithParams(ctx, params).
                     		Execute()
                     }
@@ -65027,7 +65027,7 @@ paths:
                     	}
 
                     	params = &sdk.ListTeamUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		ListTeamUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -65123,7 +65123,7 @@ paths:
                     	}
 
                     	params = &sdk.AddTeamUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		AddTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -65220,7 +65220,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveTeamUserApiParams{}
-                    	httpResp, err := sdk.TeamsApi.
+                    	httpResp, err := client.TeamsApi.
                     		RemoveTeamUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -65303,7 +65303,7 @@ paths:
                     	}
 
                     	params = &sdk.GetTeamByNameApiParams{}
-                    	sdkResp, httpResp, err := sdk.TeamsApi.
+                    	sdkResp, httpResp, err := client.TeamsApi.
                     		GetTeamByNameWithParams(ctx, params).
                     		Execute()
                     }
@@ -65380,7 +65380,7 @@ paths:
                     	}
 
                     	params = &sdk.ListOrganizationUsersApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		ListOrganizationUsersWithParams(ctx, params).
                     		Execute()
                     }
@@ -65464,7 +65464,7 @@ paths:
                     	}
 
                     	params = &sdk.RemoveOrganizationUserApiParams{}
-                    	httpResp, err := sdk.OrganizationsApi.
+                    	httpResp, err := client.OrganizationsApi.
                     		RemoveOrganizationUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -65554,7 +65554,7 @@ paths:
                     	}
 
                     	params = &sdk.UpdateOrganizationRolesApiParams{}
-                    	sdkResp, httpResp, err := sdk.OrganizationsApi.
+                    	sdkResp, httpResp, err := client.OrganizationsApi.
                     		UpdateOrganizationRolesWithParams(ctx, params).
                     		Execute()
                     }
@@ -65622,7 +65622,7 @@ paths:
                     	}
 
                     	params = &sdk.ReturnAllControlPlaneIPAddressesApiParams{}
-                    	sdkResp, httpResp, err := sdk.RootApi.
+                    	sdkResp, httpResp, err := client.RootApi.
                     		ReturnAllControlPlaneIPAddressesWithParams(ctx, params).
                     		Execute()
                     }
@@ -65705,7 +65705,7 @@ paths:
                     	}
 
                     	params = &sdk.CreateUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		CreateUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -65789,7 +65789,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserWithParams(ctx, params).
                     		Execute()
                     }
@@ -65867,7 +65867,7 @@ paths:
                     	}
 
                     	params = &sdk.GetUserByUsernameApiParams{}
-                    	sdkResp, httpResp, err := sdk.MongoDBCloudUsersApi.
+                    	sdkResp, httpResp, err := client.MongoDBCloudUsersApi.
                     		GetUserByUsernameWithParams(ctx, params).
                     		Execute()
                     }


### PR DESCRIPTION
## Proposed changes
This PR adds autogenerated example of the GO SDK in the openapi specification. 

You can preview how the documentation will look using this [bump.sh link](https://bump.sh/mongodb/doc/andrea-test/group/endpoint-alert-configurations)

Redocly:

![Screenshot 2025-06-13 at 14 42 26](https://github.com/user-attachments/assets/553b8075-abee-4abd-9633-4bdf49ab8384)
