### PR TITLE
CLOUDP-325047: add support for extension in the main element of the OAS

### DIFF
--- a/tools/cli/internal/openapi/openapi.go
+++ b/tools/cli/internal/openapi/openapi.go
@@ -34,6 +34,7 @@ type Spec struct {
 	Paths        *openapi3.Paths               `json:"paths" yaml:"paths"`
 	Components   *openapi3.Components          `json:"components,omitempty" yaml:"components,omitempty"`
 	ExternalDocs *openapi3.ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	Extensions   map[string]any                `json:"-" yaml:"-"`
 }
 type Parser interface {
 	CreateOpenAPISpecFromPath(string) (*load.SpecInfo, error)


### PR DESCRIPTION
## Proposed changes
CLOUDP-325047:


Related to https://github.com/10gen/mms/pull/131979, bump recently added support for a custom extension. Here I am adding the support for extensions to the struct we use to represent an open api spec.