### PR TITLE
ci: remove windows unit test

### DIFF
--- a/.github/workflows/code-health-foascli.yml
+++ b/.github/workflows/code-health-foascli.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Proposed changes
This PR removes windows from the OSes where we run unit tests since we don't release foascli for windows